### PR TITLE
🐛 fix(task-progress): 任务列表展开时支持滚动

### DIFF
--- a/frontend/src/components/agentre/task-progress/__tests__/task-progress-bar.test.tsx
+++ b/frontend/src/components/agentre/task-progress/__tests__/task-progress-bar.test.tsx
@@ -48,6 +48,21 @@ describe("TaskProgressBar", () => {
     expect(screen.queryByText("当前")).not.toBeInTheDocument();
   });
 
+  it("constrains the expanded list height and enables vertical scrolling", () => {
+    const many: TaskProgress = {
+      tasks: Array.from({ length: 30 }, (_, i) => ({
+        id: `t_${i + 1}`,
+        description: `task ${i + 1}`,
+        status: "queued" as const,
+      })),
+    };
+    render(<TaskProgressBar progress={many} />);
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const list = screen.getByRole("list");
+    expect(list.className).toMatch(/overflow-y-auto/);
+    expect(list.className).toMatch(/max-h-/);
+  });
+
   it("auto-collapses to recap label 2s after all tasks complete", () => {
     vi.useFakeTimers();
     const allDone: TaskProgress = {

--- a/frontend/src/components/agentre/task-progress/task-progress-bar.tsx
+++ b/frontend/src/components/agentre/task-progress/task-progress-bar.tsx
@@ -158,7 +158,7 @@ export function TaskProgressBar({ progress }: Props) {
         </span>
       </button>
       {expanded ? (
-        <ul className="flex flex-col">
+        <ul className="flex max-h-64 flex-col overflow-y-auto overscroll-contain">
           {tasks.map((t, i) => (
             <TaskRow key={t.id} index={i} task={t} />
           ))}


### PR DESCRIPTION
聊天输入框上方的任务列表在展开后不受高度约束，任务过多时会
把消息区挤出视口，看不到全部任务。

为展开后的 <ul> 加上 max-h-64、overflow-y-auto、overscroll-contain， 长列表就地滚动而不再撑大 topSlot。补一条回归测试，断言展开后的
列表带上高度与滚动相关的 className。

<!-- 标题请使用 gitmoji / Use gitmoji in title: ✨ Feature / 🐛 Bugfix / ♻️ Refactor / 🎨 UI / ⚡️ Perf / 🔒 Security / 🔧 Chore / ✅ Tests / 📄 Docs -->

## 变更说明 / Summary

<!-- 简述改动内容与动机 / What changed and why -->

## 关联 Issue / Related Issue

Closes #

## 截图 / Screenshots

<!-- UI 改动必填 / Required for UI changes -->

## 自检 / Checklist

- [ ]  Fixes mentioned issues / 修复已提及的问题
- [ ]  Code reviewed by human / 代码通过人工检查
- [ ]  Changes tested / 已完成测试
