### PR TITLE
✨ projects: 父级「自己的会话」独立成可折叠子组

### DIFF
--- a/frontend/src/components/agentre/__tests__/project-page.test.tsx
+++ b/frontend/src/components/agentre/__tests__/project-page.test.tsx
@@ -1008,6 +1008,149 @@ describe("ProjectsPage active tab anchor", () => {
   });
 });
 
+describe("ProjectsPage parent own-sessions sub-group", () => {
+  // 父级项目同时有「自己的会话」和「子项目」时，自己的会话应收进一个可独立
+  // 折叠的「会话」子组：父级标题箭头仍收整卡，会话子组箭头只管自己的会话。
+  function parentWithChildTree() {
+    return [
+      {
+        project: {
+          color: "agent-1",
+          icon: "folder",
+          id: 1,
+          name: "Agentre",
+          parentID: 0,
+          path: "/tmp/agentre",
+        },
+        children: [
+          {
+            project: {
+              color: "agent-2",
+              icon: "folder",
+              id: 2,
+              name: "backend",
+              parentID: 1,
+              path: "/tmp/agentre/backend",
+            },
+            children: [],
+          },
+        ],
+      },
+    ];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useSessionReadStore.setState({ overrides: new Map() });
+    useChatAgentsStore.getState().__reset();
+    useChatTabsStore.setState({ tabs: [], activeTabId: null });
+
+    appMocks.ListChatAgents.mockResolvedValue({ agents: [] });
+    appMocks.ProjectGet.mockResolvedValue({
+      project: null,
+      directMembers: [],
+      inheritedMembers: [],
+    });
+    appMocks.ProjectLocationList.mockResolvedValue([]);
+    appMocks.RemoteDeviceList.mockResolvedValue([]);
+    appMocks.ProjectListTree.mockResolvedValue(parentWithChildTree());
+    appMocks.ProjectListSessions.mockImplementation(
+      async (projectID: number) =>
+        projectID === 1
+          ? [
+              buildSession({
+                id: 11,
+                title: "Parent Own A",
+                lastMessageAt: 2000,
+              }),
+            ]
+          : [buildSession({ id: 22, title: "Child One", lastMessageAt: 1000 })],
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("Given a parent with own sessions AND sub-projects, Then own sessions get a separate collapsible sessions sub-group", async () => {
+    renderProjectsPage();
+
+    await screen.findByText("backend");
+    const toggle = screen.getByRole("button", {
+      name: /Toggle Agentre sessions/i,
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /Parent Own A/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("When the sessions sub-group is collapsed, Then own sessions hide but sub-projects stay visible", async () => {
+    renderProjectsPage();
+
+    await screen.findByText("backend");
+    expect(
+      screen.getByRole("button", { name: /Parent Own A/ }),
+    ).toBeInTheDocument();
+
+    await setupUser().click(
+      screen.getByRole("button", { name: /Toggle Agentre sessions/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Parent Own A/ }),
+      ).not.toBeInTheDocument();
+    });
+    // 子项目不受影响，仍然可见。
+    expect(screen.getByText("backend")).toBeInTheDocument();
+  });
+
+  it("Then collapsing the sessions sub-group persists under its own project:<id>:sessions key", async () => {
+    renderProjectsPage();
+
+    await screen.findByText("backend");
+    await setupUser().click(
+      screen.getByRole("button", { name: /Toggle Agentre sessions/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        localStorage.getItem("agentre.agentExpanded.project:1:sessions"),
+      ).toBe("0");
+    });
+    // 项目整体折叠态不应被这次操作写入。
+    expect(localStorage.getItem("agentre.agentExpanded.project:1")).toBeNull();
+  });
+
+  it("Given a leaf project with no sub-projects, Then no separate sessions sub-group is rendered", async () => {
+    appMocks.ProjectListTree.mockResolvedValue([
+      {
+        project: {
+          color: "agent-1",
+          icon: "folder",
+          id: 1,
+          name: "Agentre",
+          parentID: 0,
+          path: "/tmp/agentre",
+        },
+        children: [],
+      },
+    ]);
+    appMocks.ProjectListSessions.mockResolvedValue([
+      buildSession({ id: 11, title: "Leaf Own A", lastMessageAt: 2000 }),
+    ]);
+
+    renderProjectsPage();
+
+    await screen.findByRole("button", { name: /Leaf Own A/ });
+    expect(
+      screen.queryByRole("button", { name: /Toggle Agentre sessions/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
 function buildSession({
   id,
   title,

--- a/frontend/src/components/agentre/project-page.tsx
+++ b/frontend/src/components/agentre/project-page.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from "i18next";
 import {
   Briefcase,
   ChevronDown,
+  MessagesSquare,
   MoreVertical,
   Plus,
   Search,
@@ -669,6 +670,49 @@ function SortableProjectCard({
   );
 }
 
+// SessionsSubGroupHeader —— 父级项目「自己的会话」子组的头部。
+// 仅当父级同时有自己的会话和子项目时出现（见 ProjectCard 的 nestOwnSessions），
+// 让父级会话能独立于子项目折叠/展开。视觉上与子项目头部同级，但用 messages 图标
+// 而非项目头像，明确「这是会话分组、不是子项目」。
+function SessionsSubGroupHeader({
+  name,
+  count,
+  expanded,
+  toggle,
+}: {
+  name: string;
+  count: number;
+  expanded: boolean;
+  toggle: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-xs outline-none hover:bg-sidebar-active-bg focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      onClick={toggle}
+      aria-expanded={expanded}
+      aria-label={t("projects.session.groupToggle", { name })}
+    >
+      <ChevronDown
+        className={cn(
+          "size-3 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none",
+          !expanded && "-rotate-90",
+        )}
+        aria-hidden="true"
+      />
+      <MessagesSquare
+        className="size-3.5 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <span className="font-mono text-2xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {t("projects.session.group")}
+      </span>
+      <span className="font-mono text-2xs text-subtle-foreground">{count}</span>
+    </button>
+  );
+}
+
 function ProjectCard({
   node,
   depth,
@@ -838,6 +882,66 @@ function ProjectCard({
   const isSub = depth > 0;
   const isDeep = depth >= 2;
 
+  // 父级「自己的会话」与子项目共用同一个 SessionGroup 的折叠箭头会把两者绑死。
+  // 当父级同时有自己的会话和子项目时，把自己的会话拆到一个独立折叠的内层
+  // SessionGroup（persistenceKey: project:<id>:sessions），父级标题箭头仍收整卡。
+  const nestOwnSessions = ownSessions.length > 0 && children.length > 0;
+  const ownSessionsTotal =
+    ownSessions.length > 5 ? ownSessions.length : undefined;
+
+  const renderSessionsPopover = (close: () => void) => (
+    <SessionsPopover
+      header={{
+        name: project.name,
+        avatarColor: project.color,
+        avatarIcon: project.icon || "folder",
+        activeCount,
+      }}
+      loader={async ({ offset, limit }) => {
+        // 后端 ProjectListSessions 暂不分页；客户端切片即可。
+        const all = (await WailsApp.ProjectListSessions(project.id)) ?? [];
+        const slice = all.slice(offset, offset + limit);
+        return {
+          sessions: slice.map((s) => ({
+            id: s.id,
+            title: s.title,
+            status: s.agentStatus,
+            lastMessageAt: s.lastMessageAt,
+          })),
+          total: all.length,
+          hasMore: offset + limit < all.length,
+        };
+      }}
+      onClose={close}
+      onSelectSession={(sid, opts) => {
+        const s = subtreeSessions.find((x) => x.id === sid);
+        if (s) {
+          onSelect(
+            { kind: "session", projectID: s.projectID, session: s },
+            opts,
+          );
+        }
+      }}
+    />
+  );
+
+  const subProjectsList =
+    children.length > 0 ? (
+      <div className="mt-1 flex flex-col gap-0.5">
+        <ProjectSortableList
+          nodes={children}
+          depth={depth + 1}
+          filter={filter}
+          sessions={sessions}
+          selection={selection}
+          onSelect={onSelect}
+          onOpenSettings={onOpenSettings}
+          onAddSubProject={onAddSubProject}
+          dragDisabled={!drag}
+        />
+      </div>
+    ) : null;
+
   return (
     <div
       ref={drag?.setNodeRef}
@@ -847,71 +951,46 @@ function ProjectCard({
       <SessionGroup
         persistenceKey={`project:${project.id}`}
         defaultExpanded
-        sessions={top5AgentSessions}
-        totalSessions={ownSessions.length > 5 ? ownSessions.length : undefined}
+        sessions={nestOwnSessions ? [] : top5AgentSessions}
+        totalSessions={nestOwnSessions ? undefined : ownSessionsTotal}
         selectedSessionId={selectedSessionIdStr}
         onSessionSelect={handleSessionSelect}
-        attentionSessions={attentionAgentSessions}
+        attentionSessions={nestOwnSessions ? [] : attentionAgentSessions}
         collapsedAttentionSessions={collapsedAttentionAgentSessions}
         attentionAriaLabel={t("projects.session.attentionAria", {
           name: project.name,
         })}
         emptyLabel={children.length === 0 ? t("projects.session.empty") : null}
-        renderSessionsPopover={(close) => (
-          <SessionsPopover
-            header={{
-              name: project.name,
-              avatarColor: project.color,
-              avatarIcon: project.icon || "folder",
-              activeCount,
-            }}
-            loader={async ({ offset, limit }) => {
-              // 后端 ProjectListSessions 暂不分页；客户端切片即可。
-              const all =
-                (await WailsApp.ProjectListSessions(project.id)) ?? [];
-              const slice = all.slice(offset, offset + limit);
-              return {
-                sessions: slice.map((s) => ({
-                  id: s.id,
-                  title: s.title,
-                  status: s.agentStatus,
-                  lastMessageAt: s.lastMessageAt,
-                })),
-                total: all.length,
-                hasMore: offset + limit < all.length,
-              };
-            }}
-            onClose={close}
-            onSelectSession={(sid, opts) => {
-              const s = subtreeSessions.find((x) => x.id === sid);
-              if (s) {
-                onSelect(
-                  {
-                    kind: "session",
-                    projectID: s.projectID,
-                    session: s,
-                  },
-                  opts,
-                );
-              }
-            }}
-          />
-        )}
+        renderSessionsPopover={renderSessionsPopover}
         renderAfterSessions={
           children.length > 0 ? (
-            <div className="mt-1 flex flex-col gap-0.5">
-              <ProjectSortableList
-                nodes={children}
-                depth={depth + 1}
-                filter={filter}
-                sessions={sessions}
-                selection={selection}
-                onSelect={onSelect}
-                onOpenSettings={onOpenSettings}
-                onAddSubProject={onAddSubProject}
-                dragDisabled={!drag}
-              />
-            </div>
+            <>
+              {nestOwnSessions ? (
+                <SessionGroup
+                  persistenceKey={`project:${project.id}:sessions`}
+                  defaultExpanded
+                  sessions={top5AgentSessions}
+                  totalSessions={ownSessionsTotal}
+                  selectedSessionId={selectedSessionIdStr}
+                  onSessionSelect={handleSessionSelect}
+                  attentionSessions={attentionAgentSessions}
+                  attentionAriaLabel={t("projects.session.attentionAria", {
+                    name: project.name,
+                  })}
+                  emptyLabel={null}
+                  renderSessionsPopover={renderSessionsPopover}
+                  renderHeader={({ expanded, toggle }) => (
+                    <SessionsSubGroupHeader
+                      name={project.name}
+                      count={ownSessions.length}
+                      expanded={expanded}
+                      toggle={toggle}
+                    />
+                  )}
+                />
+              ) : null}
+              {subProjectsList}
+            </>
           ) : undefined
         }
         renderHeader={({ expanded, toggle }) => (

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1370,6 +1370,8 @@
       "activeCount": "{{count}} active sessions including sub-projects",
       "attentionAria": "{{name}} sessions needing attention",
       "empty": "No sessions",
+      "group": "Sessions",
+      "groupToggle": "Toggle {{name}} sessions",
       "inherited": "Inherited",
       "loadMembersFailed": "Failed to load members: {{error}}",
       "loadingMembers": "Loading members...",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1370,6 +1370,8 @@
       "activeCount": "{{count}} 个活跃会话（含子项目）",
       "attentionAria": "{{name}} 待处理会话",
       "empty": "暂无会话",
+      "group": "会话",
+      "groupToggle": "展开/收起 {{name}} 的会话",
       "inherited": "继承",
       "loadMembersFailed": "加载成员失败：{{error}}",
       "loadingMembers": "加载成员中…",


### PR DESCRIPTION
## 背景

项目侧栏里，父级项目同时有**自己的会话**和**子项目**时，两者共用同一个 `SessionGroup` 的折叠箭头 —— 收起父级会把自己的会话和全部子项目一起藏掉，没法只收起会话去专注导航子项目（反之亦然）。

## 方案（已先出 mockup 对齐，`~/Desktop/agentry.pen`）

当 `ownSessions.length > 0 && children.length > 0` 时，把父级自己的会话拆进一个**独立折叠的内层 `SessionGroup`**：

- 头部是新的 `SessionsSubGroupHeader`（messages 图标 + 「会话」+ 计数，区别于子项目的彩色头像）。
- 折叠态分键记忆：新增 `project:<id>:sessions`，与项目整体折叠态 `project:<id>` 互不干扰。
- **父级标题箭头语义不变**：仍一键收/展整卡，向后兼容。
- **叶子项目**（无子项目）保持原样，会话直接挂标题下。
- **不藏死提醒**：会话子组折叠时，running/等待/未读仍通过现有 attention 气泡透出。

实现是**纯组合** —— `session-group.tsx` 一行未改，复用其 `renderHeader` slot + attention 气泡能力。

## 测试

新增 4 个 BDD 测试（子组出现条件 / 折叠只藏会话不动子项目 / 分键持久化 / 叶子项目不加子组）。

- 新行为 4 个 ✅；`project-page` + `session-group` 40/40 ✅
- i18n key 校验 + `no-literal-string` 19/19 ✅
- ESLint 0 error、`tsc -b` 干净
- 全量前端 **1083/1083** ✅