### PR TITLE
✨ 退出 App 二次确认(活跃会话保护)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-quit-confirmation-design.md
+++ b/docs/superpowers/specs/2026-06-04-quit-confirmation-design.md
@@ -1,0 +1,143 @@
+# 退出 App 二次确认(活跃会话保护)设计
+
+**日期**: 2026-06-04
+**状态**: 设计完成,待 review
+**作者**: Claude (结对 with 王一之)
+
+## 背景
+
+用户按 cmd+Q(macOS)/ 点关闭按钮 / Alt+F4(Windows)退出 App 时,如果当前**有正在进行的会话**,会直接杀掉常驻 CLI 子进程、中断当前回合,未完成的回合丢失且无任何提示。诉求:**退出前若存在活跃会话,弹一个二次确认框**,跨平台(macOS / Windows / Linux)统一处理。
+
+### 关键可行性结论(已核实)
+
+- **`OnBeforeClose` 是 Wails v2.12.0 所有平台唯一的退出拦截点**。已读源码确认三条退出路径全部汇入 `Frontend.Quit()` → `OnBeforeClose`:
+  - macOS:cmd+Q / 菜单 Quit / Dock Quit → `AppDelegate.applicationShouldTerminate` 返回 `NSTerminateCancel` 并 `processMessage("Q")` → dispatcher `case 'Q': sender.Quit()`(`darwin/AppDelegate.m`、`darwin/frontend.go:364`、`dispatcher.go:69`)。
+  - Windows:关闭按钮 / Alt+F4 / `wailsruntime.Quit` → `windows/frontend.go:453 Quit()`。
+  - 返回 `true` 即阻止退出。
+  - 平台差异:macOS 在 goroutine 里跑 `OnBeforeClose`,Windows 在主线程同步跑。**因此 `OnBeforeClose` 内必须只做一次快速 COUNT 查询、不可阻塞**(不能在里面弹原生对话框等待)。
+- 当前 `main.go` 只接了 `OnStartup` / `OnShutdown`,**没接 `OnBeforeClose`**。
+- 「活跃」判定沿用启动时 `ResetStaleActiveSessions` 的口径:`agent_status IN ('running','waiting') AND status = consts.ACTIVE`(`chat_repo/session.go:308`)。
+- 自动更新「重启」(`internal/app/update.go:128`)也调 `wailsruntime.Quit`——它在拉起新进程后退出旧进程,**必须跳过确认**,否则旧进程被拦、新进程撞单实例锁(`SingleInstanceLock`)→ 更新静默失败。
+- 前端常驻挂载点:`App.tsx` 的 `AppLayout` 里 `<Toaster/>` 旁(始终挂载,跨路由存活);事件订阅沿用 `EventsOn`(`wailsjs/runtime/runtime`,参考 `hooks/use-chat-stream.ts:156`)。
+- 代码库**没有 shadcn `alert-dialog`**;复用现成的 `components/agentre/app-dialog.tsx`(`AgentreDialog`,基于 `components/ui/dialog.tsx`)。
+- 会话展示数据分两处:运行态 `stores/session-status-store.ts`(只有 `agentStatus`/`needsAttention`,**无名称**);展示名在 `stores/session-meta-store.ts`(`SessionMeta`:`agentName`/`agentColor`/`projectId`/`title`)。
+
+## 已确认的设计决策
+
+1. **确认框形式 = 应用内 shadcn 弹窗**(复用 `AgentreDialog`),走 react-i18next,和无边框自定义窗口风格一致。不用系统原生 MessageDialog。
+2. **活跃口径 = `running` + `waiting`**(任何进行中的回合;与 `ResetStaleActiveSessions` 一致)。
+3. **确认框带「进行中会话列表」**:每行 agent 头像 + 名称 + 项目/分支 + 状态胶囊(绿 `运行中` / 琥珀 `等待确认`)。
+4. **列表溢出**:可见行**上限 3 行**,其余折叠为一行 `还有 N 个会话`(放在可滚动区域内);**header 计数永远显示后端真实总数**。
+5. **计数以后端为准**:确认框 header 的数字来自后端 `OnBeforeClose` 的 COUNT;列表行从前端 store 派生(best-effort,store 不全时只少列几行,不影响 header 数字)。
+6. 设计稿:`~/Desktop/agentry.pen` 的 `Quit Confirm — Light`(常规)与 `Quit Confirm — Many`(溢出)两帧,复用既有 Delete Dialog 的 token。
+
+## 后端设计
+
+### 1. `internal/repository/chat_repo/session.go` — 新增 `CountActive`
+
+仿照已有 `CountActiveByProject`,去掉 project 过滤,做全局计数:
+
+```go
+// CountActive 统计 status=ACTIVE 且 agent_status 在指定集合内的会话总数(跨所有 agent/项目)。
+// 用于退出二次确认:agentStatuses 传 {"running","waiting"}。
+func (r *sessionRepo) CountActive(ctx context.Context, agentStatuses []string) (int64, error)
+```
+
+加入 `Session` 接口(`session.go:28` 附近)。实现:`db.Ctx(ctx).Model(&chat_entity.Session{}).Where("agent_status IN ? AND status = ?", agentStatuses, consts.ACTIVE).Count(&n)`。需 `make mock` 重生 `mock_chat_repo`。
+
+### 2. `internal/service/chat_svc/chat.go` — 新增 `CountActiveSessions`
+
+```go
+// CountActiveSessions 返回正在进行(running|waiting)的会话数,供退出二次确认判断。
+func (s *chatSvc) CountActiveSessions(ctx context.Context) (int, error)
+```
+
+加入 `ChatSvc` 接口(`chat.go:73`)。实现:`n, err := chat_repo.Session().CountActive(ctx, []string{"running", "waiting"})`,返回 `int(n)`。
+
+### 3. `internal/app/app.go` — `OnBeforeClose` + `ConfirmQuit`
+
+App 新增字段 `quitConfirmed atomic.Bool`。决策抽成可测纯函数,真实依赖在 `OnBeforeClose` 注入:
+
+```go
+// shouldPreventQuit 决定是否拦截退出并通知前端弹确认框。
+//   confirmed=true(已确认/自动更新重启) → 放行
+//   count 出错或为 0 → 放行(fail-open:计数失败不困住用户)
+//   count>0 → emit "app:quit-blocked"{count} 并拦截
+func shouldPreventQuit(ctx context.Context, confirmed bool,
+    count func(context.Context) (int, error), emit func(n int)) bool {
+    if confirmed {
+        return false
+    }
+    n, err := count(ctx)
+    if err != nil || n == 0 {
+        return false
+    }
+    emit(n)
+    return true
+}
+
+func (a *App) OnBeforeClose(ctx context.Context) (prevent bool) {
+    return shouldPreventQuit(ctx, a.quitConfirmed.Load(),
+        func(c context.Context) (int, error) { return chat_svc.Chat().CountActiveSessions(c) },
+        func(n int) {
+            logger.Ctx(ctx).Info("app.OnBeforeClose: quit blocked by active sessions", zap.Int("count", n))
+            wailsruntime.EventsEmit(a.ctx, "app:quit-blocked", map[string]any{"count": n})
+        })
+}
+
+// ConfirmQuit 前端点「仍然退出」后调用:标记已确认并真正退出。
+func (a *App) ConfirmQuit() {
+    a.quitConfirmed.Store(true)
+    wailsruntime.Quit(a.ctx)
+}
+```
+
+- `main.go` 的 wails options 加 `OnBeforeClose: appInst.OnBeforeClose`。
+- **fail-open 取舍**:COUNT 出错时放行而非拦截——拦截会因瞬时 DB 错误把用户困在「退不出去」,代价仅是极罕见错误下漏一次确认;已 `logger.Warn`。
+
+### 4. `internal/app/update.go` — 重启跳过确认
+
+`restartApp`(`update.go:128`)在 `wailsruntime.Quit(a.ctx)` 前加 `a.quitConfirmed.Store(true)`,让自动更新重启绕过确认。
+
+## 前端设计
+
+### 1. `App.ConfirmQuit` 绑定
+
+`make generate` 后 `wailsjs/go/app/App.d.ts` 生成 `ConfirmQuit():Promise<void>`(无参)。
+
+### 2. 新组件 `frontend/src/components/agentre/quit-confirm-dialog.tsx`
+
+始终挂载在 `App.tsx` 的 `AppLayout` 内 `<Toaster/>` 旁:
+
+- 内部 `useState` 持有 `{ open, count }`;`useEffect` 里 `EventsOn("app:quit-blocked", p => setState({open:true, count:p.count}))`,返回 `off` 清理(镜像 `use-chat-stream.ts` 的 ref 模式)。
+- 渲染用 `AgentreDialog`:标题「退出 Agentre？」+ 琥珀 `triangle-alert`,描述含 `count`,footer `取消`(关闭)+ `仍然退出`(destructive,调 `ConfirmQuit()`)。
+- **会话列表**:`useSessionStatusStore` 取所有 `agentStatus ∈ {running,waiting}` 的 sessionId,`useSessionMetaStore` 取每个的 `agentName/agentColor/projectId/title` 渲染行;可见上限 3,其余折叠为 `还有 N 个会话` 行,列表区 `max-h` 可滚。header 数字用后端 `count`。store 无 meta 的行用兜底文案。
+- `取消` / Esc / 点遮罩 = 关闭(安全默认),**不**调 `ConfirmQuit`。
+
+### 3. i18n
+
+`frontend/src/i18n/locales/{zh-CN,en}/common.json` 新增 `quitConfirm` 段:`title` / `description`(带 `{{count}}`)/ `runningSessions`(带 `{{count}}`)/ `more`(带 `{{count}}`)/ `statusRunning` / `statusWaiting` / `cancel` / `quitAnyway` / 兜底会话名。两份 locale 同步,过 `i18n.test.ts`。
+
+## 边界与交互
+
+- **取消后再次退出**:`quitConfirmed` 仍为 false,重新 COUNT、重新弹框(符合预期)。
+- **确认后**:`quitConfirmed=true` → `Quit` 重入 `OnBeforeClose` → 放行退出。
+- **无活跃会话**:`OnBeforeClose` 返回 false,正常秒退,无框。
+- **自动更新重启**:`update.go` 预置 `quitConfirmed=true`,不弹框,正常重启。
+- **重复触发**(连按 cmd+Q):每次 emit 一次事件,前端 `open` 幂等(已开着就保持开)。
+
+## 测试计划(TDD:Red → Green)
+
+| 层 | 文件 | 用例 |
+|---|---|---|
+| repo (sqlmock) | `chat_repo/session_test.go` | `TestSessionRepo_CountActive`:断言 SQL `agent_status IN ('running','waiting') AND status=ACTIVE` 的 COUNT,返回 N(仿 `TestSessionRepo_CountActiveByProject`) |
+| svc (repo mock) | `chat_svc/..._test.go` | `CountActiveSessions` 透传 mock 计数;断言传入 statuses 为 `{running,waiting}` |
+| app (纯函数+fake) | `internal/app/app_quit_test.go` | `shouldPreventQuit`:confirmed→false 不 emit;count=0→false 不 emit;count>0→true 且 emit(n);count err→false 不 emit |
+| 前端 (vitest) | `components/agentre/__tests__/quit-confirm-dialog.test.tsx` | 触发 `app:quit-blocked` 事件→框打开且显示 count;点「仍然退出」→调 `ConfirmQuit`;点「取消」→关闭且不调 `ConfirmQuit`;>3 会话→显示「还有 N 个会话」 |
+
+## 不做的事(YAGNI)
+
+- 不做「下次不再提醒」偏好。
+- 不把活跃判定扩展到终端进程/未保存草稿(只看 chat 会话 running/waiting)。
+- 不在事件 payload 里下发会话列表(列表由前端 store 派生);后端只给权威 count。
+- 不新增 shadcn `alert-dialog` 组件(复用 `AgentreDialog`)。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import {
   OrgChartPage,
   PaletteScopeBridge,
   ProjectsPage,
+  QuitConfirmDialog,
   ShortcutsProvider,
   SidebarButton,
   SettingsPage,
@@ -855,6 +856,8 @@ function App() {
           unmount,但这里继续维持 Wails EventsOn,把 chunk/tool 事件累到全局
           store,切回来时 ChatPanel 能从 store 还原完整流式状态。*/}
       <ChatStreamsHost />
+      {/* 退出二次确认:常驻订阅 "app:quit-blocked",活跃会话存在时拦截退出弹框。*/}
+      <QuitConfirmDialog />
       <Routes>
         <Route element={<AppLayout />}>
           <Route path="/chat" element={<ChatPage />} />

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -8,7 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import App from "../App";
 
@@ -635,12 +635,25 @@ function mockHooks(
   return app;
 }
 
+// runtimeEventStubs supplies no-op EventsOn/EventsOff so always-mounted
+// subscribers (e.g. QuitConfirmDialog's "app:quit-blocked" listener) don't blow
+// up on window.runtime.EventsOnMultiple when <App/> renders without a full runtime.
+function runtimeEventStubs() {
+  return {
+    EventsOn: vi.fn(() => vi.fn()),
+    EventsOnMultiple: vi.fn(() => vi.fn()),
+    EventsOff: vi.fn(),
+    EventsEmit: vi.fn(),
+  };
+}
+
 function mockWailsRuntime({
   fullscreen = false,
   platform = "darwin",
   size = { h: 768, w: 1024 },
 }: MockWailsRuntimeOptions = {}) {
   const runtime = {
+    ...runtimeEventStubs(),
     Environment: vi.fn(() =>
       Promise.resolve({
         arch: "arm64",
@@ -662,6 +675,13 @@ function mockWailsRuntime({
 
   return runtime;
 }
+
+beforeEach(() => {
+  // Baseline full runtime so <App/> startup (Environment/Window*) and the
+  // always-mounted QuitConfirmDialog's "app:quit-blocked" subscription both
+  // work; individual tests still override via mockWailsRuntime as needed.
+  mockWailsRuntime();
+});
 
 afterEach(() => {
   restoreMatchMedia?.();

--- a/frontend/src/__tests__/mocks/wailsApp.ts
+++ b/frontend/src/__tests__/mocks/wailsApp.ts
@@ -206,3 +206,8 @@ export const PreviewImportData = windowBackedMock("PreviewImportData", () =>
 export const ApplyImportData = windowBackedMock("ApplyImportData", () =>
   Promise.resolve({ counts: {} }),
 );
+
+// Quit confirmation — called when the user confirms quitting with active sessions.
+export const ConfirmQuit = windowBackedMock("ConfirmQuit", () =>
+  Promise.resolve(),
+);

--- a/frontend/src/components/agentre/__tests__/quit-confirm-dialog.test.tsx
+++ b/frontend/src/components/agentre/__tests__/quit-confirm-dialog.test.tsx
@@ -1,0 +1,128 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSessionMetaStore } from "@/stores/session-meta-store";
+import { useSessionStatusStore } from "@/stores/session-status-store";
+
+import { QuitConfirmDialog } from "../quit-confirm-dialog";
+
+import type { AgentStatus } from "@/stores/types";
+
+const runtimeMocks = vi.hoisted(() => ({
+  EventsOn: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("../../../../wailsjs/runtime/runtime", () => runtimeMocks);
+
+function installConfirmQuit() {
+  const ConfirmQuit = vi.fn(() => Promise.resolve());
+  Object.defineProperty(window, "go", {
+    configurable: true,
+    value: { app: { App: { ConfirmQuit } } },
+  });
+  return ConfirmQuit;
+}
+
+function emitQuitBlocked(count: number) {
+  const calls = runtimeMocks.EventsOn.mock.calls as unknown as Array<
+    [string, (p: { count: number }) => void]
+  >;
+  const entry = calls.find((c) => c[0] === "app:quit-blocked");
+  if (!entry) throw new Error("app:quit-blocked handler was never registered");
+  act(() => entry[1]({ count }));
+}
+
+function seedSession(
+  id: number,
+  status: AgentStatus,
+  agentName: string,
+  title: string,
+) {
+  useSessionStatusStore.getState().upsert(id, {
+    agentStatus: status,
+    needsAttention: status === "waiting",
+  });
+  useSessionMetaStore.getState().setMeta(id, {
+    agentId: id,
+    agentName,
+    agentColor: "agent-1",
+    title,
+  });
+}
+
+beforeEach(() => {
+  useSessionStatusStore.getState().__reset();
+  useSessionMetaStore.getState().__reset();
+  runtimeMocks.EventsOn.mockReset();
+  runtimeMocks.EventsOn.mockImplementation(() => vi.fn());
+});
+
+describe("QuitConfirmDialog", () => {
+  it("stays closed until a quit-blocked event arrives", () => {
+    installConfirmQuit();
+    render(<QuitConfirmDialog />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens and lists the in-progress sessions when quit is blocked", async () => {
+    installConfirmQuit();
+    seedSession(1, "running", "Backend refactor", "Drop group table");
+    seedSession(2, "waiting", "Frontend i18n", "Proofread copy");
+    render(<QuitConfirmDialog />);
+    await waitFor(() => expect(runtimeMocks.EventsOn).toHaveBeenCalled());
+
+    emitQuitBlocked(2);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Backend refactor")).toBeInTheDocument();
+    expect(screen.getByText("Frontend i18n")).toBeInTheDocument();
+  });
+
+  it("quits when the user confirms", async () => {
+    const ConfirmQuit = installConfirmQuit();
+    seedSession(1, "running", "Backend refactor", "Drop group table");
+    render(<QuitConfirmDialog />);
+    await waitFor(() => expect(runtimeMocks.EventsOn).toHaveBeenCalled());
+    emitQuitBlocked(1);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /quit anyway/i }),
+    );
+
+    expect(ConfirmQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes without quitting when the user cancels", async () => {
+    const ConfirmQuit = installConfirmQuit();
+    seedSession(1, "running", "Backend refactor", "Drop group table");
+    render(<QuitConfirmDialog />);
+    await waitFor(() => expect(runtimeMocks.EventsOn).toHaveBeenCalled());
+    emitQuitBlocked(1);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(ConfirmQuit).not.toHaveBeenCalled();
+  });
+
+  it("caps the visible list at three rows and summarizes the rest", async () => {
+    installConfirmQuit();
+    for (let i = 1; i <= 6; i++) {
+      seedSession(i, "running", `Agent ${i}`, `Task ${i}`);
+    }
+    render(<QuitConfirmDialog />);
+    await waitFor(() => expect(runtimeMocks.EventsOn).toHaveBeenCalled());
+
+    emitQuitBlocked(6);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/3 more/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/agentre/index.ts
+++ b/frontend/src/components/agentre/index.ts
@@ -16,6 +16,7 @@ export { AgentGroup, AgentPanelSection, SessionRow } from "./agent-list";
 export type { AgentSession } from "./agent-list";
 export { ChatPage } from "./chat-page";
 export { ChatStreamsHost } from "./chat-streams-host";
+export { QuitConfirmDialog } from "./quit-confirm-dialog";
 export { HooksPage } from "./hooks-page";
 export { IssuesPage } from "./issues-page";
 export { OrgChartPage } from "./org-chart-page";

--- a/frontend/src/components/agentre/quit-confirm-dialog.tsx
+++ b/frontend/src/components/agentre/quit-confirm-dialog.tsx
@@ -1,0 +1,144 @@
+// QuitConfirmDialog 是退出 App 的二次确认框。后端 OnBeforeClose 检测到还有
+// 进行中(running|waiting)的会话时拦截退出并 emit "app:quit-blocked"{count},
+// 本组件据此弹框;用户点「仍然退出」→ App.ConfirmQuit() 真正退出,点「取消」→ 关闭。
+//
+// 常驻挂载在 App 根(<ChatStreamsHost/> 旁),跨路由存活。会话列表从 session-status-store
+// (运行态)+ session-meta-store(展示名)就地派生 —— count 以后端 payload 为准。
+
+import { LogOut, TriangleAlert } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { AgentreDialog } from "@/components/agentre/app-dialog";
+import { AgentAvatar, StatusPill } from "@/components/agentre/primitives";
+import { Button } from "@/components/ui/button";
+import { useSessionMetaStore } from "@/stores/session-meta-store";
+import { useSessionStatusStore } from "@/stores/session-status-store";
+
+import { ConfirmQuit } from "../../../wailsjs/go/app/App";
+import { EventsOn } from "../../../wailsjs/runtime/runtime";
+
+import type { AgentColor } from "@/components/agentre/types";
+import type { AgentStatus } from "@/stores/types";
+
+const ACTIVE_STATUSES: AgentStatus[] = ["running", "waiting"];
+const MAX_VISIBLE = 3;
+
+type ActiveRow = {
+  sessionId: number;
+  status: AgentStatus;
+  agentName: string;
+  agentColor: string;
+  title: string;
+};
+
+export function QuitConfirmDialog() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [count, setCount] = useState(0);
+
+  const statuses = useSessionStatusStore((s) => s.statuses);
+  const metas = useSessionMetaStore((s) => s.metas);
+
+  useEffect(() => {
+    const off = EventsOn("app:quit-blocked", (payload?: { count?: number }) => {
+      setCount(payload?.count ?? 0);
+      setOpen(true);
+    });
+    return () => {
+      if (typeof off === "function") off();
+    };
+  }, []);
+
+  const active = useMemo<ActiveRow[]>(() => {
+    const rows: ActiveRow[] = [];
+    for (const [sessionId, status] of statuses) {
+      if (!ACTIVE_STATUSES.includes(status.agentStatus)) continue;
+      const meta = metas.get(sessionId);
+      rows.push({
+        sessionId,
+        status: status.agentStatus,
+        agentName: meta?.agentName ?? t("quitConfirm.unknownSession"),
+        agentColor: meta?.agentColor ?? "neutral",
+        title: meta?.title ?? "",
+      });
+    }
+    return rows;
+  }, [statuses, metas, t]);
+
+  const visible = active.slice(0, MAX_VISIBLE);
+  const overflow = active.length - visible.length;
+
+  const handleConfirm = () => {
+    setOpen(false);
+    void ConfirmQuit();
+  };
+
+  return (
+    <AgentreDialog
+      open={open}
+      onOpenChange={setOpen}
+      title={
+        <span className="flex items-center gap-2">
+          <TriangleAlert className="size-[18px] text-status-waiting" />
+          {t("quitConfirm.title")}
+        </span>
+      }
+      description={t("quitConfirm.description", { count })}
+      footer={
+        <>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {t("quitConfirm.cancel")}
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm}>
+            <LogOut />
+            {t("quitConfirm.quitAnyway")}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-2">
+        <p className="font-mono text-2xs font-semibold tracking-wide text-muted-foreground">
+          {t("quitConfirm.runningSessions", { count })}
+        </p>
+        <div className="flex max-h-[168px] flex-col gap-2 overflow-y-auto">
+          {visible.map((row) => (
+            <div
+              key={row.sessionId}
+              className="flex items-center gap-2.5 rounded-md border border-border bg-card px-3 py-2.5"
+            >
+              <AgentAvatar
+                name={row.agentName}
+                color={row.agentColor as AgentColor}
+                size="sm"
+              />
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="truncate text-sm font-semibold text-foreground">
+                  {row.agentName}
+                </span>
+                {row.title ? (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {row.title}
+                  </span>
+                ) : null}
+              </div>
+              <StatusPill
+                status={row.status}
+                label={
+                  row.status === "running"
+                    ? t("quitConfirm.statusRunning")
+                    : t("quitConfirm.statusWaiting")
+                }
+              />
+            </div>
+          ))}
+          {overflow > 0 ? (
+            <p className="px-1 py-1 text-center text-xs font-medium text-muted-foreground">
+              {t("quitConfirm.more", { count: overflow })}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </AgentreDialog>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1406,6 +1406,17 @@
     "notCancellable": "Not cancellable (codex backend)",
     "notCancellableTitle": "codex turn/steer protocol is not cancellable after send"
   },
+  "quitConfirm": {
+    "title": "Quit Agentre?",
+    "description": "{{count}} session(s) are still in progress. Quitting will interrupt their current turn, and unfinished turns will not be saved.",
+    "runningSessions": "In progress · {{count}}",
+    "statusRunning": "Running",
+    "statusWaiting": "Awaiting you",
+    "more": "{{count}} more session(s)",
+    "cancel": "Cancel",
+    "quitAnyway": "Quit anyway",
+    "unknownSession": "Untitled session"
+  },
   "remoteFs": {
     "actions": {
       "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1406,6 +1406,17 @@
     "notCancellable": "不可撤回（codex 后端）",
     "notCancellableTitle": "codex turn/steer 协议一发即不可撤"
   },
+  "quitConfirm": {
+    "title": "退出 Agentre？",
+    "description": "有 {{count}} 个会话仍在进行，退出会中断它们当前的回合，未完成的回合不会保存。",
+    "runningSessions": "进行中的会话 · {{count}}",
+    "statusRunning": "运行中",
+    "statusWaiting": "等待确认",
+    "more": "还有 {{count}} 个会话",
+    "cancel": "取消",
+    "quitAnyway": "仍然退出",
+    "unknownSession": "未命名会话"
+  },
   "remoteFs": {
     "actions": {
       "cancel": "取消",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -140,11 +140,25 @@ func (a *App) Shutdown(ctx context.Context) {
 // "app:quit-blocked" so the frontend can show a confirmation dialog.
 func (a *App) OnBeforeClose(ctx context.Context) (prevent bool) {
 	return shouldPreventQuit(ctx, a.quitConfirmed.Load(),
-		func(c context.Context) (int, error) { return chat_svc.Chat().CountActiveSessions(c) },
+		countActiveSessions,
 		func(n int) {
 			logger.Ctx(ctx).Info("app.OnBeforeClose: quit blocked by active sessions", zap.Int("count", n))
 			wailsruntime.EventsEmit(a.ctx, "app:quit-blocked", map[string]any{"count": n})
 		})
+}
+
+// countActiveSessions reports the running/waiting session count for the quit gate.
+// Wails runs OnStartup in a goroutine concurrent with the window run loop (darwin /
+// windows / linux all do), so OnBeforeClose can fire before Startup wires the chat
+// service — in that window chat_svc.Chat() is still nil and there cannot yet be any
+// session the user would lose. Treat the unregistered service as zero rather than
+// dereferencing a nil interface: fail-open, never panic on the quit path.
+func countActiveSessions(ctx context.Context) (int, error) {
+	chat := chat_svc.Chat()
+	if chat == nil {
+		return 0, nil
+	}
+	return chat.CountActiveSessions(ctx)
 }
 
 // shouldPreventQuit decides whether to block the quit and notify the user.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"agentre/internal/bootstrap"
@@ -38,6 +39,9 @@ type App struct {
 	hookPollerCancel context.CancelFunc
 	ccUsageStop      func()
 	terminalSvc      *terminal_svc.Service
+
+	// quitConfirmed 标记本次退出已被用户确认(或自动更新重启),OnBeforeClose 见到即放行。
+	quitConfirmed atomic.Bool
 
 	lastImportPath   string
 	lastImportPathMu sync.Mutex
@@ -128,6 +132,49 @@ func (a *App) Shutdown(ctx context.Context) {
 		a.terminalSvc.Shutdown()
 	}
 	logger.Ctx(ctx).Info("app shutdown")
+}
+
+// OnBeforeClose is wired to wails OnBeforeClose; it fires on every quit path
+// (macOS cmd+Q / menu, Windows close button / Alt+F4, programmatic Quit).
+// Returning true prevents the quit. If active sessions exist it emits
+// "app:quit-blocked" so the frontend can show a confirmation dialog.
+func (a *App) OnBeforeClose(ctx context.Context) (prevent bool) {
+	return shouldPreventQuit(ctx, a.quitConfirmed.Load(),
+		func(c context.Context) (int, error) { return chat_svc.Chat().CountActiveSessions(c) },
+		func(n int) {
+			logger.Ctx(ctx).Info("app.OnBeforeClose: quit blocked by active sessions", zap.Int("count", n))
+			wailsruntime.EventsEmit(a.ctx, "app:quit-blocked", map[string]any{"count": n})
+		})
+}
+
+// shouldPreventQuit decides whether to block the quit and notify the user.
+//   - confirmed (user pressed "quit anyway", or auto-update restart) → allow
+//   - count errors or is 0 → allow (fail-open: a count failure must never trap
+//     the user in an app they cannot quit)
+//   - count > 0 → emit the count and prevent
+func shouldPreventQuit(ctx context.Context, confirmed bool,
+	count func(context.Context) (int, error), emit func(n int)) bool {
+	if confirmed {
+		return false
+	}
+	n, err := count(ctx)
+	if err != nil {
+		logger.Ctx(ctx).Warn("app.shouldPreventQuit: count active sessions", zap.Error(err))
+		return false
+	}
+	if n == 0 {
+		return false
+	}
+	emit(n)
+	return true
+}
+
+// ConfirmQuit is called from the frontend when the user confirms quitting with
+// active sessions. It marks the quit as confirmed and triggers the real quit,
+// which re-enters OnBeforeClose and is allowed through.
+func (a *App) ConfirmQuit() {
+	a.quitConfirmed.Store(true)
+	wailsruntime.Quit(a.ctx)
 }
 
 // registerChatService wires the chat service singleton with a real wails-runtime

--- a/internal/app/app_quit_test.go
+++ b/internal/app/app_quit_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestShouldPreventQuit(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("confirmed quit is allowed without counting or emitting", func(t *testing.T) {
+		countCalls, emitCalls := 0, 0
+		prevent := shouldPreventQuit(ctx, true,
+			func(context.Context) (int, error) { countCalls++; return 3, nil },
+			func(int) { emitCalls++ })
+		if prevent {
+			t.Fatal("confirmed quit must be allowed (prevent=false)")
+		}
+		if countCalls != 0 {
+			t.Fatalf("count called %d times, want 0 (short-circuit on confirmed)", countCalls)
+		}
+		if emitCalls != 0 {
+			t.Fatalf("emit called %d times, want 0", emitCalls)
+		}
+	})
+
+	t.Run("no active sessions is allowed without emitting", func(t *testing.T) {
+		emitCalls := 0
+		prevent := shouldPreventQuit(ctx, false,
+			func(context.Context) (int, error) { return 0, nil },
+			func(int) { emitCalls++ })
+		if prevent {
+			t.Fatal("zero active sessions must be allowed (prevent=false)")
+		}
+		if emitCalls != 0 {
+			t.Fatalf("emit called %d times, want 0", emitCalls)
+		}
+	})
+
+	t.Run("active sessions are prevented and emit the count", func(t *testing.T) {
+		emitCalls, emitted := 0, 0
+		prevent := shouldPreventQuit(ctx, false,
+			func(context.Context) (int, error) { return 2, nil },
+			func(n int) { emitCalls++; emitted = n })
+		if !prevent {
+			t.Fatal("active sessions must prevent quit (prevent=true)")
+		}
+		if emitCalls != 1 {
+			t.Fatalf("emit called %d times, want 1", emitCalls)
+		}
+		if emitted != 2 {
+			t.Fatalf("emitted count = %d, want 2", emitted)
+		}
+	})
+
+	t.Run("count error fails open (allow) without emitting", func(t *testing.T) {
+		emitCalls := 0
+		prevent := shouldPreventQuit(ctx, false,
+			func(context.Context) (int, error) { return 0, errors.New("db down") },
+			func(int) { emitCalls++ })
+		if prevent {
+			t.Fatal("count error must fail open (prevent=false) so the user is never trapped")
+		}
+		if emitCalls != 0 {
+			t.Fatalf("emit called %d times, want 0", emitCalls)
+		}
+	})
+}

--- a/internal/app/app_quit_test.go
+++ b/internal/app/app_quit_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"agentre/internal/service/chat_svc"
 )
 
 func TestShouldPreventQuit(t *testing.T) {
@@ -66,4 +68,21 @@ func TestShouldPreventQuit(t *testing.T) {
 			t.Fatalf("emit called %d times, want 0", emitCalls)
 		}
 	})
+}
+
+// TestOnBeforeClose_NilChatServiceFailsOpen guards the race where the user quits
+// before Startup finishes wiring the chat service. Wails runs OnStartup in a
+// goroutine concurrent with the window run loop (darwin/windows/linux all do), so
+// cmd+Q / close button can fire OnBeforeClose while chat_svc.Chat() is still nil.
+// That must fail open (allow quit), never panic on a nil-interface dereference.
+func TestOnBeforeClose_NilChatServiceFailsOpen(t *testing.T) {
+	prev := chat_svc.Chat()
+	t.Cleanup(func() { chat_svc.RegisterChat(prev) })
+	chat_svc.RegisterChat(nil) // simulate the pre-registration window
+
+	a := NewApp()
+	// quitConfirmed defaults to false → OnBeforeClose has to count active sessions.
+	if prevent := a.OnBeforeClose(context.Background()); prevent {
+		t.Fatal("early quit before chat service registration must fail open (prevent=false)")
+	}
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -122,6 +122,10 @@ func (a *App) RestartApp() error {
 		}
 	}
 
+	// 重启已拉起新进程,旧进程必须无条件退出:标记已确认,绕过活跃会话二次确认,
+	// 否则 OnBeforeClose 拦住旧进程、新进程撞单实例锁 → 更新静默失败。
+	a.quitConfirmed.Store(true)
+
 	go func() {
 		// 留一拍时间让 wails Quit 走完 OnShutdown。
 		time.Sleep(500 * time.Millisecond)

--- a/internal/repository/chat_repo/mock_chat_repo/mock_session.go
+++ b/internal/repository/chat_repo/mock_chat_repo/mock_session.go
@@ -41,6 +41,21 @@ func (m *MockSessionRepo) EXPECT() *MockSessionRepoMockRecorder {
 	return m.recorder
 }
 
+// CountActive mocks base method.
+func (m *MockSessionRepo) CountActive(ctx context.Context, agentStatuses []string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountActive", ctx, agentStatuses)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountActive indicates an expected call of CountActive.
+func (mr *MockSessionRepoMockRecorder) CountActive(ctx, agentStatuses any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActive", reflect.TypeOf((*MockSessionRepo)(nil).CountActive), ctx, agentStatuses)
+}
+
 // CountActiveByProject mocks base method.
 func (m *MockSessionRepo) CountActiveByProject(ctx context.Context, projectID int64, agentStatuses []string) (int64, error) {
 	m.ctrl.T.Helper()
@@ -175,21 +190,6 @@ func (mr *MockSessionRepoMockRecorder) ListByAgentPaged(ctx, agentID, offset, li
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAgentPaged", reflect.TypeOf((*MockSessionRepo)(nil).ListByAgentPaged), ctx, agentID, offset, limit)
 }
 
-// ListIDsByAgents mocks base method.
-func (m *MockSessionRepo) ListIDsByAgents(ctx context.Context, agentIDs []int64) (map[int64][]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListIDsByAgents", ctx, agentIDs)
-	ret0, _ := ret[0].(map[int64][]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListIDsByAgents indicates an expected call of ListIDsByAgents.
-func (mr *MockSessionRepoMockRecorder) ListIDsByAgents(ctx, agentIDs any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIDsByAgents", reflect.TypeOf((*MockSessionRepo)(nil).ListIDsByAgents), ctx, agentIDs)
-}
-
 // ListByProject mocks base method.
 func (m *MockSessionRepo) ListByProject(ctx context.Context, projectID int64) ([]*chat_entity.Session, error) {
 	m.ctrl.T.Helper()
@@ -203,6 +203,21 @@ func (m *MockSessionRepo) ListByProject(ctx context.Context, projectID int64) ([
 func (mr *MockSessionRepoMockRecorder) ListByProject(ctx, projectID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByProject", reflect.TypeOf((*MockSessionRepo)(nil).ListByProject), ctx, projectID)
+}
+
+// ListIDsByAgents mocks base method.
+func (m *MockSessionRepo) ListIDsByAgents(ctx context.Context, agentIDs []int64) (map[int64][]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListIDsByAgents", ctx, agentIDs)
+	ret0, _ := ret[0].(map[int64][]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListIDsByAgents indicates an expected call of ListIDsByAgents.
+func (mr *MockSessionRepoMockRecorder) ListIDsByAgents(ctx, agentIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIDsByAgents", reflect.TypeOf((*MockSessionRepo)(nil).ListIDsByAgents), ctx, agentIDs)
 }
 
 // MarkRead mocks base method.

--- a/internal/repository/chat_repo/session.go
+++ b/internal/repository/chat_repo/session.go
@@ -26,6 +26,7 @@ type SessionRepo interface {
 	CountByAgents(ctx context.Context, agentIDs []int64) (map[int64]int64, error)
 	CountRunningByAgents(ctx context.Context, agentIDs []int64) (map[int64]int, error)
 	CountActiveByProject(ctx context.Context, projectID int64, agentStatuses []string) (int64, error)
+	CountActive(ctx context.Context, agentStatuses []string) (int64, error)
 	Create(ctx context.Context, s *chat_entity.Session) error
 	Update(ctx context.Context, s *chat_entity.Session) error
 	UpdatePermissionMode(ctx context.Context, sessionID int64, mode string) error
@@ -224,6 +225,17 @@ func (r *sessionRepo) CountActiveByProject(ctx context.Context, projectID int64,
 	}
 	var n int64
 	err := q.Count(&n).Error
+	return n, err
+}
+
+// CountActive 统计 status=ACTIVE 且 agent_status 在指定集合内的会话总数(跨所有 agent/项目)。
+// 退出二次确认用它判断是否还有进行中的会话:agentStatuses 传 {"running","waiting"}。
+func (r *sessionRepo) CountActive(ctx context.Context, agentStatuses []string) (int64, error) {
+	var n int64
+	err := db.Ctx(ctx).
+		Model(&chat_entity.Session{}).
+		Where("status = ? AND agent_status IN ?", consts.ACTIVE, agentStatuses).
+		Count(&n).Error
 	return n, err
 }
 

--- a/internal/repository/chat_repo/session_test.go
+++ b/internal/repository/chat_repo/session_test.go
@@ -253,6 +253,18 @@ func TestSessionRepo_CountActiveByProject(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionRepo_CountActive(t *testing.T) {
+	ctx, _, mock := testutils.Database(t)
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `chat_sessions`").
+		WithArgs(consts.ACTIVE, "running", "waiting").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(4))
+
+	n, err := chat_repo.NewSession().CountActive(ctx, []string{"running", "waiting"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), n)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSessionRepo_MarkRead(t *testing.T) {
 	t.Run("ts > current last_read_at 时正常 UPDATE 1 行", func(t *testing.T) {
 		ctx, _, mock := testutils.Database(t)

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -94,6 +94,7 @@ type ChatSvc interface {
 	AnswerUserQuestion(ctx context.Context, req *AnswerUserQuestionRequest) (*AnswerUserQuestionResponse, error)
 	AnswerToolPermission(ctx context.Context, req *AnswerToolPermissionRequest) (*AnswerToolPermissionResponse, error)
 	ResolvePlanAction(ctx context.Context, req *ResolvePlanActionRequest) (*ResolvePlanActionResponse, error)
+	CountActiveSessions(ctx context.Context) (int, error)
 }
 
 var defaultChat ChatSvc
@@ -168,6 +169,15 @@ type chatSvc struct {
 }
 
 // ── ListAgents ───────────────────────────────────────────────────────────────
+
+// CountActiveSessions 返回正在进行(running|waiting)的会话总数,供退出二次确认判断。
+func (s *chatSvc) CountActiveSessions(ctx context.Context) (int, error) {
+	n, err := chat_repo.Session().CountActive(ctx, []string{"running", "waiting"})
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
 
 func (s *chatSvc) ListAgents(ctx context.Context, _ *ListAgentsRequest) (*ListAgentsResponse, error) {
 	agents, err := agent_repo.Agent().List(ctx)

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -115,6 +115,17 @@ func setupChatTest(t *testing.T) *chatMocks {
 	return m
 }
 
+func TestCountActiveSessions(t *testing.T) {
+	m := setupChatTest(t)
+	m.session.EXPECT().
+		CountActive(gomock.Any(), []string{"running", "waiting"}).
+		Return(int64(5), nil)
+
+	n, err := m.svc.CountActiveSessions(m.ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+}
+
 func TestRegisterGatewayBeforeNewChatMakesCLIBackendsChattable(t *testing.T) {
 	chat_svc.RegisterChat(nil)
 	chat_svc.RegisterGateway(nil)

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func newWailsOptionsForDataDir(a *app.App, assets fs.FS, goos, dataDir string) *
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        a.Startup,
 		OnShutdown:       a.Shutdown,
+		OnBeforeClose:    a.OnBeforeClose,
 		Mac: &mac.Options{
 			TitleBar: mac.TitleBarHiddenInset(),
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,14 @@ func TestNewWailsOptionsConfiguresSingleInstanceLock(t *testing.T) {
 	}
 }
 
+func TestNewWailsOptionsWiresOnBeforeClose(t *testing.T) {
+	var assets fs.FS = fstest.MapFS{}
+	opts := newWailsOptionsForDataDir(app.NewApp(), assets, "darwin", "/tmp/agentre-test")
+	if opts.OnBeforeClose == nil {
+		t.Fatal("OnBeforeClose must be wired so active-session quit confirmation can intercept the quit")
+	}
+}
+
 func TestNewWailsOptionsOmitsSingleInstanceLockInWailsDev(t *testing.T) {
 	t.Run("Given Wails dev sets devserver When options are built Then single instance lock is disabled", func(t *testing.T) {
 		t.Setenv("devserver", "localhost:34115")


### PR DESCRIPTION
## 背景

cmd+Q / 关闭按钮 / Alt+F4 退出 App 时,若有正在进行的会话会直接杀掉常驻 CLI 子进程、中断当前回合且无任何提示。本 PR 在退出前若存在活跃会话弹一个**应用内二次确认框**,跨平台统一处理。

设计稿:`docs/superpowers/specs/2026-06-04-quit-confirmation-design.md`

## 改动

**后端**
- `chat_repo.CountActive(statuses)`:全局统计 `status=ACTIVE` 且 `agent_status IN (...)` 的会话数
- `chat_svc.CountActiveSessions`:封装 `[running, waiting]` 计数
- `app.OnBeforeClose`:Wails v2 全平台唯一退出拦截点。有活跃会话 → emit `app:quit-blocked{count}` 并返回 `true` 阻止退出。决策抽成纯函数 `shouldPreventQuit`(已确认 / 计数为 0 / 计数出错 均放行 —— **fail-open**,计数失败绝不困住用户)
- `app.ConfirmQuit`:前端确认后置 `quitConfirmed` 并真正 `wailsruntime.Quit`
- `main.go` 接 `OnBeforeClose`;`update.go` 自动更新重启预置 `quitConfirmed` 绕过确认(否则旧进程被拦 + 新进程撞单实例锁 → 更新静默失败)

**前端**
- `QuitConfirmDialog`:订阅 `app:quit-blocked`,复用现成 `AgentreDialog` + `StatusPill`(未新增 shadcn `alert-dialog`)。会话列表从 `session-status-store` + `session-meta-store` 派生,可见上限 3 行 + 「还有 N 个会话」,header 计数以后端为准。`仍然退出` → `ConfirmQuit()`,`取消` / Esc / 点遮罩 → 关闭
- 常驻挂载在 App 根(`ChatStreamsHost` 旁),跨路由存活;`quitConfirm` i18n(zh-CN / en)

## 关键决策

- 活跃口径 = `running` + `waiting`(与启动时 `ResetStaleActiveSessions` 一致)
- 计数失败 fail-open;列表前端派生、count 后端权威
- 溢出:可见 3 行 + 汇总行,header 显示真实总数

## 测试(Red → Green)

- repo `TestSessionRepo_CountActive`(sqlmock)
- svc `TestCountActiveSessions`(repo mock)
- app `TestShouldPreventQuit`(注入 counter/emitter,4 例:confirmed / 0 / >0 / err)
- main `TestNewWailsOptionsWiresOnBeforeClose`
- 前端 `quit-confirm-dialog.test.tsx`(5 例:不弹 / 弹+列会话 / 确认调 ConfirmQuit / 取消不退 / 溢出汇总)

后端 `go test -race` + golangci-lint 0 issues;前端 vitest 1084 全过、`tsc -b` + eslint 干净。

## 待手动验证

真机 end-to-end(`make dev` 跑会话后按 cmd+Q)未自动化 —— 建议合并前在 macOS / Windows 各点一次确认弹窗行为。