### PR TITLE
🐛 terminal: PTY 输出 base64 + 合并,修内嵌终端 TUI 乱码

### DIFF
--- a/frontend/src/components/agentre/terminal/__tests__/terminal-panel.test.tsx
+++ b/frontend/src/components/agentre/terminal/__tests__/terminal-panel.test.tsx
@@ -109,14 +109,15 @@ describe("TerminalPanel", () => {
       useTerminal as unknown as {
         mock: {
           calls: Array<
-            Array<{ terminalID: string; onData: (s: string) => void }>
+            Array<{ terminalID: string; onData: (d: Uint8Array) => void }>
           >;
         };
       }
     ).mock.calls[0][0];
     expect(args.terminalID).toBe("t1");
-    act(() => args.onData("hello"));
-    expect(writeMock).toHaveBeenCalledWith("hello");
+    const bytes = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+    act(() => args.onData(bytes));
+    expect(writeMock).toHaveBeenCalledWith(bytes);
   });
 
   it("Given a terminal tab is mounted active, When xterm opens, Then focus lands on the terminal before the next macrotask", () => {

--- a/frontend/src/components/agentre/terminal/__tests__/use-terminal.test.ts
+++ b/frontend/src/components/agentre/terminal/__tests__/use-terminal.test.ts
@@ -50,7 +50,7 @@ describe("useTerminal", () => {
     expect(result.current.state).toBe("open");
   });
 
-  it("exposes incoming data via onData callback", async () => {
+  it("base64-decodes incoming data to raw bytes for onData", async () => {
     const onData = vi.fn();
     renderHook(() =>
       useTerminal({
@@ -65,8 +65,14 @@ describe("useTerminal", () => {
     await act(async () => {
       await Promise.resolve();
     });
-    act(() => onHandlers["terminal:t1:data"]({ data: "hello" }));
-    expect(onData).toHaveBeenCalledWith("hello");
+    // base64 of bytes [0x68,0x69,0x20,0xe2,0x94,0x80] = "hi ─" — the box-drawing
+    // char '─' is 3 bytes (E2 94 80) and must reach xterm intact as raw bytes.
+    const b64 = btoa(String.fromCharCode(0x68, 0x69, 0x20, 0xe2, 0x94, 0x80));
+    act(() => onHandlers["terminal:t1:data"]({ data: b64 }));
+    expect(onData).toHaveBeenCalledTimes(1);
+    const arg = onData.mock.calls[0][0] as Uint8Array;
+    expect(arg).toBeInstanceOf(Uint8Array);
+    expect(Array.from(arg)).toEqual([0x68, 0x69, 0x20, 0xe2, 0x94, 0x80]);
   });
 
   it("calls TerminalClose and EventsOff on unmount", async () => {

--- a/frontend/src/components/agentre/terminal/use-terminal.ts
+++ b/frontend/src/components/agentre/terminal/use-terminal.ts
@@ -2,6 +2,17 @@ import { useEffect, useState, useCallback } from "react";
 import * as App from "@/../wailsjs/go/app/App";
 import { EventsOn, EventsOff } from "@/../wailsjs/runtime/runtime";
 
+// Terminal stdout arrives base64-encoded: raw PTY bytes survive the JSON event
+// bridge that way (a UTF-8 string would have multibyte sequences split across
+// chunks mangled to U+FFFD; see terminal_svc.pump). Decode to bytes and hand
+// them to xterm, which reassembles split multibyte sequences across writes.
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
 type Reason =
   | "natural"
   | "killed"
@@ -16,7 +27,7 @@ export interface UseTerminalArgs {
   deviceId: string;
   cols: number;
   rows: number;
-  onData?: (data: string) => void;
+  onData?: (data: Uint8Array) => void;
   onExit?: (info: { code: number; reason: Reason; msg?: string }) => void;
 }
 
@@ -30,7 +41,7 @@ export function useTerminal(args: UseTerminalArgs) {
     let cancelled = false;
 
     EventsOn(dataEvent, (payload: { data: string }) => {
-      args.onData?.(payload.data);
+      args.onData?.(base64ToBytes(payload.data));
     });
     EventsOn(
       exitEvent,

--- a/internal/daemon/handlers/terminal.go
+++ b/internal/daemon/handlers/terminal.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"sync"
@@ -95,8 +96,11 @@ func (h *TerminalHandlers) pump(ctx context.Context, id string, hd PTYHandle) {
 	go func() {
 		defer close(done)
 		for data := range queue {
+			// base64 so multibyte UTF-8 split across PTY reads survives the
+			// WebSocket JSON hop instead of being mangled to U+FFFD. The desktop
+			// remote backend decodes it back to raw bytes.
 			h.emitter.Emit(ctx, EventNameTerminalData, protocol.TerminalDataEvent{
-				TerminalID: id, Data: string(data),
+				TerminalID: id, Data: base64.StdEncoding.EncodeToString(data),
 			})
 		}
 	}()

--- a/internal/daemon/handlers/terminal_base64_test.go
+++ b/internal/daemon/handlers/terminal_base64_test.go
@@ -1,0 +1,57 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"agentre/internal/daemon/handlers"
+	"agentre/internal/pkg/pty"
+	"agentre/pkg/agentred/protocol"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTerminal_Pump_EmitsBase64SurvivingJSON is the remote-side regression for the
+// garbled-terminal bug: the daemon serializes TerminalDataEvent to JSON over the
+// WebSocket, so a multi-byte UTF-8 char ('─' = E2 94 80) split across two PTY
+// reads gets its half-rune bytes rewritten to U+FFFD if shipped as a raw string.
+// The data must be base64-encoded so it survives the JSON hop intact.
+func TestTerminal_Pump_EmitsBase64SurvivingJSON(t *testing.T) {
+	full := []byte("─") // E2 94 80
+	data := make(chan []byte, 2)
+	data <- full[:1] // E2
+	data <- full[1:] // 94 80
+	close(data)
+	exit := make(chan pty.ExitInfo, 1)
+	exit <- pty.ExitInfo{Code: 0, Reason: "natural"}
+	close(exit)
+
+	rec := &recordingEmitter{}
+	h := handlers.NewTerminalHandlers(&fakeTermBackend{h: &fakeTermHandle{data: data, exit: exit}}, rec)
+	_, err := h.Open(context.Background(), protocol.TerminalOpenParams{Cols: 80, Rows: 24})
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !sawDaemonExit(rec.snapshot()) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	require.True(t, sawDaemonExit(rec.snapshot()), "daemon never emitted exit")
+
+	var got []byte
+	for _, e := range rec.snapshot() {
+		if e.Name != handlers.EventNameTerminalData {
+			continue
+		}
+		wire, err := json.Marshal(e.Payload) // what the WebSocket serializes
+		require.NoError(t, err)
+		var ev protocol.TerminalDataEvent
+		require.NoError(t, json.Unmarshal(wire, &ev))
+		dec, err := base64.StdEncoding.DecodeString(ev.Data)
+		require.NoErrorf(t, err, "daemon data %q must be base64-encoded raw bytes", ev.Data)
+		got = append(got, dec...)
+	}
+	require.Equal(t, full, got, "split multibyte char must survive the daemon→desktop JSON hop")
+}

--- a/internal/daemon/handlers/terminal_test.go
+++ b/internal/daemon/handlers/terminal_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"sync"
@@ -153,7 +154,9 @@ func TestTerminal_Pump_EmitsDataEvent(t *testing.T) {
 	assert.Equal(t, handlers.EventNameTerminalData, events[0].Name)
 	pay := events[0].Payload.(protocol.TerminalDataEvent)
 	assert.Equal(t, res.TerminalID, pay.TerminalID)
-	assert.Equal(t, "hello", pay.Data)
+	decoded, err := base64.StdEncoding.DecodeString(pay.Data)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(decoded))
 }
 
 func TestTerminal_Pump_EmitsExitAndClearsMap(t *testing.T) {
@@ -259,7 +262,8 @@ func TestTerminal_Pump_DropsOldestAndInsertsThrottleMarkerWhenBufferFull(t *test
 	var sawThrottle bool
 	for _, ev := range events {
 		if pay, ok := ev.Payload.(protocol.TerminalDataEvent); ok {
-			if strings.Contains(pay.Data, "--- output throttled ---") {
+			decoded, _ := base64.StdEncoding.DecodeString(pay.Data)
+			if strings.Contains(string(decoded), "--- output throttled ---") {
 				sawThrottle = true
 				break
 			}

--- a/internal/daemon/handlers/terminal_test.go
+++ b/internal/daemon/handlers/terminal_test.go
@@ -262,7 +262,8 @@ func TestTerminal_Pump_DropsOldestAndInsertsThrottleMarkerWhenBufferFull(t *test
 	var sawThrottle bool
 	for _, ev := range events {
 		if pay, ok := ev.Payload.(protocol.TerminalDataEvent); ok {
-			decoded, _ := base64.StdEncoding.DecodeString(pay.Data)
+			decoded, err := base64.StdEncoding.DecodeString(pay.Data)
+			require.NoError(t, err, "terminal data event must be valid base64")
 			if strings.Contains(string(decoded), "--- output throttled ---") {
 				sawThrottle = true
 				break

--- a/internal/pkg/pty/remote/remote.go
+++ b/internal/pkg/pty/remote/remote.go
@@ -4,6 +4,7 @@ package remote
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"sync"
 	"time"
@@ -119,8 +120,15 @@ func (h *handleImpl) pump() {
 			if !ok {
 				return
 			}
+			// The daemon base64-encodes each chunk so it survives the JSON hop;
+			// decode back to raw bytes. Skip a malformed frame rather than feed
+			// the encoded text to xterm.
+			decoded, err := base64.StdEncoding.DecodeString(ev.Data)
+			if err != nil {
+				continue
+			}
 			select {
-			case h.data <- []byte(ev.Data):
+			case h.data <- decoded:
 			case <-h.done:
 				return
 			}

--- a/internal/pkg/pty/remote/remote_test.go
+++ b/internal/pkg/pty/remote/remote_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -49,7 +50,10 @@ func TestRemoteBackend_Open_RPC_RoundTrip(t *testing.T) {
 	require.Equal(t, "/r", op.Cwd)
 	require.Equal(t, uint16(80), op.Cols)
 
-	fc.dataPush <- protocol.TerminalDataEvent{TerminalID: "remote-1", Data: "xyz"}
+	// The daemon ships terminal data base64-encoded; the backend decodes it.
+	fc.dataPush <- protocol.TerminalDataEvent{
+		TerminalID: "remote-1", Data: base64.StdEncoding.EncodeToString([]byte("xyz")),
+	}
 
 	select {
 	case chunk := <-h.Data():
@@ -57,6 +61,43 @@ func TestRemoteBackend_Open_RPC_RoundTrip(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("did not receive data within 1s")
 	}
+}
+
+// TestRemoteBackend_Data_Base64DecodedAcrossSplit is the desktop-side regression
+// for the garbled-terminal bug: the daemon base64-encodes each PTY chunk, so the
+// backend must base64-decode it back to raw bytes. A multibyte char '─'
+// (E2 94 80) split across two daemon pushes must reassemble exactly — the old
+// []byte(ev.Data) reinterpreted the base64 text itself as bytes.
+func TestRemoteBackend_Data_Base64DecodedAcrossSplit(t *testing.T) {
+	fc := &fakeClient{
+		openParams: make(chan protocol.TerminalOpenParams, 1),
+		dataPush:   make(chan protocol.TerminalDataEvent, 2),
+		exitPush:   make(chan protocol.TerminalExitEvent, 1),
+	}
+	be := remote.NewBackend(fc)
+	h, err := be.Open(context.Background(), pty.Spec{Cwd: "/r"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+	<-fc.openParams
+
+	full := []byte("─") // E2 94 80
+	fc.dataPush <- protocol.TerminalDataEvent{
+		TerminalID: "remote-1", Data: base64.StdEncoding.EncodeToString(full[:1]),
+	}
+	fc.dataPush <- protocol.TerminalDataEvent{
+		TerminalID: "remote-1", Data: base64.StdEncoding.EncodeToString(full[1:]),
+	}
+
+	var got []byte
+	for len(got) < len(full) {
+		select {
+		case chunk := <-h.Data():
+			got = append(got, chunk...)
+		case <-time.After(time.Second):
+			t.Fatalf("did not receive full data within 1s; got %x", got)
+		}
+	}
+	require.Equal(t, full, got, "split multibyte char must reassemble from base64 daemon pushes")
 }
 
 func TestRemoteBackend_ExitEvent_DeliveredAndChannelsClose(t *testing.T) {

--- a/internal/service/terminal_svc/integration_test.go
+++ b/internal/service/terminal_svc/integration_test.go
@@ -5,6 +5,7 @@ package terminal_svc_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 	"time"
@@ -31,8 +32,13 @@ type collectingEmitter struct {
 func (c *collectingEmitter) Emit(_ context.Context, _ string, payload any) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Data events ship base64; decode each one (as the frontend's atob does)
+	// before accumulating. Exit events carry a different payload type and are
+	// skipped by the map type-assertion.
 	if m, ok := payload.(map[string]string); ok {
-		c.buf.WriteString(m["data"])
+		if dec, err := base64.StdEncoding.DecodeString(m["data"]); err == nil {
+			c.buf.Write(dec)
+		}
 	}
 }
 

--- a/internal/service/terminal_svc/integration_test.go
+++ b/internal/service/terminal_svc/integration_test.go
@@ -25,8 +25,9 @@ func (b localBackendBridge) Open(ctx context.Context, spec pty.Spec) (pty.Handle
 }
 
 type collectingEmitter struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	decodeErr error // first base64 decode failure; asserted on the test goroutine
 }
 
 func (c *collectingEmitter) Emit(_ context.Context, _ string, payload any) {
@@ -36,10 +37,26 @@ func (c *collectingEmitter) Emit(_ context.Context, _ string, payload any) {
 	// before accumulating. Exit events carry a different payload type and are
 	// skipped by the map type-assertion.
 	if m, ok := payload.(map[string]string); ok {
-		if dec, err := base64.StdEncoding.DecodeString(m["data"]); err == nil {
-			c.buf.Write(dec)
+		// Every data event is EncodeToString output, so a decode failure means
+		// the encoding pipeline regressed. Record it rather than silently
+		// dropping the chunk — Emit runs on the pump goroutine where t.Fatal is
+		// unsafe, so the test goroutine asserts DecodeErr instead.
+		dec, err := base64.StdEncoding.DecodeString(m["data"])
+		if err != nil {
+			if c.decodeErr == nil {
+				c.decodeErr = err
+			}
+			return
 		}
+		c.buf.Write(dec)
 	}
+}
+
+// DecodeErr returns the first base64 decode failure seen by Emit, if any.
+func (c *collectingEmitter) DecodeErr() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.decodeErr
 }
 
 func (c *collectingEmitter) Bytes() []byte {
@@ -65,6 +82,7 @@ func TestIntegration_LocalPTY_HappyPath(t *testing.T) {
 		case <-deadline:
 			t.Fatalf("did not see echo output; got: %q", string(emit.Bytes()))
 		case <-time.After(50 * time.Millisecond):
+			require.NoError(t, emit.DecodeErr(), "every terminal data event must be valid base64")
 			if bytes.Contains(emit.Bytes(), []byte("integ-test")) {
 				return
 			}

--- a/internal/service/terminal_svc/pump_output_test.go
+++ b/internal/service/terminal_svc/pump_output_test.go
@@ -1,0 +1,126 @@
+//go:build !windows
+
+package terminal_svc_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"agentre/internal/pkg/pty"
+	"agentre/internal/service/terminal_svc"
+
+	"github.com/stretchr/testify/require"
+)
+
+// decodeDataEvents reassembles the bytes the frontend would receive: every
+// terminal:<id>:data payload's "data" field, base64-decoded and concatenated.
+// A payload that is not valid base64 fails the test — raw PTY bytes shipped as a
+// JSON string get their invalid-UTF-8 runs rewritten to U+FFFD by json.Marshal,
+// so the only way the frontend can rebuild the exact bytes is base64.
+func decodeDataEvents(t *testing.T, evs []recordedEvent, id string) (data []byte, count int) {
+	t.Helper()
+	for _, e := range evs {
+		if e.Name != terminal_svc.DataEventName(id) {
+			continue
+		}
+		count++
+		m, ok := e.Payload.(map[string]string)
+		require.Truef(t, ok, "data payload should be map[string]string, got %T", e.Payload)
+		b, err := base64.StdEncoding.DecodeString(m["data"])
+		require.NoErrorf(t, err, "data payload %q must be base64-encoded raw bytes", m["data"])
+		data = append(data, b...)
+	}
+	return data, count
+}
+
+func waitForExit(t *testing.T, rec *recordingEmitter) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !sawExitEvent(rec.Snapshot()) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	require.True(t, sawExitEvent(rec.Snapshot()), "pump never emitted the exit event")
+}
+
+func openPump(t *testing.T, data chan []byte, exit chan pty.ExitInfo) *recordingEmitter {
+	t.Helper()
+	rec := &recordingEmitter{}
+	sel := terminal_svc.NewBackendSelector(
+		&fixedHandleBackend{h: &fakeExitHandle{data: data, exit: exit}}, nil,
+	)
+	svc := terminal_svc.NewService(sel, rec)
+	require.NoError(t, svc.Open(context.Background(), "1", "", "/tmp", 80, 24))
+	return rec
+}
+
+// TestService_Pump_PreservesMultibyteSplitAcrossChunks is the core regression for
+// the garbled-terminal bug: a 3-byte box-drawing char '─' (U+2500 = E2 94 80)
+// split across two PTY reads must reach the frontend intact. The old pump emitted
+// map{"data": string(chunk)}; Wails' json.Marshal then replaced each half-rune
+// byte with U+FFFD, destroying box-drawing / powerline / emoji glyphs.
+func TestService_Pump_PreservesMultibyteSplitAcrossChunks(t *testing.T) {
+	full := []byte("─") // E2 94 80
+	data := make(chan []byte, 2)
+	data <- full[:1] // E2
+	data <- full[1:] // 94 80
+	close(data)
+	exit := make(chan pty.ExitInfo, 1)
+	exit <- pty.ExitInfo{Code: 0, Reason: "natural"}
+	close(exit)
+
+	rec := openPump(t, data, exit)
+	waitForExit(t, rec)
+
+	got, _ := decodeDataEvents(t, rec.Snapshot(), "1")
+	require.Equal(t, full, got, "split multibyte char must survive the Wails JSON hop")
+}
+
+// TestService_Pump_CoalescesBurstIntoFewerEvents is the regression for the TUI
+// interleave: a burst of small PTY chunks must be coalesced into fewer Wails
+// events. The old pump emitted one event per chunk, flooding the event bridge so
+// that dropped/reordered events desynced xterm's parser into garbled output.
+// Bytes must still arrive intact and in order.
+func TestService_Pump_CoalescesBurstIntoFewerEvents(t *testing.T) {
+	chunks := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")}
+	data := make(chan []byte, len(chunks))
+	for _, c := range chunks {
+		data <- c // whole burst already buffered when pump starts draining
+	}
+	close(data)
+	exit := make(chan pty.ExitInfo, 1)
+	exit <- pty.ExitInfo{Code: 0, Reason: "natural"}
+	close(exit)
+
+	rec := openPump(t, data, exit)
+	waitForExit(t, rec)
+
+	got, count := decodeDataEvents(t, rec.Snapshot(), "1")
+	require.Equal(t, []byte("abcde"), got, "coalescing must preserve byte order")
+	require.Less(t, count, len(chunks),
+		"a burst of %d buffered chunks should coalesce into fewer data events, got %d", len(chunks), count)
+}
+
+// TestService_Pump_FlushesLoneChunkPromptly guards the time-based flush: a single
+// chunk that never reaches the size threshold and is not followed by close must
+// still be emitted on its own (otherwise interactive output — a shell prompt, a
+// single keystroke echo — would be withheld until more bytes or EOF arrive).
+func TestService_Pump_FlushesLoneChunkPromptly(t *testing.T) {
+	data := make(chan []byte, 1)
+	data <- []byte("x")
+	// data stays open; exit never fires — only the timer can flush.
+	exit := make(chan pty.ExitInfo)
+
+	rec := openPump(t, data, exit)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got, count := decodeDataEvents(t, rec.Snapshot(), "1"); count > 0 {
+			require.Equal(t, []byte("x"), got)
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("lone chunk was never flushed — time-based flush missing")
+}

--- a/internal/service/terminal_svc/service.go
+++ b/internal/service/terminal_svc/service.go
@@ -2,11 +2,24 @@ package terminal_svc
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"sync"
+	"time"
 
 	"agentre/internal/pkg/pty"
 	"agentre/pkg/agentred/protocol"
+)
+
+// Output coalescing: PTY stdout accumulates and is flushed to the emitter at
+// most every flushInterval, or sooner once flushThreshold bytes pile up. This
+// keeps a high-frequency full-screen TUI (claude, vim) from flooding the Wails
+// event bridge with hundreds of tiny events per second — a flood that drops or
+// reorders events and desyncs xterm's parser into the garbled output this fixes.
+// Mirrors the opskat terminal pipeline.
+const (
+	flushInterval  = 10 * time.Millisecond
+	flushThreshold = 32 * 1024
 )
 
 var (
@@ -181,21 +194,42 @@ func (s *Service) pump(ctx context.Context, terminalID string, h pty.Handle) {
 	// Exit() while data is still buffered and drops the trailing output.
 	dataCh := h.Data()
 	exitCh := h.Exit()
+
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+
+	var pending []byte
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		s.emitter.Emit(ctx, DataEventName(terminalID),
+			map[string]string{"data": base64.StdEncoding.EncodeToString(pending)})
+		pending = pending[:0]
+	}
+
 	var exitInfo pty.ExitInfo
 stream:
 	for {
 		select {
 		case data, ok := <-dataCh:
 			if !ok {
-				// Data closed before we observed exit; block for the single
-				// exit value (real handles always deliver it).
+				// Data closed before we observed exit; flush trailing output,
+				// then block for the single exit value (real handles always
+				// deliver it).
+				flush()
 				exitInfo = <-exitCh
 				break stream
 			}
-			s.emitter.Emit(ctx, DataEventName(terminalID), map[string]string{"data": string(data)})
+			pending = append(pending, data...)
+			if len(pending) >= flushThreshold {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
 		case info := <-exitCh:
 			exitInfo = info
-			// Drain any already-buffered data so trailing output is emitted
+			// Drain any already-buffered data so trailing output is flushed
 			// before the exit event.
 			for drained := false; !drained; {
 				select {
@@ -203,7 +237,7 @@ stream:
 					if !ok {
 						drained = true
 					} else {
-						s.emitter.Emit(ctx, DataEventName(terminalID), map[string]string{"data": string(data)})
+						pending = append(pending, data...)
 					}
 				default:
 					drained = true
@@ -212,6 +246,8 @@ stream:
 			break stream
 		}
 	}
+	// Flush whatever remains so no trailing output arrives after the exit event.
+	flush()
 
 	s.mu.Lock()
 	if cur, exists := s.sessions[terminalID]; exists && cur == h {

--- a/pkg/agentred/protocol/terminal.go
+++ b/pkg/agentred/protocol/terminal.go
@@ -31,7 +31,9 @@ type TerminalCloseParams struct {
 	TerminalID string `json:"terminalId"`
 }
 
-// TerminalDataEvent is the daemon→client push for stdout chunks.
+// TerminalDataEvent is the daemon→client push for stdout chunks. Data is
+// base64-encoded raw PTY bytes — not a UTF-8 string — so multibyte sequences
+// split across PTY reads survive the JSON hop instead of being mangled to U+FFFD.
 type TerminalDataEvent struct {
 	TerminalID string `json:"terminalId"`
 	Data       string `json:"data"`


### PR DESCRIPTION
## 问题
内嵌终端(xterm)跑 `claude` 等全屏 TUI 时渲染乱码;真终端(iTerm2)跑同样输出正常 → 缺陷在 agentre 的 PTY→xterm 数据通路。

## 根因
1. **字节损坏**:`terminal_svc.pump` 用 `string(data)` 把原始 PTY 字节当字符串,经 Wails(本地)/ WebSocket(远端)的 JSON 序列化时,跨 8KB 读边界切分的多字节 UTF-8(制表符 `─│┌`、powerline、emoji)被 `json.Marshal` 替换成 U+FFFD。
2. **字符交错**:每个 PTY chunk 发一个事件,高频 TUI 重绘把事件桥冲垮,丢/重排事件使 xterm 的有状态 ANSI 解析器失同步 → 两行字逐字符交错。

## 修复(对齐同作者已验证的 opskat 终端实现)
| 层 | 改动 |
|---|---|
| `terminal_svc.pump` | 累积 + flush(10ms / 32KB / exit 前各一次),每批 **base64** —— 同治损坏与交错 |
| daemon `terminal.go` | emit 改 base64(WebSocket 跳) |
| `remote.go` | 收到 base64 解码回原始字节 |
| 前端 `use-terminal.ts` | `atob → Uint8Array → term.write(bytes)` |

输入路径(键盘→PTY)不变:键入的是完整 UTF-8,不会被切。

## 测试
- 新增 RED→GREEN:多字节跨 chunk 切分(本地 pump + 远端两端)、突发合并成更少事件、孤立 chunk 按时 flush。
- 既有 exit-race、真 PTY 集成、节流标记测试同步更新为解码后断言。
- 全绿:`go test -race`(terminal_svc / pty/remote / daemon/handlers / app)、`go build ./...`、golangci-lint 0、前端 vitest 40 + i18n 13、ESLint / tsc clean。

## 注意
- **交错(A)是对齐 opskat 的实现 + 测试覆盖「合并发生且字节有序」,但 Wails 丢/重排未能在 headless 复现**;最终确认建议 `make dev` 跑一次 `claude` 验收。
- 远端 daemon→桌面 WebSocket 跳**未**加合并(TCP 有序,且共享的 Wails 跳已合并);其既有 32/256-cap drop-on-full 节流不变。
