### PR TITLE
⚡️ chat: 流式 markdown 增量渲染,消除活跃对话全局卡顿

### DIFF
--- a/frontend/src/components/agentre/__tests__/chat.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat.test.tsx
@@ -678,6 +678,28 @@ describe("ChatTranscript typing indicator", () => {
     ).toBeTruthy();
   });
 
+  it("renders multi-block live streaming text fully within one markdown-body", () => {
+    // 流式尾巴跨多个 block(段落 + 空行 + 段落)时,增量渲染路径不能丢内容,
+    // 且所有 block 落在同一个 .markdown-body 容器里(间距与一次性解析一致)。
+    render(
+      <ChatTranscript
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        liveDelta={"committed para\n\ngrowing tail"}
+        liveTargetId={2}
+        messages={[userMessage(1, "hi"), assistantMessage(2, [])]}
+        streaming
+      />,
+    );
+
+    const committed = screen.getByText("committed para");
+    const tail = screen.getByText("growing tail");
+    expect(committed.closest(".markdown-body")).not.toBeNull();
+    expect(tail.closest(".markdown-body")).toBe(
+      committed.closest(".markdown-body"),
+    );
+  });
+
   it("does not render the indicator when streaming is false", () => {
     render(
       <ChatTranscript

--- a/frontend/src/components/agentre/__tests__/streaming-markdown.test.tsx
+++ b/frontend/src/components/agentre/__tests__/streaming-markdown.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StreamingMarkdown } from "../markdown-text";
+
+// StreamingMarkdown 增量渲染流式 markdown:把已定稿 block 与活跃尾巴拆成多个
+// 独立的(React.memo 的)内层 ReactMarkdown,只有尾巴每 chunk 重解析。这里验证:
+//   1. 渲染结果与一次性整段解析等价(内容不丢、代码块仍渲染);
+//   2. 所有 block 共享同一个 .markdown-body 容器 —— 段落的 first/last 外边距重置
+//      必须跨整条消息生效,否则已定稿段落间距会塌成 0,turn done 整段重渲染时
+//      又撑开,产生「流式挤在一起、done 时啪地展开」的跳变。
+describe("StreamingMarkdown", () => {
+  it("when streaming text has prose + closed code + tail then renders all content", () => {
+    const { container } = render(
+      <StreamingMarkdown
+        text={"para one\n\n```js\nconst x = 1;\n```\n\ntail growing"}
+      />,
+    );
+    expect(screen.getByText("para one")).toBeInTheDocument();
+    // 代码经 highlight.js 拆进多个 span,文本被切碎 —— 用 textContent 整体断言。
+    expect(container.textContent).toContain("const x = 1;");
+    expect(screen.getByText("tail growing")).toBeInTheDocument();
+  });
+
+  it("when text has multiple committed blocks then they share a single markdown-body wrapper", () => {
+    // 单一容器是间距与一次性解析保持一致的结构前提。
+    const { container } = render(
+      <StreamingMarkdown text={"para one\n\npara two\n\ntail growing"} />,
+    );
+    expect(container.querySelectorAll(".markdown-body")).toHaveLength(1);
+    // 三个段落都在同一容器里,作为兄弟节点参与 first/last 外边距计算。
+    expect(screen.getByText("para one")).toBeInTheDocument();
+    expect(screen.getByText("para two")).toBeInTheDocument();
+    expect(screen.getByText("tail growing")).toBeInTheDocument();
+  });
+
+  it("when text is a single growing block then it renders a single markdown-body wrapper", () => {
+    const { container } = render(<StreamingMarkdown text="just growing" />);
+    expect(container.querySelectorAll(".markdown-body")).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/agentre/chat.tsx
+++ b/frontend/src/components/agentre/chat.tsx
@@ -32,7 +32,7 @@ import { AIChatInput, type AIChatInputHandle } from "./chat-input";
 import { CodeBlock } from "./code-block";
 import { CompactBoundaryDivider } from "./compact-boundary-divider";
 import { CompactHistoryFold } from "./compact-history-fold";
-import { MarkdownText } from "./markdown-text";
+import { MarkdownText, StreamingMarkdown } from "./markdown-text";
 import { AgentAvatar } from "./primitives";
 import { ThinkingBlock } from "./thinking-block";
 
@@ -1420,7 +1420,9 @@ function renderMessageBlocks(
   t?: TFunction,
 ): React.ReactNode {
   type RenderItem =
-    | { text: string; type: "text" }
+    // streaming=true 标记这是「流式途中正在生长」的文本项 —— 用 StreamingMarkdown
+    // 增量渲染(已定稿 block memo 跳过、只重解析活跃尾巴);持久化文本仍走整段 MarkdownText。
+    | { text: string; type: "text"; streaming?: boolean }
     | { block: ChatBlockData; type: "plan" }
     | {
         block: ChatBlockData;
@@ -1475,14 +1477,17 @@ function renderMessageBlocks(
   // can_use_tool control_request 也不携带未来的 tool_use_id。
   const pendingPermsByTool = new Map<string, number[]>();
 
-  function appendText(text: string) {
+  function appendText(text: string, streaming = false) {
     if (!text) return;
     const last = items.at(-1);
     if (last?.type === "text") {
       last.text += text;
+      // 与前一个已冻结的 text 段合并后,整段都按流式尾巴处理 ——
+      // StreamingMarkdown 会把已冻结的前缀也切成 memo 命中的定稿块,只重解析真尾巴。
+      if (streaming) last.streaming = true;
       return;
     }
-    items.push({ text, type: "text" });
+    items.push({ text, type: "text", streaming });
   }
 
   const consumeBlock = (b: ChatBlockData) => {
@@ -1631,7 +1636,8 @@ function renderMessageBlocks(
     });
   }
   liveBlocks.forEach(consumeBlock);
-  appendText(liveTail);
+  // liveTail 是本轮仍在生长的尾巴文本 —— 标记 streaming,走 StreamingMarkdown 增量渲染。
+  appendText(liveTail, true);
 
   // 被 merge 到下方 tool_use 卡的审批 RenderItem 不再独立渲染。
   const visibleItems = items.filter(
@@ -1641,7 +1647,11 @@ function renderMessageBlocks(
   return visibleItems.map((item, idx) => {
     switch (item.type) {
       case "text":
-        return <MarkdownText key={`text-${idx}`} cwd={cwd} text={item.text} />;
+        return item.streaming ? (
+          <StreamingMarkdown key={`text-${idx}`} cwd={cwd} text={item.text} />
+        ) : (
+          <MarkdownText key={`text-${idx}`} cwd={cwd} text={item.text} />
+        );
       case "plan":
         return (
           <PlanApproveCard

--- a/frontend/src/components/agentre/markdown-text.tsx
+++ b/frontend/src/components/agentre/markdown-text.tsx
@@ -7,6 +7,7 @@ import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
+import { splitStreamingMarkdown } from "@/lib/streaming-markdown";
 
 import { CodeBlock } from "./code-block";
 import { RichLink } from "./rich-link";
@@ -208,7 +209,11 @@ const markdownRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [
   [rehypeHighlight, { detect: true, ignoreMissing: true }],
 ];
 
-export const MarkdownText = React.memo(function MarkdownText({
+// MarkdownInner 是「不带 .markdown-body 外壳」的 ReactMarkdown。单独 React.memo:
+// 文本稳定时跳过 markdown 解析 + highlight.js 高亮。抽出外壳是为了让 StreamingMarkdown
+// 能把多个已定稿段塞进同一个 .markdown-body 里渲染 —— 段落的 first/last 外边距
+// 重置必须跨整条消息生效,分到多个外壳会让已定稿段落间距塌成 0。
+const MarkdownInner = React.memo(function MarkdownInner({
   text,
   cwd,
 }: {
@@ -232,15 +237,59 @@ export const MarkdownText = React.memo(function MarkdownText({
   );
 
   return (
+    <ReactMarkdown
+      components={components}
+      remarkPlugins={markdownRemarkPlugins}
+      rehypePlugins={markdownRehypePlugins}
+      urlTransform={whitelistUrl}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+});
+
+export const MarkdownText = React.memo(function MarkdownText({
+  text,
+  cwd,
+}: {
+  text: string;
+  cwd?: string;
+}) {
+  return (
     <div className="markdown-body break-words text-sm leading-relaxed">
-      <ReactMarkdown
-        components={components}
-        remarkPlugins={markdownRemarkPlugins}
-        rehypePlugins={markdownRehypePlugins}
-        urlTransform={whitelistUrl}
-      >
-        {text}
-      </ReactMarkdown>
+      <MarkdownInner text={text} cwd={cwd} />
+    </div>
+  );
+});
+
+// StreamingMarkdown 增量渲染「流式累积中」的 markdown:把文本按 block 边界切成
+// [已定稿 block...] + [活跃尾巴],每段交给一个 React.memo 的 MarkdownInner,
+// 全部塞进同一个 .markdown-body 外壳。已定稿段的文本逐字节稳定 → memo 命中 →
+// 只解析+高亮一次,后续 chunk 跳过;只有活跃尾巴每个 chunk 重解析,把单 chunk
+// 渲染开销从 O(n) 降到 O(Δ),彻底消除「整段 markdown 每 chunk 全量重解析 +
+// highlight.js 全量重探测」的 O(n²) 卡顿。各段同处一个外壳,段落 first/last
+// 外边距跨整条消息计算,间距与一次性解析完全一致。
+//
+// 定稿段的 key 用顺序下标:切分是 append-only,已出现的下标对应的文本永不改变,
+// memo 稳定命中。仅用于流式途中的活跃消息;turn done 后消息从持久化数据走普通
+// MarkdownText 整段渲染一次,所以切分近似(松散列表 / 后置引用定义等极少数情形)会自愈。
+export const StreamingMarkdown = React.memo(function StreamingMarkdown({
+  text,
+  cwd,
+}: {
+  text: string;
+  cwd?: string;
+}) {
+  const { committed, tail } = React.useMemo(
+    () => splitStreamingMarkdown(text),
+    [text],
+  );
+  return (
+    <div className="markdown-body break-words text-sm leading-relaxed">
+      {committed.map((segment, i) => (
+        <MarkdownInner key={i} text={segment} cwd={cwd} />
+      ))}
+      {tail ? <MarkdownInner key="tail" text={tail} cwd={cwd} /> : null}
     </div>
   );
 });

--- a/frontend/src/lib/streaming-markdown.test.ts
+++ b/frontend/src/lib/streaming-markdown.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { splitStreamingMarkdown } from "./streaming-markdown";
+
+// splitStreamingMarkdown 把「流式累积中的 markdown 文本」切成
+// [已定稿 block...] + [活跃尾巴]。已定稿 block 一旦产出就永不再变 ——
+// 调用方据此对每个已定稿 block 做 memo,只让活跃尾巴每 chunk 重解析,
+// 把单 chunk 渲染开销从 O(n) 降到 O(Δ)。
+describe("splitStreamingMarkdown", () => {
+  it("when empty string then no committed blocks and empty tail", () => {
+    expect(splitStreamingMarkdown("")).toEqual({ committed: [], tail: "" });
+  });
+
+  it("when single growing paragraph (no blank line) then it stays in tail", () => {
+    // 还没出现 block 边界 —— 整段都可能继续生长,不能定稿。
+    expect(splitStreamingMarkdown("hello wor")).toEqual({
+      committed: [],
+      tail: "hello wor",
+    });
+  });
+
+  it("when paragraph + blank line + new paragraph then first commits, last is tail", () => {
+    expect(splitStreamingMarkdown("para one\n\npara two")).toEqual({
+      committed: ["para one"],
+      tail: "para two",
+    });
+  });
+
+  it("when text ends with a blank line then the trailing block is committed too", () => {
+    // 末尾的空行意味着该段已闭合,模型已经移到下一个 block,可安全定稿。
+    expect(splitStreamingMarkdown("para one\n\n")).toEqual({
+      committed: ["para one"],
+      tail: "",
+    });
+  });
+
+  it("when a fenced code block is closed then it commits as one atomic block", () => {
+    // 闭合的代码块永不再变 —— 定稿后只跑一次 highlight.js,后续 chunk 跳过。
+    expect(splitStreamingMarkdown("```js\nconst x = 1;\n```\nafter")).toEqual({
+      committed: ["```js\nconst x = 1;\n```"],
+      tail: "after",
+    });
+  });
+
+  it("when a fenced code block is still open then the whole fence stays in tail", () => {
+    // 未闭合的 fence 仍在生长且其内容解释可能改变,必须留在尾巴里整体重解析。
+    expect(splitStreamingMarkdown("intro line\n\n```js\nconst x =")).toEqual({
+      committed: ["intro line"],
+      tail: "```js\nconst x =",
+    });
+  });
+
+  it("when a blank line sits inside an open fence then it does not split the block", () => {
+    // fence 内部的空行不是 block 边界 —— 不能据此切开。
+    expect(splitStreamingMarkdown("```\nline1\n\nline2\n```\ntail")).toEqual({
+      committed: ["```\nline1\n\nline2\n```"],
+      tail: "tail",
+    });
+  });
+
+  it("when multiple committed blocks precede the tail then all but the last commit", () => {
+    expect(
+      splitStreamingMarkdown("a\n\n```\ncode\n```\n\nb\n\nc growing"),
+    ).toEqual({
+      committed: ["a", "```\ncode\n```", "b"],
+      tail: "c growing",
+    });
+  });
+});

--- a/frontend/src/lib/streaming-markdown.ts
+++ b/frontend/src/lib/streaming-markdown.ts
@@ -1,0 +1,79 @@
+// streaming-markdown: 把「流式累积中的 markdown 文本」切成
+// [已定稿 block...] + [活跃尾巴]。
+//
+// 关键事实:流式消息里只有末尾正在生长的那一个 block 会变,它前面的内容
+// 一旦产出就永不改变。调用方据此对每个已定稿 block 做 React.memo —— 闭合的
+// 代码块只跑一次 highlight.js,后续 chunk 直接跳过,把单 chunk 渲染开销从
+// O(n)(全量重解析+重高亮)降到 O(Δ)(只解析活跃尾巴)。
+//
+// 定稿边界的判定保守取「fence 之外的空行」与「闭合的围栏代码块」两类:
+//   - fence 外的空行 = CommonMark block 边界,之前的 block 不会再被后续 token
+//     改写;
+//   - 闭合的围栏代码块整体是一个原子 block,内部空行不算边界。
+// 未闭合的 fence 及最后一个仍在生长的 block 留在 tail 里每 chunk 重解析。
+//
+// 切分只是近似:turn done 后消息会从持久化数据走普通路径整体重渲染一次
+// (单次完整解析),所以流式期间的任何切分近似都会自愈。
+
+export type SplitStreamingMarkdown = {
+  /** 已定稿、逐字节稳定的 block 文本,按出现顺序排列。 */
+  committed: string[];
+  /** 仍在生长的尾部(可能是半截段落或未闭合的 fence);为空表示无活跃尾巴。 */
+  tail: string;
+};
+
+// 围栏起始:最多 3 个前导空格 + 连续 3 个以上的 ` 或 ~。
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+
+function isFenceClose(line: string, marker: "`" | "~"): boolean {
+  const re = marker === "`" ? /^ {0,3}`{3,}\s*$/ : /^ {0,3}~{3,}\s*$/;
+  return re.test(line);
+}
+
+export function splitStreamingMarkdown(text: string): SplitStreamingMarkdown {
+  const lines = text.split("\n");
+  const committed: string[] = [];
+  let current: string[] = [];
+  let fenceOpen = false;
+  let fenceMarker: "`" | "~" = "`";
+
+  const flush = () => {
+    if (current.length > 0) {
+      committed.push(current.join("\n"));
+      current = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (fenceOpen) {
+      current.push(line);
+      if (isFenceClose(line, fenceMarker)) {
+        // 闭合的围栏代码块整体定稿。
+        fenceOpen = false;
+        flush();
+      }
+      continue;
+    }
+
+    const open = FENCE_OPEN.exec(line);
+    if (open) {
+      // fence 起始会打断上一段 —— 先把已累积的 prose 定稿,再开始攒 fence。
+      flush();
+      fenceOpen = true;
+      fenceMarker = open[1][0] as "`" | "~";
+      current.push(line);
+      continue;
+    }
+
+    if (line.trim() === "") {
+      // fence 外的空行 = block 边界,之前的内容已定稿。
+      flush();
+      continue;
+    }
+
+    current.push(line);
+  }
+
+  // 残留在 current 里的就是仍在生长的尾巴(含未闭合的 fence)。
+  return { committed, tail: current.join("\n") };
+}


### PR DESCRIPTION
## 问题

活跃流式对话时**整个 app 卡** —— 连切 tab、点项目「新建会话」菜单等和对话无关的操作都有明显延迟。

## 根因

流式消息**每个 chunk 都对整段累积文本全量重跑** `ReactMarkdown` 解析 + `rehypeHighlight({detect:true})`(highlight.js 全语言自动探测)→ **O(n²)**,而且 turn 中"每秒几十次",还对**每个挂载的面板**(隐藏 tab 仅 `display:none`、React 照常渲染)都在跑。主线程被占满,一切交互被挤到这些渲染之后执行 → 全局卡顿。

`MarkdownText` 虽是 `React.memo`,但流式消息的 `text` 每 chunk 都变,memo 永远失效。

## 方案:增量渲染 + 正确 memo(无节流、零延迟)

利用「流式消息只有末尾正在生长的 block 会变,前面永不改变」这一事实:

- **`lib/streaming-markdown.ts`** — `splitStreamingMarkdown` 把流式文本按 block 边界切成 `[已定稿块...] + [活跃尾巴]`(围栏代码块整体原子、内部空行不切;未闭合 fence 留在尾巴)。
- **`markdown-text.tsx`** — 抽出**无壳**的 memo 内层 `MarkdownInner`;`StreamingMarkdown` 把各段塞进**同一个** `.markdown-body`。已定稿块文本逐字节稳定 → `React.memo` 命中 → 只解析/高亮一次,闭合代码块不再每 chunk 重探测;只有尾巴每 chunk 重解析 → **O(n²) 降到 O(Δ)**。单一容器保证段落 `first/last` 外边距跨整条消息计算,间距与一次性解析**完全一致**(避免「流式挤一起、done 时啪地撑开」的跳变)。
- **`chat.tsx`** — 仅给 live tail 文本项打 `streaming` 标走 `StreamingMarkdown`;持久化/历史文本不变;turn `done` 后整段重渲染自愈切分近似。

## 测试(严格 TDD,Red→Green→Refactor)

- 切分器 8 个单测 + `StreamingMarkdown` 3 个组件测 + 1 个集成测
- **完整套件 116 文件 / 1091 测试全绿**(无回归)
- `tsc -b` 干净;改动文件 `eslint` 干净

> 注:本 PR 只动了流式 markdown 渲染路径。残余优化层(面板常驻 `display:none`、后端逐 chunk emit 合批)刻意未动,避免越界。已通过测试与代码分析验证机制,**尚未**在运行中的 app 实测帧率。