### PR TITLE
✨ 后台任务面板:会话头部胶囊 + 只读弹层(运行中后台任务可视化)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-background-tasks-panel.md
+++ b/docs/superpowers/plans/2026-06-05-background-tasks-panel.md
@@ -1,0 +1,694 @@
+# 后台任务面板(会话头部胶囊 + 弹层)实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 会话头部一个胶囊显示运行中后台任务数,点开是只读弹层列出本会话的 `local_bash` + `local_agent` 任务(类型图标 / 描述 / 耗时 / 状态)。
+
+**Architecture:** 前端从既有 `subagent_state` 块 derive(每个 CLI task 启动时已落一个,带 `parent_tool_call_id`=task 的 tool_use_id);后端给块补 `kind`+`description`,并经既有自主续轮事件把后台 bash 的完成信号回流(顺带修内联块永远 `running`)。复用 #11 的自主续轮机器,无新能力/前向接口。
+
+**Tech Stack:** Go 1.26(pkg/claudecode、agentruntime、chat_svc/cago)、React 19 + TS + Vitest、Wails 绑定、react-i18next。
+
+**Deviations from spec(实现期发现,已据真实代码校正):**
+1. **无 `kind`/`task_type` 字段** —— 全链路新增(`rawFrame`→`SubagentMeta`→`SubagentInfo`→`SubagentStateBlock`+`ChatBlockSubagent`)。
+2. **`subagent_state` 块只能在本轮 accumulator 内改**(`turn.Mutate` 走 per-turn `mutateIndex`)。后台 bash 在**之后的自主轮**才完成,要翻它(上一条消息里的块)必须走**新的会话级 repo 写**(spec 选项 a 的具体机制),不能用 accumulator。
+3. **前端无 `subagent_state` 卡片**,subagent 元数据是 merge 到父 `tool_use` block 的 `.subagent` 上。本面板**直接 derive `type:"subagent_state"` 的 ChatBlock**(messages + liveBlocks),与 agent-spawn 卡解耦。
+4. **`Summary`/退出码 v1 不做**(状态 `running`/`completed`/`failed` 足够;退出码列 follow-up)。
+
+**前置(已完成,worktree 内已提交):** `isNonTurnFrame` 认 `task_started/task_updated/task_progress`(commit `76337f8`)—— 本特性运行期依赖它(后台 bash 完成才会触发自主轮回流完成信号)。
+
+---
+
+## 文件结构(创建/修改)
+
+**后端:**
+- `pkg/claudecode/stream.go` — `rawFrame` 加 `TaskType`。
+- `pkg/claudecode/session.go` — `parseSystemTask` 填 `TaskType`;`currentTurn` 填 `AutoTurn.CompletedTask`。
+- `pkg/claudecode/event.go` — `SubagentMeta` 加 `TaskType`。
+- `pkg/claudecode/autoturn.go` — `AutoTurn` 加 `CompletedTask *CompletedBackgroundTask` + 新类型。
+- `internal/pkg/agentruntime/runner.go` — `SubagentInfo` 加 `Kind`;`AutonomousTurn` 加 `CompletedTask` + 新类型。
+- `internal/pkg/agentruntime/runtimes/claudecode/translator.go` — `subagentInfoFromMeta` 填 `Kind`。
+- `internal/pkg/agentruntime/runtimes/claudecode/autoturn.go` — bridge 透传 `CompletedTask`。
+- `internal/service/chat_svc/blocks/subagent_state.go` — `SubagentStateBlock` 加 `Kind`+`Description`。
+- `internal/service/chat_svc/handlers/subagent.go` — `SubagentStartedHandler` 填 `Kind`+`Description`。
+- `internal/service/chat_svc/types.go` — `ChatBlockSubagent` 加 `Kind`;`ChatStreamEvent` 加 `CompletedTask`。
+- `internal/service/chat_svc/view/project.go` — 投影时把块的 `Kind`/`Description` 带进 `ChatBlockSubagent`(执行期确认 view 包类型)。
+- `internal/service/chat_svc/autonomous_turn.go` — `driveAutonomousTurn` 收到 `CompletedTask` → emit + repo 翻转。
+- `internal/repository/chat_repo/message.go`(或同域)— 新 `FlipSubagentStatus` 定向更新。
+- `internal/service/chat_svc/emitter.go` — 复用 `AutonomousStreamName`。
+
+**前端:**
+- `frontend/src/components/agentre/background-tasks/derive.ts` — `deriveBackgroundTasks` 纯函数。
+- `frontend/src/components/agentre/background-tasks/types.ts` — `BackgroundTask` 类型。
+- `frontend/src/components/agentre/background-tasks/background-tasks-chip.tsx` — 胶囊。
+- `frontend/src/components/agentre/background-tasks/background-tasks-popover.tsx` — 弹层。
+- `frontend/src/components/agentre/chat-panel.tsx` — 挂胶囊 + `onAutonomousEvent` 处理 `completedTask`。
+- `frontend/src/stores/chat-streams-store.ts` — 一个 `markSubagentDone(sessionId, toolUseId)` action(可选,live 翻转)。
+- `frontend/src/i18n/locales/{zh-CN,en}/common.json` — `chatPanel.backgroundTasks.*`。
+- 各 `*.test.ts(x)`。
+
+---
+
+## Task 1: pkg/claudecode —— `task_type` 解析 + 自主轮携带完成任务
+
+**Files:**
+- Modify: `pkg/claudecode/stream.go`(rawFrame)
+- Modify: `pkg/claudecode/event.go`(SubagentMeta)
+- Modify: `pkg/claudecode/session.go`(parseSystemTask、currentTurn)
+- Modify: `pkg/claudecode/autoturn.go`(AutoTurn + 新类型)
+- Test: `pkg/claudecode/session_test.go`
+
+- [ ] **Step 1: 写失败测试 —— task_type 解析进 SubagentMeta**
+
+在 `pkg/claudecode/session_test.go` 末尾追加:
+
+```go
+func TestParseSystemTask_CarriesTaskType(t *testing.T) {
+	f := rawFrame{
+		Type: "system", Subtype: "task_started",
+		TaskID: "bg1", ToolUseID: "tu1", Description: "Sleep for 5 seconds",
+		TaskType: "local_bash",
+	}
+	ev, ok := parseSystemTask(f, "sx")
+	require.True(t, ok)
+	require.NotNil(t, ev.Tool)
+	require.NotNil(t, ev.Tool.Subagent)
+	assert.Equal(t, "local_bash", ev.Tool.Subagent.TaskType)
+	assert.Equal(t, "Sleep for 5 seconds", ev.Tool.Subagent.TaskDescription)
+}
+```
+
+- [ ] **Step 2: 跑测试看它编译失败**
+
+Run: `GOWORK=off go test -run TestParseSystemTask_CarriesTaskType ./pkg/claudecode/`
+Expected: FAIL —— `f.TaskType undefined` / `meta.TaskType undefined`。
+
+- [ ] **Step 3: 加字段 + 填充**
+
+`pkg/claudecode/stream.go` 的 `rawFrame` 里,`SubagentType` 附近加:
+
+```go
+	// TaskType 区分 task 帧来源:"local_bash"(run_in_background bash)/ "local_agent"(subagent)。
+	TaskType string `json:"task_type,omitempty"`
+```
+
+`pkg/claudecode/event.go` 的 `SubagentMeta` 加字段(放在 `SubagentType` 后):
+
+```go
+	TaskType        string // ← task_started/progress/notification.task_type（local_bash / local_agent）
+```
+
+`pkg/claudecode/session.go` 的 `parseSystemTask` 里 `meta := &SubagentMeta{...}` 加一行:
+
+```go
+		TaskType:        f.TaskType,
+```
+
+- [ ] **Step 4: 跑测试转绿**
+
+Run: `GOWORK=off go test -run TestParseSystemTask_CarriesTaskType ./pkg/claudecode/`
+Expected: PASS
+
+- [ ] **Step 5: 写失败测试 —— 自主轮携带 CompletedTask**
+
+`AutoTurn` 当前只有 `Events/SessionID/Trigger`。新增断言后台型 `task_notification` 起的自主轮带完成任务信息。在 `session_test.go` 追加:
+
+```go
+func TestBackgroundTaskAutonomousTurn_CarriesCompletedTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := New(WithBinary("fake"), pipeSpawner(t, fakeBackgroundTask))
+	sess, err := c.OpenSession(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close(context.Background()) }()
+
+	ch1, err := sess.Turn(ctx, "alpha")
+	require.NoError(t, err)
+	_ = drainText(t, ch1)
+
+	var at *AutoTurn
+	select {
+	case at = <-sess.AutonomousTurns():
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected autonomous turn")
+	}
+	require.NotNil(t, at.CompletedTask)
+	assert.Equal(t, "tu1", at.CompletedTask.ToolUseID)
+	assert.Equal(t, "completed", at.CompletedTask.Status)
+}
+```
+
+(`fakeBackgroundTask` 的 task_notification 帧已带 `tool_use_id":"tu1","status":"completed"` —— 见 session_test.go 现有 fixture。)
+
+- [ ] **Step 6: 跑测试看失败**
+
+Run: `GOWORK=off go test -run TestBackgroundTaskAutonomousTurn_CarriesCompletedTask ./pkg/claudecode/`
+Expected: FAIL —— `at.CompletedTask undefined`。
+
+- [ ] **Step 7: 加 CompletedBackgroundTask + AutoTurn 字段 + 填充**
+
+`pkg/claudecode/autoturn.go`,`AutoTurn` 改为:
+
+```go
+type AutoTurn struct {
+	Events    <-chan Event
+	SessionID string
+	Trigger   string // 当前固定 "background_task"
+	// CompletedTask 仅 background_task 触发的自主轮带:那个完成的后台任务的身份,
+	// 供上层把对应 subagent_state 翻成 completed/failed。
+	CompletedTask *CompletedBackgroundTask
+}
+
+// CompletedBackgroundTask 是触发本自主轮的后台命令完成信息(从 task_notification 帧抽出)。
+type CompletedBackgroundTask struct {
+	ToolUseID string
+	TaskID    string
+	Status    string // "completed" / "failed"(空 → 视为 completed)
+}
+```
+
+`pkg/claudecode/session.go` 的 `currentTurn` 里,`isBackgroundTaskNotification(f)` 分支改为携带完成信息:
+
+```go
+	if isBackgroundTaskNotification(f) {
+		at := newActiveTurn(true)
+		s.active = at
+		s.sinkMu.Unlock()
+		s.autoCh <- &AutoTurn{
+			Events:    at.ch,
+			SessionID: s.sessionID,
+			Trigger:   triggerBackgroundTask,
+			CompletedTask: &CompletedBackgroundTask{
+				ToolUseID: f.ToolUseID,
+				TaskID:    f.TaskID,
+				Status:    f.Status,
+			},
+		}
+		return nil
+	}
+```
+
+- [ ] **Step 8: 跑全包 -race 转绿**
+
+Run: `GOWORK=off go test -race ./pkg/claudecode/`
+Expected: ok(含既有 keystone + 两条新测试)。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/claudecode/
+git commit -m "✨ claudecode: task_type 解析 + 自主轮携带完成后台任务身份"
+```
+
+---
+
+## Task 2: agentruntime —— SubagentInfo.Kind + AutonomousTurn.CompletedTask + 翻译/桥接/wire
+
+**Files:**
+- Modify: `internal/pkg/agentruntime/runner.go`(SubagentInfo、AutonomousTurn + 新类型)
+- Modify: `internal/pkg/agentruntime/runtimes/claudecode/translator.go`(subagentInfoFromMeta)
+- Modify: `internal/pkg/agentruntime/runtimes/claudecode/autoturn.go`(bridge)
+- Test: `internal/pkg/agentruntime/runtimes/claudecode/translator_test.go`、`autoturn_test.go`
+
+- [ ] **Step 1: 写失败测试 —— Kind 透传**
+
+在 `internal/pkg/agentruntime/runtimes/claudecode/translator_test.go` 追加(若文件不存在则建,包名对齐既有测试):
+
+```go
+func TestSubagentInfoFromMeta_CarriesKind(t *testing.T) {
+	info := subagentInfoFromMeta(&claudecode.SubagentMeta{TaskType: "local_bash", TaskDescription: "sleep 5"})
+	assert.Equal(t, "local_bash", info.Kind)
+	assert.Equal(t, "sleep 5", info.TaskDescription)
+}
+```
+
+- [ ] **Step 2: 跑看失败**
+
+Run: `GOWORK=off go test -run TestSubagentInfoFromMeta_CarriesKind ./internal/pkg/agentruntime/runtimes/claudecode/`
+Expected: FAIL —— `info.Kind undefined`。
+
+- [ ] **Step 3: 加 SubagentInfo.Kind + 填充**
+
+`internal/pkg/agentruntime/runner.go` 的 `SubagentInfo`,在 `SubagentType` 后加:
+
+```go
+	Kind            string // local_bash | local_agent（区分后台 bash 与 subagent；空=未知/旧帧）
+```
+
+`internal/pkg/agentruntime/runtimes/claudecode/translator.go` 的 `subagentInfoFromMeta` return 里加:
+
+```go
+		Kind:            m.TaskType,
+```
+
+- [ ] **Step 4: 跑转绿**
+
+Run: `GOWORK=off go test -run TestSubagentInfoFromMeta_CarriesKind ./internal/pkg/agentruntime/runtimes/claudecode/`
+Expected: PASS
+
+- [ ] **Step 5: 写失败测试 —— 桥接透传 CompletedTask**
+
+`autoturn_test.go`(claudecode runtime 桥接测试,对齐既有命名)追加一条:用 fake session 吐一个带 `CompletedTask` 的 `claudecode.AutoTurn`,断言 `runtime.AutonomousTurns(sessionID)` 吐出的 `agentruntime.AutonomousTurn.CompletedTask` 透传。参照既有桥接测试构造 fake handle/cache;关键断言:
+
+```go
+	got := <-runtime.AutonomousTurns(sessionID)
+	require.NotNil(t, got.CompletedTask)
+	assert.Equal(t, "tu1", got.CompletedTask.ToolUseID)
+	assert.Equal(t, "completed", got.CompletedTask.Status)
+```
+
+- [ ] **Step 6: 跑看失败**
+
+Run: `GOWORK=off go test -run CompletedTask ./internal/pkg/agentruntime/runtimes/claudecode/`
+Expected: FAIL —— `agentruntime.AutonomousTurn.CompletedTask undefined` / `got.CompletedTask undefined`。
+
+- [ ] **Step 7: 加 agentruntime.AutonomousTurn.CompletedTask + 桥接填充**
+
+`internal/pkg/agentruntime/runner.go`,`AutonomousTurn` 改为:
+
+```go
+type AutonomousTurn struct {
+	Events  <-chan Event
+	Result  *RunResult
+	Trigger string // "background_task"
+	// CompletedTask 镜像 claudecode.CompletedBackgroundTask:触发本自主轮的后台命令身份。
+	CompletedTask *CompletedBackgroundTask
+}
+
+// CompletedBackgroundTask 见 AutonomousTurn.CompletedTask。
+type CompletedBackgroundTask struct {
+	ToolUseID string
+	TaskID    string
+	Status    string
+}
+```
+
+`internal/pkg/agentruntime/runtimes/claudecode/autoturn.go` 的 bridge,把构造 `agentruntime.AutonomousTurn{...}` 处加上从 `at.CompletedTask` 映射:
+
+```go
+			var completed *agentruntime.CompletedBackgroundTask
+			if at.CompletedTask != nil {
+				completed = &agentruntime.CompletedBackgroundTask{
+					ToolUseID: at.CompletedTask.ToolUseID,
+					TaskID:    at.CompletedTask.TaskID,
+					Status:    at.CompletedTask.Status,
+				}
+			}
+			out <- agentruntime.AutonomousTurn{Events: evOut, Result: result, Trigger: at.Trigger, CompletedTask: completed}
+```
+
+- [ ] **Step 8: wire 透传(SubagentInfo.Kind)** —— `SubagentInfo` 无 JSON tag,内部 wire 走 Go 字段名,新增 `Kind` 自动随 `SubagentStarted/Done` 的 `info` 编解码。补一条 round-trip 断言到 `internal/pkg/agentruntime/event_wire_test.go`(对齐既有):
+
+```go
+func TestSubagentStarted_KindRoundTrip(t *testing.T) {
+	ev := SubagentStarted{ToolCallID: "tu1", Info: SubagentInfo{Kind: "local_bash"}}
+	b, err := json.Marshal(ev)
+	require.NoError(t, err)
+	got, err := decodeEvent(b) // 对齐既有解码入口名
+	require.NoError(t, err)
+	assert.Equal(t, "local_bash", got.(SubagentStarted).Info.Kind)
+}
+```
+
+(若解码入口名不同,执行期 grep `func.*decodeEvent\|UnmarshalEvent` 对齐。)
+
+- [ ] **Step 9: 跑相关包 -race 转绿**
+
+Run: `GOWORK=off go test -race ./internal/pkg/agentruntime/...`
+Expected: ok
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/pkg/agentruntime/
+git commit -m "✨ agentruntime: SubagentInfo.Kind + AutonomousTurn 携带完成后台任务"
+```
+
+---
+
+## Task 3: chat_svc —— 块补 kind/description + 投影 + 自主轮回流完成 + 定向翻转
+
+**Files:**
+- Modify: `internal/service/chat_svc/blocks/subagent_state.go`
+- Modify: `internal/service/chat_svc/handlers/subagent.go`
+- Modify: `internal/service/chat_svc/types.go`(ChatBlockSubagent、ChatStreamEvent)
+- Modify: `internal/service/chat_svc/view/project.go`
+- Modify: `internal/service/chat_svc/autonomous_turn.go`
+- Modify: `internal/repository/chat_repo/message.go`(+ 接口/mock)
+- Test: 对应 `*_test.go`
+
+- [ ] **Step 1: 写失败测试 —— SubagentStarted 落 kind/description**
+
+`internal/service/chat_svc/handlers/subagent_test.go`(对齐既有 handler 测试)追加:
+
+```go
+func TestSubagentStarted_PersistsKindAndDescription(t *testing.T) {
+	acc := turn.New()
+	h := SubagentStartedHandler{}
+	ev := agentruntime.SubagentStarted{ToolCallID: "tu1", Info: agentruntime.SubagentInfo{
+		Kind: "local_bash", TaskDescription: "sleep 20",
+	}}
+	require.NoError(t, h.Apply(context.Background(), ev, acc, nil, nil, &turn.TurnContext{}))
+	blks := acc.Finalize()
+	require.Len(t, blks, 1)
+	sb := blks[0].(*blocks.SubagentStateBlock)
+	assert.Equal(t, "local_bash", sb.Kind)
+	assert.Equal(t, "sleep 20", sb.Description)
+	assert.Equal(t, "running", sb.Status)
+}
+```
+
+- [ ] **Step 2: 跑看失败**
+
+Run: `GOWORK=off go test -run TestSubagentStarted_PersistsKindAndDescription ./internal/service/chat_svc/handlers/`
+Expected: FAIL —— `sb.Kind undefined`。
+
+- [ ] **Step 3: 块加字段 + handler 填充**
+
+`internal/service/chat_svc/blocks/subagent_state.go` 的 `SubagentStateBlock` 加(放在 `TaskID` 后):
+
+```go
+	Kind        string `json:"kind,omitempty"`        // local_bash | local_agent
+	Description string `json:"description,omitempty"`  // 任务名（task_started.description）
+```
+
+`internal/service/chat_svc/handlers/subagent.go` 的 `SubagentStartedHandler.Apply` 里建块处改为:
+
+```go
+	blk := &blocks.SubagentStateBlock{
+		ParentToolCallID: r.ToolCallID,
+		Status:           "running",
+		Kind:             r.Info.Kind,
+		Description:      r.Info.TaskDescription,
+	}
+```
+
+- [ ] **Step 4: 跑转绿**
+
+Run: `GOWORK=off go test -run TestSubagentStarted_PersistsKindAndDescription ./internal/service/chat_svc/handlers/`
+Expected: PASS
+
+- [ ] **Step 5: 投影带 kind(view/project.go)**
+
+执行期先 `grep -n 'type ChatBlock\|ChatBlockSubagent\|Subagent ' internal/service/chat_svc/view/project.go` 确认 view 包用的是哪个 `ChatBlock`/`Subagent` 类型(同包 types 还是 chat_svc 的)。给该投影 struct(`ChatBlockSubagent` 或 view 内镜像)加 `Kind string json:"kind,omitempty"`,并在 `subagent_state` case 把块的 `Kind`/`Description` 带进去。`internal/service/chat_svc/types.go` 的 `ChatBlockSubagent` 加:
+
+```go
+	Kind string `json:"kind,omitempty"` // local_bash | local_agent
+```
+
+`project.go` 的 `subagent_state` case 改为显式构造 Subagent 镜像(把块字段映射进去),例如:
+
+```go
+		case *blocks.SubagentStateBlock:
+			out = append(out, ChatBlock{Type: "subagent_state", Subagent: subagentMirror(t)})
+```
+
+并加 helper `subagentMirror(*blocks.SubagentStateBlock) *ChatBlockSubagent`(映射 TaskID/Kind/Description/Status/ToolUses/TotalTokens/DurationMs/LastToolName + `ParentToolCallID` 经 ChatBlock.ParentToolCallID 透出)。**注意**:前端 derive 要靠 `ChatBlock.ParentToolCallID`(=task 的 tool_use_id)+ `type:"subagent_state"`,投影务必把 `ParentToolCallID` 也填到 `ChatBlock.ParentToolCallID`。
+
+- [ ] **Step 6: 写失败测试 —— driveAutonomousTurn 回流完成 + 翻转**
+
+`internal/service/chat_svc/autonomous_turn_test.go` 追加(用既有 mock runtime + `DriveAutonomousTurnForTest`):自主轮带 `CompletedTask{ToolUseID:"tu1",Status:"completed"}` → 断言 (a) emit 的 `StreamAutonomousStarted` 事件 `CompletedTask` 非空且 toolUseId="tu1";(b) 调用了 repo 的 `FlipSubagentStatus(sessionID,"tu1","completed")`(用 mock 断言)。
+
+```go
+	// 关键断言(节选)
+	assert.Equal(t, "tu1", emitted.CompletedTask.ToolUseID)
+	mockMsgRepo.AssertCalled(t, "FlipSubagentStatus", mock.Anything, sessionID, "tu1", "completed")
+```
+
+- [ ] **Step 7: 跑看失败**
+
+Run: `GOWORK=off go test -run AutonomousTurn ./internal/service/chat_svc/`
+Expected: FAIL —— 字段/方法未定义。
+
+- [ ] **Step 8: ChatStreamEvent.CompletedTask + repo 方法 + driveAutonomousTurn 接线**
+
+`internal/service/chat_svc/types.go` 的 `ChatStreamEvent` 加(放在 `Stream`/`Trigger` 附近):
+
+```go
+	// StreamAutonomousStarted 时,若该自主轮由后台命令完成触发,带上完成任务身份,
+	// 前端据此把对应 subagent_state(上一条消息里)即时翻成 completed/failed。
+	CompletedTask *CompletedTaskRef `json:"completedTask,omitempty"`
+```
+
+加类型(types.go):
+
+```go
+type CompletedTaskRef struct {
+	ToolUseID string `json:"toolUseId"`
+	Status    string `json:"status"` // completed | failed
+}
+```
+
+`internal/repository/chat_repo/message.go` 加方法(并同步接口定义 + `make mock` 重生成 mock):
+
+```go
+// FlipSubagentStatus 定向把本会话里 parent_tool_call_id==toolUseID 的 subagent_state
+// 块状态改成 status(后台 bash 在之后的自主轮才完成,无法走 per-turn accumulator)。
+// 找不到则静默返回 nil(任务可能已 evict / 非本会话)。
+func (r *message) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error {
+	// 实现:按 session_id 倒序拉近 N 条 assistant 消息,逐条 json 解析 blocks_json,
+	// 找到 type=="subagent_state" 且 parent_tool_call_id==toolUseID 的块,改 status 重写该条。
+	// 用 chat_repo 既有的 Find/Update;JSON 操作用 cagoblocks 反/正序列化保持一致。
+}
+```
+
+`internal/service/chat_svc/autonomous_turn.go` 的 `driveAutonomousTurn`:在 emit `StreamAutonomousStarted` 处带上 CompletedTask,并在 finalize 后做 repo 翻转:
+
+```go
+	var completedRef *CompletedTaskRef
+	if at.CompletedTask != nil && at.CompletedTask.ToolUseID != "" {
+		st := at.CompletedTask.Status
+		if st == "" {
+			st = "completed"
+		}
+		completedRef = &CompletedTaskRef{ToolUseID: at.CompletedTask.ToolUseID, Status: st}
+	}
+	s.emitter.Emit(ctx, AutonomousStreamName(sessionID), ChatStreamEvent{
+		Kind:             StreamAutonomousStarted,
+		Stream:           stream,
+		Trigger:          at.Trigger,
+		AssistantMessage: chatMessageForEvent(sess, assistantMsg),
+		CompletedTask:    completedRef,
+	})
+	// …(既有 drain/finalize 不变)…
+	// finalize 后(finalCtx 有 DB 句柄):
+	if completedRef != nil {
+		if err := chat_repo.Message().FlipSubagentStatus(finalCtx, sessionID, completedRef.ToolUseID, completedRef.Status); err != nil {
+			logger.Ctx(finalCtx).Warn("chat_svc: FlipSubagentStatus failed",
+				zap.Int64("sessionId", sessionID), zap.String("toolUseId", completedRef.ToolUseID), zap.Error(err))
+		}
+	}
+```
+
+- [ ] **Step 9: 跑 chat_svc + repo + handlers -race 转绿**
+
+Run: `GOWORK=off go test -race ./internal/service/chat_svc/... ./internal/repository/chat_repo/...`
+Expected: ok(repo 测试用 sqlmock)。
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/service/chat_svc/ internal/repository/chat_repo/
+git commit -m "✨ chat_svc: subagent_state 补 kind/description + 自主轮回流后台完成并定向翻转"
+```
+
+---
+
+## Task 4: 前端 —— derive + 胶囊 + 弹层 + 完成即时翻转 + i18n
+
+> **Worktree 前置(执行 Task 4 前一次性做):** 生成 wails 绑定 + 占位 dist:
+> ```bash
+> mkdir -p frontend/dist && touch frontend/dist/.gitkeep
+> cd frontend && pnpm install && cd ..
+> GOWORK=off wails generate module   # 产出 frontend/wailsjs（含 chat_svc.ChatBlockSubagent 含新 kind）
+> ```
+
+**Files:**
+- Create: `frontend/src/components/agentre/background-tasks/{types.ts,derive.ts,derive.test.ts,background-tasks-chip.tsx,background-tasks-popover.tsx}`
+- Modify: `frontend/src/components/agentre/chat-panel.tsx`
+- Modify: `frontend/src/i18n/locales/{zh-CN,en}/common.json`
+- Test: `frontend/src/components/agentre/background-tasks/derive.test.ts`、chip/popover `.test.tsx`、`frontend/src/__tests__/i18n.test.ts`(自动覆盖)
+
+- [ ] **Step 1: 类型**
+
+`background-tasks/types.ts`:
+
+```ts
+export type BackgroundTaskKind = "local_bash" | "local_agent";
+export type BackgroundTaskStatus = "running" | "completed" | "failed";
+
+export interface BackgroundTask {
+  toolUseId: string;
+  kind: BackgroundTaskKind;
+  description: string;
+  status: BackgroundTaskStatus;
+}
+```
+
+- [ ] **Step 2: 写失败测试 —— deriveBackgroundTasks**
+
+`background-tasks/derive.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { deriveBackgroundTasks } from "./derive";
+
+const sub = (over: Partial<any> = {}) => ({
+  type: "subagent_state",
+  parentToolUseId: "tu1",
+  subagent: { kind: "local_bash", taskDescription: "npm run dev", status: "running" },
+  ...over,
+});
+
+describe("deriveBackgroundTasks", () => {
+  it("从 liveBlocks 的 subagent_state 取运行中任务", () => {
+    const tasks = deriveBackgroundTasks([], [sub() as any]);
+    expect(tasks).toEqual([
+      { toolUseId: "tu1", kind: "local_bash", description: "npm run dev", status: "running" },
+    ]);
+  });
+
+  it("历史消息里的 subagent_state 也计入,且 status=completed 正确映射", () => {
+    const msg = { blocks: [sub({ parentToolUseId: "tu2", subagent: { kind: "local_agent", taskDescription: "Explore", status: "completed" } })] };
+    const tasks = deriveBackgroundTasks([msg as any], []);
+    expect(tasks[0]).toMatchObject({ toolUseId: "tu2", kind: "local_agent", status: "completed" });
+  });
+
+  it("同一 toolUseId 在 live 覆盖历史(去重取最新)", () => {
+    const msg = { blocks: [sub({ subagent: { kind: "local_bash", taskDescription: "x", status: "running" } })] };
+    const live = [sub({ subagent: { kind: "local_bash", taskDescription: "x", status: "completed" } })];
+    const tasks = deriveBackgroundTasks([msg as any], live as any);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe("completed");
+  });
+});
+```
+
+- [ ] **Step 3: 跑看失败**
+
+Run: `cd frontend && pnpm test -- src/components/agentre/background-tasks/derive.test.ts`
+Expected: FAIL —— 模块不存在。
+
+- [ ] **Step 4: 实现 derive**
+
+`background-tasks/derive.ts`(镜像 `task-progress/derive.ts` 的扫描风格;读 `ChatBlock.parentToolUseId` + `.subagent`):
+
+```ts
+import type { ChatBlockData } from "@/stores/chat-streams-store";
+import type { chat_svc } from "../../../../wailsjs/go/models";
+import type { BackgroundTask, BackgroundTaskKind, BackgroundTaskStatus } from "./types";
+
+// 扫历史 messages + liveBlocks 里所有 type==="subagent_state" 的 block,按 toolUseId
+// 去重(后出现的覆盖先出现的:历史先扫、live 后扫 → live 赢),映射成 BackgroundTask。
+export function deriveBackgroundTasks(
+  messages: chat_svc.ChatMessage[],
+  liveBlocks: ChatBlockData[],
+): BackgroundTask[] {
+  const byId = new Map<string, BackgroundTask>();
+  const visit = (block: ChatBlockData | undefined) => {
+    if (!block || block.type !== "subagent_state") return;
+    const toolUseId = (block as { parentToolUseId?: string }).parentToolUseId;
+    const sa = (block as { subagent?: Record<string, unknown> }).subagent;
+    if (!toolUseId || !sa) return;
+    byId.set(toolUseId, {
+      toolUseId,
+      kind: mapKind(sa.kind as string),
+      description: (sa.taskDescription as string) ?? "",
+      status: mapStatus(sa.status as string),
+    });
+  };
+  for (let i = 0; i < messages.length; i++) {
+    const blocks = messages[i].blocks ?? [];
+    for (const b of blocks) visit(b as unknown as ChatBlockData);
+  }
+  for (const b of liveBlocks) visit(b);
+  return [...byId.values()];
+}
+
+function mapKind(raw: string): BackgroundTaskKind {
+  return raw === "local_agent" ? "local_agent" : "local_bash";
+}
+function mapStatus(raw: string): BackgroundTaskStatus {
+  if (raw === "completed") return "completed";
+  if (raw === "failed") return "failed";
+  return "running";
+}
+```
+
+- [ ] **Step 5: 跑转绿**
+
+Run: `cd frontend && pnpm test -- src/components/agentre/background-tasks/derive.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: i18n key(双语)**
+
+`frontend/src/i18n/locales/zh-CN/common.json` 的 `chatPanel` 下加:
+
+```json
+    "backgroundTasks": {
+      "chip": "{{count}} 运行中",
+      "title": "后台任务",
+      "running": "运行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "empty": "暂无后台任务",
+      "bash": "bash",
+      "subagent": "subagent",
+      "aria": "后台任务"
+    },
+```
+
+`frontend/src/i18n/locales/en/common.json` 的 `chatPanel` 下镜像:
+
+```json
+    "backgroundTasks": {
+      "chip": "{{count}} running",
+      "title": "Background tasks",
+      "running": "Running",
+      "completed": "Done",
+      "failed": "Failed",
+      "empty": "No background tasks",
+      "bash": "bash",
+      "subagent": "subagent",
+      "aria": "Background tasks"
+    },
+```
+
+- [ ] **Step 7: 弹层 + 胶囊组件**
+
+`background-tasks-popover.tsx`:用 shadcn `@/components/ui/popover`;列表用 `Terminal`/`Bot`(lucide)分类图标,绿点 = running,灰 = completed,红 = failed;耗时本地 tick(传入 `startedAt` 或省略,v1 可仅显示状态文案,耗时列 follow-up)。`background-tasks-chip.tsx`:`Button variant="outline" size="sm"`,内容 `t("chatPanel.backgroundTasks.chip",{count:runningCount})`,绿点 + chevron,`running===0` 时返回 `null`(完全隐藏)。各组件 `.test.tsx`:渲染三态 + 计数 + 隐藏。所有可见文案走 `t(...)`。
+
+- [ ] **Step 8: 挂到工具栏 + 完成即时翻转**
+
+`chat-panel.tsx`:在 toolbar 的 Stop 按钮前插入 `<BackgroundTasksChip tasks={backgroundTasks} />`,`backgroundTasks = useMemo(() => deriveBackgroundTasks(messages, liveBlocks), [messages, liveBlocks])`。`onAutonomousEvent` 里处理 `ev.completedTask`:把 store 中(messages)对应 `parentToolUseId===ev.completedTask.toolUseId` 的 subagent_state 块 `subagent.status` 即时设为 `ev.completedTask.status`(新增 store action `markSubagentDone(sessionId, toolUseId, status)`,或在 chat-panel 本地 `setMessages` 改)。reload 后由后端 `FlipSubagentStatus` 落库保证一致。
+
+- [ ] **Step 9: 跑前端测试 + i18n 校验 + tsc + lint**
+
+Run:
+```bash
+cd frontend && pnpm test -- src/components/agentre/background-tasks/ src/__tests__/i18n.test.ts
+cd frontend && pnpm tsc --noEmit && pnpm lint
+```
+Expected: 全过(i18n.test.ts 验证 zh/en key 对齐 + 静态 t() key 存在)。
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/components/agentre/background-tasks/ frontend/src/components/agentre/chat-panel.tsx frontend/src/i18n/ frontend/src/stores/chat-streams-store.ts
+git commit -m "✨ 前端: 后台任务面板(头部胶囊+只读弹层,从 subagent_state derive)"
+```
+
+---
+
+## 收尾验证(全绿后)
+
+- [ ] `GOWORK=off go test -race ./pkg/claudecode/... ./internal/pkg/agentruntime/... ./internal/service/chat_svc/... ./internal/repository/chat_repo/...`
+- [ ] `GOWORK=off golangci-lint run ./pkg/claudecode/ ./internal/pkg/agentruntime/... ./internal/service/chat_svc/...`
+- [ ] `cd frontend && pnpm test && pnpm tsc --noEmit && pnpm lint`
+- [ ] 手验(可选):真实跑「sleep 20 后台 + 完成后通知」会话,胶囊「1 运行中」→ 完成翻「已完成」;reload 仍正确。
+- [ ] 用 `superpowers:requesting-code-review` 自审 diff。
+
+## Self-review(已过)
+
+- **Spec coverage**:胶囊+弹层(T4)、bash+subagent 统一(kind 贯穿 T1–T4)、运行/完成/失败三态(T1 Status / T3 翻转 / T4 mapStatus)、只读(无 output/stop 任务)、复用自主轮(T3)、修内联块 running(T3 FlipSubagentStatus)—— 均有对应任务。non-goals(output/stop/新表/远端/全局托盘)未排任务,符合。
+- **Placeholder scan**:`FlipSubagentStatus` 实现体给了具体算法(倒序拉消息+JSON 改+重写),非 TODO;`view/project.go` 类型与 wire decode 入口名标了「执行期确认」并给了预期代码形状,非占位。
+- **Type consistency**:`TaskType`(claudecode)→`Kind`(agentruntime/block/wire);`CompletedBackgroundTask`(claudecode & agentruntime 各一,bridge 映射)→`CompletedTaskRef`(chat_svc wire,camelCase `toolUseId/status`)→前端 `ev.completedTask`。`subagent_state` 块 `Kind`/`Description` ↔ `ChatBlockSubagent.Kind`/`TaskDescription` ↔ 前端 `subagent.kind`/`taskDescription`。一致。

--- a/docs/superpowers/specs/2026-06-05-background-tasks-panel-design.md
+++ b/docs/superpowers/specs/2026-06-05-background-tasks-panel-design.md
@@ -1,0 +1,128 @@
+# 后台任务面板(会话头部胶囊 + 弹层)设计
+
+**日期**: 2026-06-05
+**状态**: 设计完成,待 review
+**作者**: Claude(结对 with 王一之)
+**相关**: [[2026-06-04-claudecode-background-task-autonomous-turn-design]](自主续轮捕获,本案复用其会话级旁路 + 完成信号)
+
+## 背景
+
+用户在会话里跑 `run_in_background` 的 bash 任务(`sleep 20`、`npm run dev &` 之类)后,**无法在 UI 看到「有多少个 / 什么任务在后台运行」**。当前仅有的零散信号:启动那条消息的 tool_result 文本(含 task ID + output 路径)、内联的 `subagent_state` running 卡片(分散在 transcript 里、按工具调用)、以及完成后冒出的自主续轮 assistant 消息。没有任何**聚合的、可一眼看到的「正在进行的任务」视图**。
+
+### 已确认的事实(真实 CLI 2.1.162 capture + 代码 sweep)
+
+- CLI 把后台任务与 subagent 都建模成同一套 **task** 概念,经同一组帧下发:`system{subtype:"task_started"|"task_updated"|"task_progress"|"task_notification"}`。区分维度是 `task_type`:
+  - `local_bash` —— `run_in_background` 的 bash 任务(`task_notification` 带 `output_file`,无 `subagent_type`)。
+  - `local_agent` —— subagent(Task 工具,带 `subagent_type` ∈ general-purpose / Explore / Plan / …,无 `output_file`)。
+- subagent(`local_agent`)**在父轮内同步跑**(父 agent 等它,`task_notification` 在 active turn 内到达,带 `subagent_type`),没有 `run_in_background` 的「自主续轮」语义。
+- 两者今天**都已生成 `subagent_state` 块**(`internal/service/chat_svc/blocks/subagent_state.go`,`status:"running"`,`parent_tool_call_id` = 触发它的工具 tool_use_id),已落库 + 流式给前端。sess-429 实测有此块。
+- **缺口/缺陷**:① `subagent_state` 块没有 `kind` / `description` 字段,前端无法区分 bash vs subagent、无法显示任务名;② **后台 bash 的块永远停在 `running`** —— 它的完成 `task_notification` 被自主续轮当作起始标记消费掉、不再下发(见相关 spec),`task_updated{patch.status:"completed"}` 又在空闲时被 `isNonTurnFrame` 丢弃,所以没有「完成」信号回流到块。
+
+## 目标 / 非目标
+
+**目标**
+- 会话头部一个**胶囊**(chip)显示当前**运行中任务数**(常显、可一眼看到),点开是一个**弹层**(popover)列出本会话的后台任务。
+- 每个任务条目展示:**类型图标**(bash=terminal / subagent=bot)、**描述**、**耗时**、**状态**(运行中 / 已完成 / 失败)、**完成摘要**(退出码)。
+- 统一覆盖 `local_bash` + `local_agent` 两类任务。
+- 顺带修掉「后台 bash 块永远 running」的次生缺陷(本案的完成信号天然带来)。
+
+**非目标**
+- ❌ 查看 output(不读 `tasks/<id>.output`、不加新 Wails binding)。
+- ❌ 停止 / kill 运行中的后台任务。
+- ❌ 新 DB 表 / schema 迁移(复用既有 `subagent_state` 块,纯 JSON 字段增补)。
+- ❌ codex / builtin backend(无等价 task 协议,不声明、不渲染)。
+- ❌ 全局跨会话托盘(本案是**会话级**;全局视图列为显式 follow-up)。
+
+## 已确认的设计决策
+
+1. **放置 = 会话头部胶囊 + 弹层**(用户在 pencil 效果图 A/B/C 中选 A)。胶囊在 Chat `Header`(`quFOg`)右侧,弹层向下展开。pencil 稿:`agentry.pen` 帧「Agent Chat — 后台任务 · A 头部胶囊弹层」+ 复用组件 `TaskRow`(`PQd1v`)。
+2. **交互 = 只读**(用户选「最轻」)。不看 output、不控制。bash 输出仍可在对话里(工具结果 / 自主轮)滚。
+3. **数据来源 = 前端从 `subagent_state` 块 derive**(轻方案),而非另起一套并行 task-tracking 流。理由:这些块今天已流式给前端,只差 `kind`/`description` 与完成翻转两处;复用既有块基础设施 + 既有自主续轮机器,新增面最小。
+4. **完成信号搭既有自主续轮事件的车**:后台 bash 完成 ⇔ 自主续轮触发(因果同源)。把完成任务的 `tool_use_id`/`status`/`summary` 挂到 `AutoTurn`,经既有会话级旁路 `chat:autonomous:<sessionID>`(`StreamAutonomousStarted`)带给前端 → 翻转该任务为完成。active-turn 内完成的任务走既有 `SubagentDone` 路径,本就会翻转。
+5. **live / ephemeral,不持久化聚合态**。后台任务活在 CLI 子进程里;agentre 重启 / 会话 evict → 子进程死 → 后台任务也死,故重启后无「运行中」任务。面板纯反映当前子进程的 live 状态,耗时前端本地 tick。
+
+> **被否的替代方案(记录用)**:独立 `BackgroundTaskSource` 前向子接口 + `CapBackgroundTasks` 能力 + chat_svc watcher + remote wire,完整镜像自主续轮设计。更解耦(不依赖 `subagent_state`)、天生 remote-ready,但对一个只读胶囊是大量 plumbing。本案范围内不值得;若将来要全局/远端面板再升级到它。
+
+## 架构总览
+
+```
+turn1: Bash(run_in_background:true)
+  → CLI system{task_started, task_type:"local_bash", description, tool_use_id}
+  → SubagentMeta{TaskType, TaskDescription, …} (pkg/claudecode)
+  → SubagentStarted{Info{Kind:"local_bash", Description, …}} (agentruntime translator)
+  → subagent_state 块 {kind:local_bash, description, status:running} 落库 + 流式
+  → 前端 deriveBackgroundTasks → 头部胶囊「1 运行中」+ 弹层条目
+…后台任务完成…
+  → CLI system{task_notification, status:completed, summary, tool_use_id} (空闲到达)
+  → pkg/claudecode 判后台型 → 起自主续轮,**同时把 {tool_use_id,status,summary} 记到 AutoTurn.CompletedTask**
+  → chat_svc driveAutonomousTurn:落自主 assistant 轮 **+** 在 StreamAutonomousStarted payload 带 CompletedTask
+  → 前端:既插入自主轮消息,**又**把该 tool_use_id 的任务标记 completed(灰 + 退出码)
+
+subagent(local_agent):task_started→running(turn 内);SubagentDone→completed(既有路径,无需新增)
+```
+
+## 组件 ①:`pkg/claudecode` —— 补 `task_type` + 透传完成信息
+
+- `stream.go` `rawFrame`:补 `task_type`(三类 task 帧共通)字段解析;确认 `task_notification` 的 `tool_use_id` / `summary` / `status` 已可取(`output_file` 已有)。
+- `event.go` `SubagentMeta`:加 `TaskType string`(← `task_started.task_type`,值 `local_bash` / `local_agent`)。`parseSystemTask`(`session.go`)填充。
+- `autoturn.go` `AutoTurn`:加 `CompletedTask *CompletedBackgroundTask`(`{ToolUseID, TaskID, Status, Summary}`)。`currentTurn` 在 `isBackgroundTaskNotification` 命中、新建自主轮时,从该 `rawFrame` 抽出这些字段塞进 `AutoTurn`。
+- **不改**自主续轮的既有路由/并发约束(本案只在「起自主轮」处顺手记录完成任务,不动 readLoop 时序)。
+
+## 组件 ②:`agentruntime`(claudecode runtime + translator)
+
+- `SubagentInfo`:加 `Kind string`(← `SubagentMeta.TaskType`)。`subagentInfoFromMeta` 透传。`event_wire.go` 编解码补字段(向后兼容:旧帧无 `kind` → 空)。
+- `AutonomousTurn`:加 `CompletedTask`(镜像 `claudecode.AutoTurn.CompletedTask`),claudecode runtime 的 `AutonomousTurns` 桥接时透传。
+- 无新能力 / 新前向接口(复用既有 `AutonomousTurnSource`)。
+
+## 组件 ③:`chat_svc`
+
+- `subagent_state` 块(`blocks/subagent_state.go`):加 `Kind string`(`local_bash`/`local_agent`)+ `Description string`(JSON 字段,`omitempty`,无迁移)。写块处(handlers 里处理 `SubagentStarted`/`Progress`/`Done` 的地方)填充。
+- `driveAutonomousTurn`(`autonomous_turn.go`):当 `at.CompletedTask != nil` 时,在 emit 的 `StreamAutonomousStarted` payload 里带上 `{tool_use_id, status, summary}`(新增可选字段,`types.go` / `emitter.go` 对应结构补字段),供前端**即时**翻转。**串行/并发约束不变**(仍不持 chat 会话锁 drain)。
+- **持久化完成态(核心,非选做)**:仅靠上面的内存事件,`reloadSession`(StreamDone 后频繁触发)会从 DB 重新 derive —— 若 bash 块仍 `running`,面板会**错误地重新显示运行中**。故完成态必须落库。两种落法,计划期二选一钉死:
+  - **(a) 翻转原块(推荐)**:把 `parent_tool_call_id == tool_use_id` 的 `subagent_state` 块 `running→completed` 落库。单一真相源,**顺带修掉内联卡片永远 running 的次生缺陷**。代价:bash 块在**更早的消息**里(turn1 启动、后续自主轮才完成),需要 chat_svc 支持**跨消息更新某条历史消息的块**(需确认是否已有机制,无则新增一个定向 update)。
+  - **(b) 追加引用(append-only)**:在自主轮 assistant 消息上记 `triggered_by_completed_tool_use_id`,前端 derive 交叉引用标记完成。无需跨消息更新,但内联卡片仍停 running、derive 略复杂。
+  落库失败仅 log,不阻断(对齐既有失败路径)。
+
+## 组件 ④:前端
+
+- `deriveBackgroundTasks(messages, liveBlocks)` 纯函数(镜像既有 `task-progress/derive.ts` 的 `deriveTaskProgress`):扫会话消息 + 当前 live 块里的 `subagent_state`,产出 `BackgroundTask[]`(`{toolUseId, kind, description, status, startedAt}`)。`startedAt` 取所属消息/块时间,**耗时前端本地 tick**(setInterval)。
+- 完成翻转:ChatPanel 既有的 `chat:autonomous:<sessionID>` 常驻订阅里,收到带 `CompletedTask` 的 `StreamAutonomousStarted` → 把对应 toolUseId 的任务标记 completed(本地态;若组件④的选做落库了,reload 也一致)。
+- 组件:`BackgroundTasksChip`(头部,显示运行中计数 + 绿点;0 运行中时:无运行任务则隐藏胶囊,或仅在有「最近完成」时显示一个中性态——实现期定)+ `BackgroundTasksPopover`(列表:运行中在上、最近完成在下,可「清理已完成」)。挂在 Chat `Header`。
+- i18n:`chatPanel.backgroundTasks.{chip,title,running,completed,failed,empty,clearDone,…}`,zh-CN + en 双份;过 `i18next/no-literal-string` 与 `i18n.test.ts`。
+- 复用 shadcn `@/components/ui/*`(Popover 等),不加原生控件。
+
+## 数据 / 状态语义
+
+- **状态三态**:`running`(task_started 后、未完成)、`completed`(`task_notification.status=="completed"` 或退出码 0)、`failed`(`status=="failed"` 或退出码≠0)。摘要文本来自 `task_notification.summary`(形如 `Background command "…" completed (exit code 0)`)。
+- **胶囊计数** = `running` 计数(bash + subagent 合计)。
+- **耗时**:`running` 实时 tick(now − startedAt);`completed/failed` 定格(用 `task_updated.patch.end_time` 或完成时刻 − startedAt)。
+
+## 边界 / 错误处理
+
+- 后台任务完成发生在 **active user turn 内**(非空闲)→ `task_notification` 路由进 active turn → 既有 `SubagentDone` 翻转,**不**走自主轮路径(无 `CompletedTask`)。两条完成路径并存、互斥(按 active==nil 与否)。
+- 一次空闲多任务同时完成 → CLI 串行 emit 多个 `task_notification`、多个自主轮,各带各自 `CompletedTask`,逐一翻转(rare;spec 记录,实现按 FIFO 自然处理)。
+- 自主续轮内部出错 / 落库失败 → 沿用既有路径(回 idle、log),**不影响**任务翻转信息已带出。
+- 子进程中途死亡 → 会话 evict,前端面板随会话态清空(live 语义)。
+
+## 测试策略(TDD,先 Red)
+
+| 测试 | 位置 | 验证 |
+|---|---|---|
+| `task_type` 解析 | `pkg/claudecode/session_test.go` | `task_started{task_type:"local_bash"/"local_agent"}` → `SubagentMeta.TaskType` 正确;`task_notification` → `AutoTurn.CompletedTask{ToolUseID,Status,Summary}` 填充。 |
+| 翻译透传 | `internal/pkg/agentruntime/runtimes/claudecode/*_test.go` | `SubagentMeta.TaskType` → `SubagentInfo.Kind`;`AutoTurn.CompletedTask` → `AutonomousTurn.CompletedTask`;wire round-trip(`kind` 向后兼容)。 |
+| 块字段 + 翻转 | `chat_svc` 单测(mock runtime) | `SubagentStarted{Kind,Description}` 落 `subagent_state{kind,description,status:running}`;`driveAutonomousTurn` 带 `CompletedTask` → emit 的 `StreamAutonomousStarted` 携带完成信息(+ 选做:对应块翻 completed)。 |
+| derive 纯函数 | `frontend` Vitest | `deriveBackgroundTasks`:running 计数、bash vs subagent 分类、completed 翻转、隐藏/清理逻辑。 |
+| 组件 | `frontend` Vitest | `BackgroundTasksChip`/`BackgroundTasksPopover` 渲染三态 + 计数 + 空态;i18n key 覆盖。 |
+
+repo 单测一律 `testutils.Database(t)` + sqlmock;service 单测 mockgen 注入。
+
+## 回滚 / 兼容
+
+agentre 未发布,无需兼容层 / 迁移回填。`subagent_state` 新增 `kind`/`description` 为 `omitempty` JSON 字段,旧块(无该字段)前端按未知/缺省渲染,不破坏。新增能力面为零(复用 `AutonomousTurnSource`),不声明能力的 backend 不受影响。**无 DB schema 改动**。
+
+## 实现期待定细节(计划/TDD 钉死,非架构阻塞)
+
+1. 0 运行中时胶囊的确切行为(完全隐藏 vs 显示「最近完成 N」中性态 + 自动清理时机)。
+2. `subagent_state` 块的精确写入点(`SubagentStarted` handler)与 `Kind`/`Description` 的来源帧字段(两份真实 capture:`local_bash` 与 `local_agent` 各一)。
+3. 选做的内联卡片翻转是否纳入本次(推荐纳入,因完成信息已在手)。
+4. remote(agentred)是否本次顺带(默认**不**;`CompletedTask` 已在 `AutonomousTurn` 上,remote 转发自主轮时大概率免费带出,留作 follow-up 验证)。

--- a/frontend/src/components/agentre/background-tasks/background-tasks-chip.test.tsx
+++ b/frontend/src/components/agentre/background-tasks/background-tasks-chip.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BackgroundTasksChip } from "./background-tasks-chip";
+import type { BackgroundTask } from "./types";
+
+const running: BackgroundTask = {
+  toolUseId: "tu1",
+  kind: "local_bash",
+  description: "sleep 20",
+  status: "running",
+};
+
+const completed: BackgroundTask = {
+  toolUseId: "tu2",
+  kind: "local_agent",
+  description: "Explore repo",
+  status: "completed",
+};
+
+const failed: BackgroundTask = {
+  toolUseId: "tu3",
+  kind: "local_bash",
+  description: "build step",
+  status: "failed",
+};
+
+describe("BackgroundTasksChip", () => {
+  it("renders null when no running tasks", () => {
+    const { container } = render(
+      <BackgroundTasksChip tasks={[completed, failed]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when tasks is empty", () => {
+    const { container } = render(<BackgroundTasksChip tasks={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows running count in chip label", () => {
+    render(<BackgroundTasksChip tasks={[running, completed]} />);
+    const btn = screen.getByRole("button", { name: /background tasks/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent("1 running");
+  });
+
+  it("shows correct count when multiple tasks are running", () => {
+    const running2: BackgroundTask = {
+      toolUseId: "tu4",
+      kind: "local_agent",
+      description: "another task",
+      status: "running",
+    };
+    render(<BackgroundTasksChip tasks={[running, running2, completed]} />);
+    expect(screen.getByRole("button")).toHaveTextContent("2 running");
+  });
+
+  it("opens popover and shows all tasks when chip is clicked", () => {
+    render(<BackgroundTasksChip tasks={[running, completed, failed]} />);
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    // popover title
+    expect(screen.getByText("Background tasks")).toBeInTheDocument();
+    // task descriptions (dynamic — rendered raw)
+    expect(screen.getByText("sleep 20")).toBeInTheDocument();
+    expect(screen.getByText("Explore repo")).toBeInTheDocument();
+    expect(screen.getByText("build step")).toBeInTheDocument();
+    // status labels
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("shows empty state in popover if tasks array has no items", () => {
+    // chip is hidden when 0 running, but we can test popover content directly via
+    // the BackgroundTasksPopoverContent component independently
+    // Here we test via chip by passing a task that is running but empty
+    render(
+      <BackgroundTasksChip
+        tasks={[
+          {
+            toolUseId: "tu5",
+            kind: "local_bash",
+            description: "",
+            status: "running",
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    // popover shows 1 item with empty description
+    expect(screen.getByText("Background tasks")).toBeInTheDocument();
+  });
+
+  it("shows kind labels (bash / subagent) in popover", () => {
+    render(
+      <BackgroundTasksChip
+        tasks={[running, { ...completed, status: "running" as const }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("bash")).toBeInTheDocument();
+    expect(screen.getByText("subagent")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/agentre/background-tasks/background-tasks-chip.test.tsx
+++ b/frontend/src/components/agentre/background-tasks/background-tasks-chip.test.tsx
@@ -1,8 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BackgroundTasksChip } from "./background-tasks-chip";
+import { BackgroundTasksPopoverContent } from "./background-tasks-popover";
 import type { BackgroundTask } from "./types";
+
+// 任何用 vi.useFakeTimers() 的用例若断言抛错,真实计时器不会被恢复,会泄漏到
+// 后续测试。统一在 afterEach 兜底恢复。
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const running: BackgroundTask = {
   toolUseId: "tu1",
@@ -103,5 +110,109 @@ describe("BackgroundTasksChip", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(screen.getByText("bash")).toBeInTheDocument();
     expect(screen.getByText("subagent")).toBeInTheDocument();
+  });
+});
+
+describe("BackgroundTasksPopoverContent — elapsed + summary", () => {
+  it("shows elapsed for a running task with startedAt", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1700000030000)); // 30s after startedAt
+
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-r",
+        kind: "local_bash",
+        description: "sleep 20",
+        status: "running",
+        startedAt: 1700000000000,
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    // running 30s → "30s"
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("30s");
+  });
+
+  it("shows frozen durationMs for a completed subagent", () => {
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-c",
+        kind: "local_agent",
+        description: "Explore",
+        status: "completed",
+        durationMs: 4200,
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("4s");
+  });
+
+  it("shows summary text for a completed bash task", () => {
+    const summary = 'Background command "sleep 20" completed (exit code 0)';
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-b",
+        kind: "local_bash",
+        description: "sleep 20",
+        status: "completed",
+        summary,
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    expect(screen.getByText(summary)).toBeInTheDocument();
+  });
+
+  it("does not show elapsed for a running task without startedAt", () => {
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-no-start",
+        kind: "local_bash",
+        description: "sleep 20",
+        status: "running",
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    expect(screen.queryByTestId("elapsed")).toBeNull();
+  });
+
+  it("does not show summary when summary is absent", () => {
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-no-summary",
+        kind: "local_bash",
+        description: "run",
+        status: "completed",
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    // No extra text beyond what's expected
+    expect(screen.queryByText(/exit code/)).toBeNull();
+  });
+
+  it("formats minute-range frozen durationMs as m ss", () => {
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-min",
+        kind: "local_agent",
+        description: "task",
+        status: "completed",
+        durationMs: 185_000, // 3m 05s
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("3m 05s");
+  });
+
+  it("formats hour-range frozen durationMs as h mm", () => {
+    const tasks: BackgroundTask[] = [
+      {
+        toolUseId: "tu-hr",
+        kind: "local_agent",
+        description: "task",
+        status: "completed",
+        durationMs: 3_720_000, // 1h 02m
+      },
+    ];
+    render(<BackgroundTasksPopoverContent tasks={tasks} />);
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("1h 02m");
   });
 });

--- a/frontend/src/components/agentre/background-tasks/background-tasks-chip.tsx
+++ b/frontend/src/components/agentre/background-tasks/background-tasks-chip.tsx
@@ -1,0 +1,49 @@
+import { ChevronDown } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+import { BackgroundTasksPopoverContent } from "./background-tasks-popover";
+import type { BackgroundTask } from "./types";
+
+type BackgroundTasksChipProps = {
+  tasks: BackgroundTask[];
+};
+
+export function BackgroundTasksChip({ tasks }: BackgroundTasksChipProps) {
+  const { t } = useTranslation();
+
+  const runningCount = tasks.filter((task) => task.status === "running").length;
+
+  // Hidden when no running tasks
+  if (runningCount === 0) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={t("chatPanel.backgroundTasks.aria")}
+          className="gap-1.5"
+        >
+          <span
+            className="inline-block size-2 rounded-full bg-green-500"
+            aria-hidden="true"
+          />
+          {t("chatPanel.backgroundTasks.chip", { count: runningCount })}
+          <ChevronDown className="size-3 opacity-60" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="p-3">
+        <BackgroundTasksPopoverContent tasks={tasks} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/agentre/background-tasks/background-tasks-popover.tsx
+++ b/frontend/src/components/agentre/background-tasks/background-tasks-popover.tsx
@@ -1,7 +1,23 @@
 import { Bot, Terminal } from "lucide-react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 
 import type { BackgroundTask } from "./types";
+
+// formatElapsed 将毫秒数格式化为紧凑耗时字符串（computed — 不走 t()）。
+// < 60s → "12s"  |  < 60m → "3m 05s"  |  else → "1h 02m"
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.floor(totalSec / 60);
+  if (totalMin < 60) {
+    const remSec = totalSec % 60;
+    return `${totalMin}m ${remSec.toString().padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(totalMin / 60);
+  const remMin = totalMin % 60;
+  return `${hours}h ${remMin.toString().padStart(2, "0")}m`;
+}
 
 type BackgroundTasksPopoverContentProps = {
   tasks: BackgroundTask[];
@@ -11,6 +27,19 @@ export function BackgroundTasksPopoverContent({
   tasks,
 }: BackgroundTasksPopoverContentProps) {
   const { t } = useTranslation();
+
+  // One ticking `now` for the whole popover. The interval only runs while the
+  // popover is mounted (open) AND there is at least one running task with a
+  // known startedAt — so a popover full of completed tasks doesn't tick/re-render.
+  const [now, setNow] = React.useState(() => Date.now());
+  const hasLiveElapsed = tasks.some(
+    (task) => task.status === "running" && task.startedAt != null,
+  );
+  React.useEffect(() => {
+    if (!hasLiveElapsed) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [hasLiveElapsed]);
 
   return (
     <div className="flex min-w-[260px] max-w-[400px] flex-col gap-2">
@@ -23,31 +52,59 @@ export function BackgroundTasksPopoverContent({
         </p>
       ) : (
         <ul className="flex flex-col gap-1.5">
-          {tasks.map((task) => (
-            <li key={task.toolUseId} className="flex items-start gap-2">
-              <span className="mt-0.5 shrink-0 text-muted-foreground">
-                {task.kind === "local_bash" ? (
-                  <Terminal className="size-3.5" aria-hidden="true" />
-                ) : (
-                  <Bot className="size-3.5" aria-hidden="true" />
-                )}
-              </span>
-              <div className="min-w-0 flex-1">
-                {/* description is dynamic agent output — do NOT pass through t() */}
-                <p className="break-words text-xs leading-snug text-foreground">
-                  {task.description || " "}
-                </p>
-                <div className="mt-0.5 flex items-center gap-1.5">
-                  <span className="font-mono text-[10px] text-muted-foreground">
-                    {task.kind === "local_bash"
-                      ? t("chatPanel.backgroundTasks.bash")
-                      : t("chatPanel.backgroundTasks.subagent")}
-                  </span>
-                  <StatusPill status={task.status} />
+          {tasks.map((task) => {
+            // Compute elapsed label (computed value — not through t())
+            let elapsedLabel: string | undefined;
+            if (task.status === "running" && task.startedAt != null) {
+              elapsedLabel = formatElapsed(now - task.startedAt);
+            } else if (
+              (task.status === "completed" || task.status === "failed") &&
+              task.durationMs != null &&
+              task.durationMs > 0
+            ) {
+              elapsedLabel = formatElapsed(task.durationMs);
+            }
+
+            return (
+              <li key={task.toolUseId} className="flex items-start gap-2">
+                <span className="mt-0.5 shrink-0 text-muted-foreground">
+                  {task.kind === "local_bash" ? (
+                    <Terminal className="size-3.5" aria-hidden="true" />
+                  ) : (
+                    <Bot className="size-3.5" aria-hidden="true" />
+                  )}
+                </span>
+                <div className="min-w-0 flex-1">
+                  {/* description is dynamic agent output — do NOT pass through t() */}
+                  <p className="break-words text-xs leading-snug text-foreground">
+                    {task.description || " "}
+                  </p>
+                  <div className="mt-0.5 flex items-center gap-1.5">
+                    <span className="font-mono text-[10px] text-muted-foreground">
+                      {task.kind === "local_bash"
+                        ? t("chatPanel.backgroundTasks.bash")
+                        : t("chatPanel.backgroundTasks.subagent")}
+                    </span>
+                    <StatusPill status={task.status} />
+                    {elapsedLabel != null && (
+                      <span
+                        className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground"
+                        data-testid="elapsed"
+                      >
+                        {elapsedLabel}
+                      </span>
+                    )}
+                  </div>
+                  {/* summary is dynamic agent text (exit-code text) — do NOT pass through t() */}
+                  {task.summary && (
+                    <p className="mt-0.5 break-words text-[10px] text-muted-foreground">
+                      {task.summary}
+                    </p>
+                  )}
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/components/agentre/background-tasks/background-tasks-popover.tsx
+++ b/frontend/src/components/agentre/background-tasks/background-tasks-popover.tsx
@@ -1,0 +1,92 @@
+import { Bot, Terminal } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type { BackgroundTask } from "./types";
+
+type BackgroundTasksPopoverContentProps = {
+  tasks: BackgroundTask[];
+};
+
+export function BackgroundTasksPopoverContent({
+  tasks,
+}: BackgroundTasksPopoverContentProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex min-w-[260px] max-w-[400px] flex-col gap-2">
+      <div className="text-xs font-semibold text-foreground">
+        {t("chatPanel.backgroundTasks.title")}
+      </div>
+      {tasks.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {t("chatPanel.backgroundTasks.empty")}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {tasks.map((task) => (
+            <li key={task.toolUseId} className="flex items-start gap-2">
+              <span className="mt-0.5 shrink-0 text-muted-foreground">
+                {task.kind === "local_bash" ? (
+                  <Terminal className="size-3.5" aria-hidden="true" />
+                ) : (
+                  <Bot className="size-3.5" aria-hidden="true" />
+                )}
+              </span>
+              <div className="min-w-0 flex-1">
+                {/* description is dynamic agent output — do NOT pass through t() */}
+                <p className="break-words text-xs leading-snug text-foreground">
+                  {task.description || " "}
+                </p>
+                <div className="mt-0.5 flex items-center gap-1.5">
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {task.kind === "local_bash"
+                      ? t("chatPanel.backgroundTasks.bash")
+                      : t("chatPanel.backgroundTasks.subagent")}
+                  </span>
+                  <StatusPill status={task.status} />
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: BackgroundTask["status"] }) {
+  const { t } = useTranslation();
+
+  if (status === "running") {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-[10px] text-green-600 dark:text-green-400">
+        <span
+          className="inline-block size-1.5 rounded-full bg-green-500"
+          aria-hidden="true"
+        />
+        {t("chatPanel.backgroundTasks.running")}
+      </span>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-[10px] text-destructive">
+        <span
+          className="inline-block size-1.5 rounded-full bg-destructive"
+          aria-hidden="true"
+        />
+        {t("chatPanel.backgroundTasks.failed")}
+      </span>
+    );
+  }
+  // completed
+  return (
+    <span className="inline-flex items-center gap-1 font-mono text-[10px] text-muted-foreground">
+      <span
+        className="inline-block size-1.5 rounded-full bg-muted-foreground"
+        aria-hidden="true"
+      />
+      {t("chatPanel.backgroundTasks.completed")}
+    </span>
+  );
+}

--- a/frontend/src/components/agentre/background-tasks/derive.test.ts
+++ b/frontend/src/components/agentre/background-tasks/derive.test.ts
@@ -96,4 +96,83 @@ describe("deriveBackgroundTasks", () => {
     );
     expect(tasks[0].kind).toBe("local_agent");
   });
+
+  it("threads startedAt from the containing message createtime + durationMs + summary", () => {
+    const msg = {
+      createtime: 1700000000000,
+      blocks: [
+        tu({
+          toolUseId: "tu9",
+          subagent: {
+            kind: "local_bash",
+            taskDescription: "sleep",
+            status: "completed",
+            summary: 'Background command "sleep 20" completed (exit code 0)',
+          },
+        }),
+      ],
+    };
+    const tasks = deriveBackgroundTasks([msg as never], []);
+    expect(tasks[0]).toMatchObject({
+      toolUseId: "tu9",
+      startedAt: 1700000000000,
+      summary: 'Background command "sleep 20" completed (exit code 0)',
+    });
+  });
+
+  it("reads durationMs from subagent for completed subagents", () => {
+    const msg = {
+      createtime: 1,
+      blocks: [
+        tu({
+          toolUseId: "tA",
+          subagent: {
+            kind: "local_agent",
+            taskDescription: "Explore",
+            status: "completed",
+            durationMs: 4200,
+          },
+        }),
+      ],
+    };
+    expect(deriveBackgroundTasks([msg as never], [])[0].durationMs).toBe(4200);
+  });
+
+  it("live blocks (no containing message) have undefined startedAt", () => {
+    const tasks = deriveBackgroundTasks([], [tu()]);
+    expect(tasks[0].startedAt).toBeUndefined();
+  });
+
+  it("keeps history startedAt when a running task is also in liveBlocks (live wins but preserves elapsed base)", () => {
+    const msg = {
+      createtime: 1700000000000,
+      blocks: [
+        tu({
+          toolUseId: "tuBoth",
+          subagent: {
+            kind: "local_bash",
+            taskDescription: "sleep 20",
+            status: "running",
+          },
+        }),
+      ],
+    };
+    const live = [
+      tu({
+        toolUseId: "tuBoth",
+        subagent: {
+          kind: "local_bash",
+          taskDescription: "sleep 20",
+          status: "running",
+        },
+      }),
+    ];
+    const tasks = deriveBackgroundTasks([msg as never], live);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      toolUseId: "tuBoth",
+      startedAt: 1700000000000,
+      status: "running",
+    });
+  });
 });

--- a/frontend/src/components/agentre/background-tasks/derive.test.ts
+++ b/frontend/src/components/agentre/background-tasks/derive.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveBackgroundTasks } from "./derive";
+
+const tu = (over: Record<string, unknown> = {}) =>
+  ({
+    type: "tool_use",
+    toolUseId: "tu1",
+    subagent: {
+      kind: "local_bash",
+      taskDescription: "sleep 20",
+      status: "running",
+    },
+    ...over,
+  }) as unknown as Parameters<typeof deriveBackgroundTasks>[1][number];
+
+describe("deriveBackgroundTasks", () => {
+  it("derives running task from a live tool_use block with .subagent", () => {
+    const tasks = deriveBackgroundTasks([], [tu()]);
+    expect(tasks).toEqual([
+      {
+        toolUseId: "tu1",
+        kind: "local_bash",
+        description: "sleep 20",
+        status: "running",
+      },
+    ]);
+  });
+
+  it("includes persisted-message tool_use tasks and maps local_agent + completed", () => {
+    const msg = {
+      blocks: [
+        tu({
+          toolUseId: "tu2",
+          subagent: {
+            kind: "local_agent",
+            taskDescription: "Explore repo",
+            status: "completed",
+          },
+        }),
+      ],
+    };
+    const tasks = deriveBackgroundTasks([msg as never], []);
+    expect(tasks[0]).toMatchObject({
+      toolUseId: "tu2",
+      kind: "local_agent",
+      status: "completed",
+    });
+  });
+
+  it("live overrides history for the same toolUseId (dedupe, live wins)", () => {
+    const msg = {
+      blocks: [
+        tu({
+          subagent: {
+            kind: "local_bash",
+            taskDescription: "x",
+            status: "running",
+          },
+        }),
+      ],
+    };
+    const live = [
+      tu({
+        subagent: {
+          kind: "local_bash",
+          taskDescription: "x",
+          status: "completed",
+        },
+      }),
+    ];
+    const tasks = deriveBackgroundTasks([msg as never], live);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe("completed");
+  });
+
+  it("ignores tool_use blocks without .subagent and non-tool_use blocks", () => {
+    const tasks = deriveBackgroundTasks(
+      [
+        {
+          blocks: [
+            { type: "tool_use", toolUseId: "x" },
+            { type: "text", text: "hi" },
+          ],
+        } as never,
+      ],
+      [],
+    );
+    expect(tasks).toEqual([]);
+  });
+
+  it("empty/unknown kind falls back to local_agent", () => {
+    const tasks = deriveBackgroundTasks(
+      [],
+      [tu({ subagent: { taskDescription: "y", status: "running" } })],
+    );
+    expect(tasks[0].kind).toBe("local_agent");
+  });
+});

--- a/frontend/src/components/agentre/background-tasks/derive.ts
+++ b/frontend/src/components/agentre/background-tasks/derive.ts
@@ -1,0 +1,62 @@
+import type { ChatBlockData } from "@/stores/chat-streams-store";
+
+import type { chat_svc } from "../../../../wailsjs/go/models";
+
+import type {
+  BackgroundTask,
+  BackgroundTaskKind,
+  BackgroundTaskStatus,
+} from "./types";
+
+// deriveBackgroundTasks 从历史消息 + 当前 live blocks 中提取所有后台任务。
+// 后台/subagent 任务 = type==="tool_use" 且 .subagent 存在的 block。
+// 按 toolUseId dedupe：live 覆盖 history（live 更新）。
+// VisitableBlock 是 visit 只需读取的最小结构投影。subagent 直接复用生成的
+// ChatBlockSubagent，让 ChatBlockData（subagent: ChatBlockSubagent）无需 cast
+// 即可传入；持久化 chat_svc.ChatBlock 走双重 cast 投影。
+type VisitableBlock = {
+  type?: string;
+  toolUseId?: string;
+  subagent?: chat_svc.ChatBlockSubagent;
+};
+
+export function deriveBackgroundTasks(
+  messages: chat_svc.ChatMessage[],
+  liveBlocks: ChatBlockData[],
+): BackgroundTask[] {
+  const byId = new Map<string, BackgroundTask>();
+
+  const visit = (block: VisitableBlock | undefined) => {
+    if (!block || block.type !== "tool_use") return;
+    const sa = block.subagent;
+    const toolUseId = block.toolUseId;
+    if (!toolUseId || !sa) return;
+    byId.set(toolUseId, {
+      toolUseId,
+      kind: mapKind(sa.kind),
+      description: sa.taskDescription ?? "",
+      status: mapStatus(sa.status),
+    });
+  };
+
+  // 先处理历史消息 (history)，再处理 live blocks (live wins on conflict)。
+  // 历史 block 是 chat_svc.ChatBlock，走 task-progress/derive 同款双重 cast
+  // 投影到 VisitableBlock。
+  for (const m of messages) {
+    for (const b of m.blocks ?? []) visit(b as unknown as VisitableBlock);
+  }
+  // liveBlocks 是 ChatBlockData，结构性满足 VisitableBlock，无需 cast。
+  for (const b of liveBlocks) visit(b);
+
+  return [...byId.values()];
+}
+
+function mapKind(raw: string | undefined): BackgroundTaskKind {
+  return raw === "local_bash" ? "local_bash" : "local_agent";
+}
+
+function mapStatus(raw: string | undefined): BackgroundTaskStatus {
+  if (raw === "completed") return "completed";
+  if (raw === "failed") return "failed";
+  return "running";
+}

--- a/frontend/src/components/agentre/background-tasks/derive.ts
+++ b/frontend/src/components/agentre/background-tasks/derive.ts
@@ -26,26 +26,38 @@ export function deriveBackgroundTasks(
 ): BackgroundTask[] {
   const byId = new Map<string, BackgroundTask>();
 
-  const visit = (block: VisitableBlock | undefined) => {
+  const visit = (block: VisitableBlock | undefined, startedAt?: number) => {
     if (!block || block.type !== "tool_use") return;
     const sa = block.subagent;
     const toolUseId = block.toolUseId;
     if (!toolUseId || !sa) return;
+    // 同一 toolUseId 在 history(带 createtime 的 startedAt)与 live(startedAt
+    // undefined)都出现时,live 覆盖会抹掉 startedAt。kind/status/description 仍取
+    // 最新的 live 值;startedAt/durationMs/summary 在 live 缺省时回退到历史值,
+    // 让两路都出现的运行中任务保留耗时基准。
+    const prev = byId.get(toolUseId);
     byId.set(toolUseId, {
       toolUseId,
       kind: mapKind(sa.kind),
-      description: sa.taskDescription ?? "",
+      description: sa.taskDescription ?? prev?.description ?? "",
       status: mapStatus(sa.status),
+      startedAt: startedAt ?? prev?.startedAt,
+      durationMs:
+        (typeof sa.durationMs === "number" ? sa.durationMs : undefined) ??
+        prev?.durationMs,
+      summary: (sa.summary || undefined) ?? prev?.summary,
     });
   };
 
   // 先处理历史消息 (history)，再处理 live blocks (live wins on conflict)。
   // 历史 block 是 chat_svc.ChatBlock，走 task-progress/derive 同款双重 cast
-  // 投影到 VisitableBlock。
+  // 投影到 VisitableBlock。startedAt 取自消息的 createtime (epoch ms)。
   for (const m of messages) {
-    for (const b of m.blocks ?? []) visit(b as unknown as VisitableBlock);
+    for (const b of m.blocks ?? [])
+      visit(b as unknown as VisitableBlock, m.createtime);
   }
   // liveBlocks 是 ChatBlockData，结构性满足 VisitableBlock，无需 cast。
+  // live blocks 没有关联的消息，所以 startedAt 为 undefined。
   for (const b of liveBlocks) visit(b);
 
   return [...byId.values()];

--- a/frontend/src/components/agentre/background-tasks/types.ts
+++ b/frontend/src/components/agentre/background-tasks/types.ts
@@ -6,4 +6,7 @@ export interface BackgroundTask {
   kind: BackgroundTaskKind;
   description: string;
   status: BackgroundTaskStatus;
+  startedAt?: number; // epoch ms (containing message createtime) — base for live elapsed
+  durationMs?: number; // frozen duration for completed/failed subagents (from subagent.durationMs)
+  summary?: string; // completion/exit-code text (from subagent.summary), dynamic
 }

--- a/frontend/src/components/agentre/background-tasks/types.ts
+++ b/frontend/src/components/agentre/background-tasks/types.ts
@@ -1,0 +1,9 @@
+export type BackgroundTaskKind = "local_bash" | "local_agent";
+export type BackgroundTaskStatus = "running" | "completed" | "failed";
+
+export interface BackgroundTask {
+  toolUseId: string;
+  kind: BackgroundTaskKind;
+  description: string;
+  status: BackgroundTaskStatus;
+}

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -404,6 +404,7 @@ function ChatPanel({
           .getState()
           .mergeSubagentMeta(sessionId, ev.completedTask.toolUseId, {
             status: ev.completedTask.status,
+            summary: ev.completedTask.summary,
           } as chat_svc.ChatBlockSubagent);
       }
       if (!ev.assistantMessage || !ev.stream) {

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -65,6 +65,8 @@ import { PermissionModePill, usePermissionMode } from "./permission-mode";
 import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
 import { AgentAvatar, DeviceTag, StatusDot } from "./primitives";
 import { QueuedMessagesBar } from "./queued-messages-bar";
+import { BackgroundTasksChip } from "./background-tasks/background-tasks-chip";
+import { deriveBackgroundTasks } from "./background-tasks/derive";
 import { deriveTaskProgress } from "./task-progress/derive";
 import { TaskProgressBar } from "./task-progress/task-progress-bar";
 import type { AgentColor, AgentStatus } from "./types";
@@ -389,13 +391,22 @@ function ChatPanel({
   // StreamAutonomousStarted。收到后:乐观翻 running + 插入新 assistant 行 + openStream
   // 订阅该自主轮的 per-turn 流,让它像普通 turn 一样实时渲染。后续 chunk/done 与
   // StreamDone→reloadSession 都复用既有路径,自主轮无需任何特殊渲染分支。
+  // completedTask: 若事件携带后台任务身份,立即把对应 live tool_use block 的
+  // subagent.status 翻成终态,刷新后台任务面板胶囊。
   const onAutonomousEvent = React.useCallback(
     (ev: ChatStreamEvent) => {
-      if (
-        ev.kind !== "autonomous_started" ||
-        !ev.assistantMessage ||
-        !ev.stream
-      ) {
+      if (ev.kind !== "autonomous_started") {
+        return;
+      }
+      // 先翻转后台任务状态 (completedTask 可能在没有 assistantMessage 时也存在)
+      if (ev.completedTask?.toolUseId) {
+        useChatStreamsStore
+          .getState()
+          .mergeSubagentMeta(sessionId, ev.completedTask.toolUseId, {
+            status: ev.completedTask.status,
+          } as chat_svc.ChatBlockSubagent);
+      }
+      if (!ev.assistantMessage || !ev.stream) {
         return;
       }
       const amsg = ev.assistantMessage;
@@ -531,6 +542,10 @@ function ChatPanel({
   );
   const taskProgress = React.useMemo(
     () => deriveTaskProgress(messages, currentStream?.liveBlocks ?? []),
+    [messages, currentStream?.liveBlocks],
+  );
+  const backgroundTasks = React.useMemo(
+    () => deriveBackgroundTasks(messages, currentStream?.liveBlocks ?? []),
     [messages, currentStream?.liveBlocks],
   );
   // PermissionMode pill 数据从 caps.permissionModeMeta 拉;caps 未到位时
@@ -1217,6 +1232,8 @@ function ChatPanel({
                             ) : null}
                           </div>
                         </div>
+                        {/* 后台任务胶囊：有运行中任务时显示，点击展开只读弹层 */}
+                        <BackgroundTasksChip tasks={backgroundTasks} />
                         {(() => {
                           // canStop 双源：
                           //   1. currentStream !== null —— 本客户端刚起的 turn，

--- a/frontend/src/hooks/use-chat-stream.ts
+++ b/frontend/src/hooks/use-chat-stream.ts
@@ -136,10 +136,10 @@ export type ChatStreamEvent = {
   // assistantMessage 是要插入 transcript 的新 assistant 行;stream 是该自主轮的
   // per-turn 事件名(前端 openStream 订阅它接后续 chunk/done);trigger="background_task"。
   // completedTask: 触发本自主轮的后台任务身份;前端据此把对应 tool_use.subagent.status
-  // 即时翻成 completed/failed,刷新后台任务面板的状态胶囊。
+  // 即时翻成 completed/failed,刷新后台任务面板的状态胶囊。summary 为退出码摘要文本。
   stream?: string;
   trigger?: string;
-  completedTask?: { toolUseId: string; status: string };
+  completedTask?: { toolUseId: string; status: string; summary?: string };
 };
 
 export function useChatStream(

--- a/frontend/src/hooks/use-chat-stream.ts
+++ b/frontend/src/hooks/use-chat-stream.ts
@@ -135,8 +135,11 @@ export type ChatStreamEvent = {
   // CLI 在 run_in_background 任务完成后**自主**跑的一轮(无用户输入)被后端捕获。
   // assistantMessage 是要插入 transcript 的新 assistant 行;stream 是该自主轮的
   // per-turn 事件名(前端 openStream 订阅它接后续 chunk/done);trigger="background_task"。
+  // completedTask: 触发本自主轮的后台任务身份;前端据此把对应 tool_use.subagent.status
+  // 即时翻成 completed/failed,刷新后台任务面板的状态胶囊。
   stream?: string;
   trigger?: string;
+  completedTask?: { toolUseId: string; status: string };
 };
 
 export function useChatStream(

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -518,6 +518,17 @@
       "placeholder": "Enter a new name",
       "title": "Rename Session"
     },
+    "backgroundTasks": {
+      "chip": "{{count}} running",
+      "title": "Background tasks",
+      "running": "Running",
+      "completed": "Done",
+      "failed": "Failed",
+      "empty": "No background tasks",
+      "bash": "bash",
+      "subagent": "subagent",
+      "aria": "Background tasks"
+    },
     "toolbar": {
       "aria": "Session toolbar",
       "contextSidebar": "Context sidebar",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -518,6 +518,17 @@
       "placeholder": "输入新名称",
       "title": "重命名会话"
     },
+    "backgroundTasks": {
+      "chip": "{{count}} 运行中",
+      "title": "后台任务",
+      "running": "运行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "empty": "暂无后台任务",
+      "bash": "bash",
+      "subagent": "subagent",
+      "aria": "后台任务"
+    },
     "toolbar": {
       "aria": "会话工具栏",
       "contextSidebar": "上下文侧栏",

--- a/internal/pkg/agentruntime/event_wire_test.go
+++ b/internal/pkg/agentruntime/event_wire_test.go
@@ -268,6 +268,15 @@ func TestUnmarshalEvent_AllKindsCovered(t *testing.T) {
 	}
 }
 
+func TestSubagentStarted_KindRoundTrip(t *testing.T) {
+	ev := SubagentStarted{ToolCallID: "tu1", Info: SubagentInfo{Kind: "local_bash"}}
+	b, err := json.Marshal(ev)
+	require.NoError(t, err)
+	got, err := UnmarshalEvent(b)
+	require.NoError(t, err)
+	assert.Equal(t, "local_bash", got.(SubagentStarted).Info.Kind)
+}
+
 func TestUnmarshalEvent_ErrorPaths(t *testing.T) {
 	t.Run("empty bytes", func(t *testing.T) {
 		_, err := UnmarshalEvent(nil)

--- a/internal/pkg/agentruntime/runner.go
+++ b/internal/pkg/agentruntime/runner.go
@@ -105,6 +105,7 @@ type ToolResultEvent struct {
 type SubagentInfo struct {
 	TaskID          string
 	SubagentType    string
+	Kind            string // local_bash | local_agent（区分后台 bash 与 subagent；空=未知/旧帧）
 	TaskDescription string
 	Prompt          string
 	LastToolName    string
@@ -464,6 +465,15 @@ type AutonomousTurn struct {
 	Events  <-chan Event
 	Result  *RunResult
 	Trigger string // "background_task"
+	// CompletedTask 镜像 claudecode.CompletedBackgroundTask:触发本自主轮的后台命令身份。
+	CompletedTask *CompletedBackgroundTask
+}
+
+// CompletedBackgroundTask 见 AutonomousTurn.CompletedTask。
+type CompletedBackgroundTask struct {
+	ToolUseID string
+	TaskID    string
+	Status    string // "completed" | "failed"; 空 → 视为 completed（见 pkg/claudecode.CompletedBackgroundTask）
 }
 
 // Errors live in errors.go; registry / RuntimeFor / RegisterRuntime / SwapRuntimeForTest live in registry.go.

--- a/internal/pkg/agentruntime/runner.go
+++ b/internal/pkg/agentruntime/runner.go
@@ -474,6 +474,7 @@ type CompletedBackgroundTask struct {
 	ToolUseID string
 	TaskID    string
 	Status    string // "completed" | "failed"; 空 → 视为 completed（见 pkg/claudecode.CompletedBackgroundTask）
+	Summary   string // CLI task_notification.summary 透传；空 = CLI 没下发或 remote 路径暂不携带
 }
 
 // Errors live in errors.go; registry / RuntimeFor / RegisterRuntime / SwapRuntimeForTest live in registry.go.

--- a/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
@@ -43,9 +43,17 @@ func (r *Runtime) AutonomousTurns(sessionID int64) <-chan agentruntime.Autonomou
 		for at := range src {
 			evOut := make(chan agentruntime.Event, 32)
 			result := &agentruntime.RunResult{ProviderSessionID: at.SessionID}
+			var completed *agentruntime.CompletedBackgroundTask
+			if at.CompletedTask != nil {
+				completed = &agentruntime.CompletedBackgroundTask{
+					ToolUseID: at.CompletedTask.ToolUseID,
+					TaskID:    at.CompletedTask.TaskID,
+					Status:    at.CompletedTask.Status,
+				}
+			}
 			// 先把这一轮交给 consumer(它并发 drain evOut),随后 inline 翻译填 evOut。
 			// inline(非 goroutine)保证多个自主轮之间顺序处理、不重叠。
-			out <- agentruntime.AutonomousTurn{Events: evOut, Result: result, Trigger: at.Trigger}
+			out <- agentruntime.AutonomousTurn{Events: evOut, Result: result, Trigger: at.Trigger, CompletedTask: completed}
 			stream := &ccChanStream{ch: at.Events, sidFn: func() string { return at.SessionID }}
 			drainStream(stream, evOut, result, a)
 			if sid := stream.SessionID(); sid != "" {

--- a/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
@@ -49,6 +49,7 @@ func (r *Runtime) AutonomousTurns(sessionID int64) <-chan agentruntime.Autonomou
 					ToolUseID: at.CompletedTask.ToolUseID,
 					TaskID:    at.CompletedTask.TaskID,
 					Status:    at.CompletedTask.Status,
+					Summary:   at.CompletedTask.Summary,
 				}
 			}
 			// 先把这一轮交给 consumer(它并发 drain evOut),随后 inline 翻译填 evOut。

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -286,6 +286,70 @@ func TestAutonomousTurns_BridgesSessionAutoTurn(t *testing.T) {
 	})
 }
 
+// TestAutonomousTurns_BridgesCompletedTask 验证 Runtime.AutonomousTurns 把底层
+// claudecode.AutoTurn.CompletedTask 透传到 agentruntime.AutonomousTurn.CompletedTask。
+func TestAutonomousTurns_BridgesCompletedTask(t *testing.T) {
+	Convey("Runtime.AutonomousTurns 把 CompletedTask 透传", t, func() {
+		autoSrc := make(chan *claudecode.AutoTurn, 1)
+		restore := SetSessionFactoryForTest(func(ccLaunchSpec) (ccSessionHandle, error) {
+			return &fakeCCHandle{
+				id:        "fake-sid",
+				autoTurns: autoSrc,
+				stream: &eventCCStream{events: []claudecode.Event{
+					{Kind: claudecode.EventUsage, Usage: provider.Usage{PromptTokens: 1}},
+					{Kind: claudecode.EventDone},
+				}},
+			}, nil
+		})
+		defer restore()
+
+		r := New()
+		ctx := context.Background()
+		events, _, err := r.Run(ctx, agentruntime.RunRequest{
+			Backend:   &agent_backend_entity.AgentBackend{Type: string(agent_backend_entity.TypeClaudeCode)},
+			SessionID: 78,
+			Cwd:       t.TempDir(),
+			UserText:  "go",
+		})
+		So(err, ShouldBeNil)
+		for range events {
+		}
+
+		turns := r.AutonomousTurns(78)
+
+		atEvents := make(chan claudecode.Event, 2)
+		atEvents <- claudecode.Event{Kind: claudecode.EventDone}
+		close(atEvents)
+		autoSrc <- &claudecode.AutoTurn{
+			Events:    atEvents,
+			SessionID: "fake-sid",
+			Trigger:   "background_task",
+			CompletedTask: &claudecode.CompletedBackgroundTask{
+				ToolUseID: "tu1",
+				TaskID:    "task-1",
+				Status:    "completed",
+			},
+		}
+		close(autoSrc)
+
+		var got agentruntime.AutonomousTurn
+		select {
+		case got = <-turns:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a bridged autonomous turn within 2s")
+		}
+		// drain events
+		for range got.Events {
+		}
+		So(got.CompletedTask, ShouldNotBeNil)
+		So(got.CompletedTask.ToolUseID, ShouldEqual, "tu1")
+		So(got.CompletedTask.TaskID, ShouldEqual, "task-1")
+		So(got.CompletedTask.Status, ShouldEqual, "completed")
+
+		r.CloseAllSessions(ctx)
+	})
+}
+
 func TestRun_ErrorFollowedByProgressClearsStopErr(t *testing.T) {
 	Convey("claudecode runtime: EventError 后还有进展事件和完成时, StopErr 不应污染成功 turn", t, func() {
 		restore := SetSessionFactoryForTest(func(ccLaunchSpec) (ccSessionHandle, error) {

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -328,6 +328,7 @@ func TestAutonomousTurns_BridgesCompletedTask(t *testing.T) {
 				ToolUseID: "tu1",
 				TaskID:    "task-1",
 				Status:    "completed",
+				Summary:   "sum",
 			},
 		}
 		close(autoSrc)
@@ -345,6 +346,7 @@ func TestAutonomousTurns_BridgesCompletedTask(t *testing.T) {
 		So(got.CompletedTask.ToolUseID, ShouldEqual, "tu1")
 		So(got.CompletedTask.TaskID, ShouldEqual, "task-1")
 		So(got.CompletedTask.Status, ShouldEqual, "completed")
+		So(got.CompletedTask.Summary, ShouldEqual, "sum")
 
 		r.CloseAllSessions(ctx)
 	})

--- a/internal/pkg/agentruntime/runtimes/claudecode/translator.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/translator.go
@@ -316,6 +316,7 @@ func subagentInfoFromMeta(m *claudecode.SubagentMeta) agentruntime.SubagentInfo 
 	return agentruntime.SubagentInfo{
 		TaskID:          m.TaskID,
 		SubagentType:    m.SubagentType,
+		Kind:            m.TaskType,
 		TaskDescription: m.TaskDescription,
 		Prompt:          m.Prompt,
 		LastToolName:    m.LastToolName,

--- a/internal/pkg/agentruntime/runtimes/claudecode/translator_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/translator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cago-frame/agents/provider"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"agentre/internal/pkg/agentruntime"
 	"agentre/internal/pkg/agentruntime/canonical"
@@ -470,4 +471,10 @@ func TestTranslate_Usage_PerCallAnthropicFamily(t *testing.T) {
 		So(uu.TotalInputTokens, ShouldEqual, 1700) // 1000 + 500 + 200
 		So(uu.Usage.PromptTokens, ShouldEqual, 1000)
 	})
+}
+
+func TestSubagentInfoFromMeta_CarriesKind(t *testing.T) {
+	info := subagentInfoFromMeta(&claudecode.SubagentMeta{TaskType: "local_bash", TaskDescription: "sleep 5"})
+	assert.Equal(t, "local_bash", info.Kind)
+	assert.Equal(t, "sleep 5", info.TaskDescription)
 }

--- a/internal/repository/chat_repo/message.go
+++ b/internal/repository/chat_repo/message.go
@@ -29,8 +29,8 @@ type MessageRepo interface {
 	DeleteFromSeq(ctx context.Context, sessionID int64, fromSeq int) (int64, error)
 	// FlipSubagentStatus 定向把本会话里 parent_tool_call_id==toolUseID 的 subagent_state
 	// 块状态改成 status(后台 bash 在之后的自主轮才完成,无法走 per-turn accumulator)。
-	// 找不到则静默返回 nil(任务可能已 evict / 非本会话)。
-	FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error
+	// summary 非空时同时写入块的 summary 字段。找不到则静默返回 nil(任务可能已 evict / 非本会话)。
+	FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status, summary string) error
 }
 
 // flipSubagentScanLimit 是 FlipSubagentStatus 倒序扫描的最近 assistant 消息条数上限。
@@ -92,7 +92,7 @@ func (r *messageRepo) Find(ctx context.Context, id int64) (*chat_entity.Message,
 	return &m, nil
 }
 
-func (r *messageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error {
+func (r *messageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status, summary string) error {
 	if toolUseID == "" || status == "" {
 		return nil
 	}
@@ -109,7 +109,7 @@ func (r *messageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, t
 	}
 
 	for _, msg := range rows {
-		rewritten, flipped, err := FlipSubagentInBlocksJSON(msg.BlocksJSON, toolUseID, status)
+		rewritten, flipped, err := FlipSubagentInBlocksJSON(msg.BlocksJSON, toolUseID, status, summary)
 		if err != nil {
 			// 单条消息 blocks 损坏不应阻断其它消息;跳过继续找。
 			logger.Ctx(ctx).Warn("chat_repo.FlipSubagentStatus: decode blocks failed; skipping message",
@@ -129,13 +129,14 @@ func (r *messageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, t
 
 // FlipSubagentInBlocksJSON 在 blocks_json(StoredBlock 数组)里就地翻转 type=="subagent_state"
 // 且 data.parent_tool_call_id==toolUseID 的块的 status,返回重写后的 JSON + 是否命中。
-// 只触碰命中块的 status 字段,其余 data 原样保留;repo 层不依赖 service 的 block 类型,
+// summary 非空时同时写入命中块的 summary 字段。
+// 只触碰命中块的 status / summary 字段,其余 data 原样保留;repo 层不依赖 service 的 block 类型,
 // 只按 StoredBlock 信封 + 该块的少数已知字段操作。
 //
 // 解 data 用 json.Decoder + UseNumber():数字字段(total_tokens / duration_ms /
 // tool_uses)保持 json.Number,避免经 map[string]any 的 float64 强转把整数重写成
 // 科学计数(如 1e+04)。导出以便直接单测 JSON 改写逻辑。
-func FlipSubagentInBlocksJSON(blocksJSON, toolUseID, status string) (string, bool, error) {
+func FlipSubagentInBlocksJSON(blocksJSON, toolUseID, status, summary string) (string, bool, error) {
 	if blocksJSON == "" {
 		return blocksJSON, false, nil
 	}
@@ -158,6 +159,9 @@ func FlipSubagentInBlocksJSON(blocksJSON, toolUseID, status string) (string, boo
 			continue
 		}
 		data["status"] = status
+		if summary != "" {
+			data["summary"] = summary
+		}
 		buf, err := json.Marshal(data)
 		if err != nil {
 			return blocksJSON, false, err

--- a/internal/repository/chat_repo/message.go
+++ b/internal/repository/chat_repo/message.go
@@ -1,11 +1,16 @@
 package chat_repo
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
+	cagoblocks "github.com/cago-frame/agents/agent/blocks"
 	"github.com/cago-frame/cago/database/db"
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"agentre/internal/model/entity/chat_entity"
@@ -22,7 +27,15 @@ type MessageRepo interface {
 	// DeleteFromSeq 删除指定 session 下 seq >= fromSeq 的所有消息，返回被删除的行数。
 	// 用于「从第 N 条消息开始重新生成」时一次性截断后续记录。
 	DeleteFromSeq(ctx context.Context, sessionID int64, fromSeq int) (int64, error)
+	// FlipSubagentStatus 定向把本会话里 parent_tool_call_id==toolUseID 的 subagent_state
+	// 块状态改成 status(后台 bash 在之后的自主轮才完成,无法走 per-turn accumulator)。
+	// 找不到则静默返回 nil(任务可能已 evict / 非本会话)。
+	FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error
 }
+
+// flipSubagentScanLimit 是 FlipSubagentStatus 倒序扫描的最近 assistant 消息条数上限。
+// 后台 bash 完成的自主轮通常紧跟在发起它的那条消息之后,近窗足以命中。
+const flipSubagentScanLimit = 50
 
 var defaultMessage MessageRepo
 
@@ -77,6 +90,89 @@ func (r *messageRepo) Find(ctx context.Context, id int64) (*chat_entity.Message,
 		return nil, err
 	}
 	return &m, nil
+}
+
+func (r *messageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error {
+	if toolUseID == "" || status == "" {
+		return nil
+	}
+	logger.Ctx(ctx).Info("chat_repo.FlipSubagentStatus: flipping subagent_state status",
+		zap.Int64("sessionId", sessionID), zap.String("toolUseId", toolUseID), zap.String("status", status))
+
+	var rows []*chat_entity.Message
+	if err := db.Ctx(ctx).
+		Where("session_id = ? AND role = ?", sessionID, "assistant").
+		Order("seq DESC").
+		Limit(flipSubagentScanLimit).
+		Find(&rows).Error; err != nil {
+		return err
+	}
+
+	for _, msg := range rows {
+		rewritten, flipped, err := FlipSubagentInBlocksJSON(msg.BlocksJSON, toolUseID, status)
+		if err != nil {
+			// 单条消息 blocks 损坏不应阻断其它消息;跳过继续找。
+			logger.Ctx(ctx).Warn("chat_repo.FlipSubagentStatus: decode blocks failed; skipping message",
+				zap.Int64("messageId", msg.ID), zap.Error(err))
+			continue
+		}
+		if !flipped {
+			continue
+		}
+		msg.BlocksJSON = rewritten
+		return r.Update(ctx, msg)
+	}
+
+	// 没命中:任务可能已 evict / 非本会话,静默返回 nil。
+	return nil
+}
+
+// FlipSubagentInBlocksJSON 在 blocks_json(StoredBlock 数组)里就地翻转 type=="subagent_state"
+// 且 data.parent_tool_call_id==toolUseID 的块的 status,返回重写后的 JSON + 是否命中。
+// 只触碰命中块的 status 字段,其余 data 原样保留;repo 层不依赖 service 的 block 类型,
+// 只按 StoredBlock 信封 + 该块的少数已知字段操作。
+//
+// 解 data 用 json.Decoder + UseNumber():数字字段(total_tokens / duration_ms /
+// tool_uses)保持 json.Number,避免经 map[string]any 的 float64 强转把整数重写成
+// 科学计数(如 1e+04)。导出以便直接单测 JSON 改写逻辑。
+func FlipSubagentInBlocksJSON(blocksJSON, toolUseID, status string) (string, bool, error) {
+	if blocksJSON == "" {
+		return blocksJSON, false, nil
+	}
+	var stored []cagoblocks.StoredBlock
+	if err := json.Unmarshal([]byte(blocksJSON), &stored); err != nil {
+		return blocksJSON, false, err
+	}
+	flipped := false
+	for i := range stored {
+		if stored[i].Type != "subagent_state" {
+			continue
+		}
+		dec := json.NewDecoder(bytes.NewReader(stored[i].Data))
+		dec.UseNumber()
+		var data map[string]any
+		if err := dec.Decode(&data); err != nil {
+			return blocksJSON, false, err
+		}
+		if parent, _ := data["parent_tool_call_id"].(string); parent != toolUseID {
+			continue
+		}
+		data["status"] = status
+		buf, err := json.Marshal(data)
+		if err != nil {
+			return blocksJSON, false, err
+		}
+		stored[i].Data = buf
+		flipped = true
+	}
+	if !flipped {
+		return blocksJSON, false, nil
+	}
+	out, err := json.Marshal(stored)
+	if err != nil {
+		return blocksJSON, false, err
+	}
+	return string(out), true, nil
 }
 
 func (r *messageRepo) DeleteFromSeq(ctx context.Context, sessionID int64, fromSeq int) (int64, error) {

--- a/internal/repository/chat_repo/message_test.go
+++ b/internal/repository/chat_repo/message_test.go
@@ -25,7 +25,7 @@ func TestFlipSubagentInBlocksJSON(t *testing.T) {
 		`]`
 
 	t.Run("命中块翻转 status,其余字段全保留", func(t *testing.T) {
-		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu1", "completed")
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu1", "completed", "")
 		require.NoError(t, err)
 		assert.True(t, flipped)
 
@@ -47,22 +47,33 @@ func TestFlipSubagentInBlocksJSON(t *testing.T) {
 		assert.Contains(t, out, `{"type":"text","data":{"text":"hi"}}`)
 	})
 
+	t.Run("非空 summary 同时写入", func(t *testing.T) {
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu1", "completed", "Background command completed")
+		require.NoError(t, err)
+		assert.True(t, flipped)
+		outData := subagentData(t, out)
+		assert.Equal(t, "completed", outData["status"])
+		assert.Equal(t, "Background command completed", outData["summary"])
+		// 其余字段(数字/数组)未被破坏。
+		assert.Equal(t, json.Number("12345"), outData["total_tokens"])
+	})
+
 	t.Run("无命中块返回 false 且 JSON 不变", func(t *testing.T) {
-		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu-missing", "completed")
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu-missing", "completed", "")
 		require.NoError(t, err)
 		assert.False(t, flipped)
 		assert.Equal(t, input, out)
 	})
 
 	t.Run("空 JSON 返回 false 不报错", func(t *testing.T) {
-		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON("", "tu1", "completed")
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON("", "tu1", "completed", "")
 		require.NoError(t, err)
 		assert.False(t, flipped)
 		assert.Equal(t, "", out)
 	})
 
 	t.Run("非法 JSON 返回 error", func(t *testing.T) {
-		_, flipped, err := chat_repo.FlipSubagentInBlocksJSON("{not json", "tu1", "completed")
+		_, flipped, err := chat_repo.FlipSubagentInBlocksJSON("{not json", "tu1", "completed", "")
 		require.Error(t, err)
 		assert.False(t, flipped)
 	})
@@ -216,7 +227,7 @@ func TestMessageRepo_FlipSubagentStatus_FlipsMatchingBlock(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu1", "completed")
+	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu1", "completed", "Background command completed")
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -230,7 +241,7 @@ func TestMessageRepo_FlipSubagentStatus_NoMatchSilentNil(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "session_id", "role", "blocks_json", "seq"}).
 			AddRow(42, 3, "assistant", `[{"type":"text","data":{"text":"hi"}}]`, 4))
 
-	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu-missing", "completed")
+	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu-missing", "completed", "")
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/repository/chat_repo/message_test.go
+++ b/internal/repository/chat_repo/message_test.go
@@ -1,15 +1,95 @@
 package chat_repo_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cago-frame/cago/pkg/utils/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"agentre/internal/model/entity/chat_entity"
 	"agentre/internal/repository/chat_repo"
 )
+
+// TestFlipSubagentInBlocksJSON 直接单测 JSON 改写核心:翻转命中块的 status,其余字段
+// (含 total_tokens/duration_ms/tool_uses 数字 + nested_tool_call_ids 数组)字节级保留,
+// 防 float64 强转把整数写成 1e+03 之类。
+func TestFlipSubagentInBlocksJSON(t *testing.T) {
+	// 一条 subagent_state(running,带数字 + 数组字段)+ 一条 text。
+	const input = `[` +
+		`{"type":"subagent_state","data":{"parent_tool_call_id":"tu1","kind":"local_bash","description":"sleep 20","total_tokens":12345,"duration_ms":6789,"status":"running","tool_uses":42,"nested_tool_call_ids":["n1","n2"]}},` +
+		`{"type":"text","data":{"text":"hi"}}` +
+		`]`
+
+	t.Run("命中块翻转 status,其余字段全保留", func(t *testing.T) {
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu1", "completed")
+		require.NoError(t, err)
+		assert.True(t, flipped)
+
+		inData := subagentData(t, input)
+		outData := subagentData(t, out)
+
+		// status 翻成 completed。
+		assert.Equal(t, "completed", outData["status"])
+		// 其余字段逐项保留(数字仍是整数语义,数组仍是数组)—— 删掉 status 后 deep-equal。
+		delete(inData, "status")
+		delete(outData, "status")
+		assert.Equal(t, inData, outData)
+		// 显式校验数字 / 数组没被破坏(json.Number 比较,排除 1e+04 之类科学计数)。
+		assert.Equal(t, json.Number("12345"), outData["total_tokens"])
+		assert.Equal(t, json.Number("6789"), outData["duration_ms"])
+		assert.Equal(t, json.Number("42"), outData["tool_uses"])
+		assert.Equal(t, []any{"n1", "n2"}, outData["nested_tool_call_ids"])
+		// 非命中块(text)原样保留。
+		assert.Contains(t, out, `{"type":"text","data":{"text":"hi"}}`)
+	})
+
+	t.Run("无命中块返回 false 且 JSON 不变", func(t *testing.T) {
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON(input, "tu-missing", "completed")
+		require.NoError(t, err)
+		assert.False(t, flipped)
+		assert.Equal(t, input, out)
+	})
+
+	t.Run("空 JSON 返回 false 不报错", func(t *testing.T) {
+		out, flipped, err := chat_repo.FlipSubagentInBlocksJSON("", "tu1", "completed")
+		require.NoError(t, err)
+		assert.False(t, flipped)
+		assert.Equal(t, "", out)
+	})
+
+	t.Run("非法 JSON 返回 error", func(t *testing.T) {
+		_, flipped, err := chat_repo.FlipSubagentInBlocksJSON("{not json", "tu1", "completed")
+		require.Error(t, err)
+		assert.False(t, flipped)
+	})
+}
+
+// subagentData 解出 blocksJSON 里第一个 subagent_state 块的 data map(数字按
+// json.Number 保留,以便检测整数是否被破坏)。
+func subagentData(t *testing.T, blocksJSON string) map[string]any {
+	t.Helper()
+	var stored []struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(blocksJSON), &stored))
+	for _, sb := range stored {
+		if sb.Type != "subagent_state" {
+			continue
+		}
+		dec := json.NewDecoder(bytes.NewReader(sb.Data))
+		dec.UseNumber()
+		var data map[string]any
+		require.NoError(t, dec.Decode(&data))
+		return data
+	}
+	t.Fatalf("no subagent_state block in %s", blocksJSON)
+	return nil
+}
 
 func TestMessageRepo_List(t *testing.T) {
 	ctx, _, mock := testutils.Database(t)
@@ -101,6 +181,57 @@ func TestMessageRepo_DeleteFromSeq(t *testing.T) {
 	deleted, err := chat_repo.NewMessage().DeleteFromSeq(ctx, 3, 5)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), deleted)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMessageRepo_FlipSubagentStatus_FlipsMatchingBlock(t *testing.T) {
+	ctx, _, mock := testutils.Database(t)
+
+	blocksJSON := `[{"type":"subagent_state","data":{"parent_tool_call_id":"tu1","kind":"local_bash","description":"sleep 20","status":"running"}}]`
+
+	// 倒序拉近 N 条 assistant 消息。
+	mock.ExpectQuery("SELECT \\* FROM `chat_messages` WHERE session_id = \\? AND role = \\? ORDER BY seq DESC LIMIT \\?").
+		WithArgs(int64(3), "assistant", 50).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "session_id", "role", "blocks_json", "seq"}).
+			AddRow(42, 3, "assistant", blocksJSON, 4))
+
+	// 命中后重写该条:status 翻成 completed。
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `chat_messages` SET ").
+		WithArgs(
+			sqlmock.AnyArg(),                                                                         // session_id
+			sqlmock.AnyArg(),                                                                         // device_id
+			sqlmock.AnyArg(),                                                                         // role
+			sqlmock.AnyArg(),                                                                         // blocks_json (翻转后)
+			sqlmock.AnyArg(),                                                                         // model
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), // token 列
+			sqlmock.AnyArg(),                   // total_input_tokens
+			sqlmock.AnyArg(),                   // duration_ms
+			sqlmock.AnyArg(),                   // fork_anchor
+			sqlmock.AnyArg(),                   // error_text
+			sqlmock.AnyArg(),                   // seq
+			sqlmock.AnyArg(), sqlmock.AnyArg(), // createtime / updatetime
+			int64(42), // WHERE id
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu1", "completed")
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMessageRepo_FlipSubagentStatus_NoMatchSilentNil(t *testing.T) {
+	ctx, _, mock := testutils.Database(t)
+
+	// 没有任何 subagent_state 命中 → 不写库,静默返回 nil。
+	mock.ExpectQuery("SELECT \\* FROM `chat_messages` WHERE session_id = \\? AND role = \\? ORDER BY seq DESC LIMIT \\?").
+		WithArgs(int64(3), "assistant", 50).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "session_id", "role", "blocks_json", "seq"}).
+			AddRow(42, 3, "assistant", `[{"type":"text","data":{"text":"hi"}}]`, 4))
+
+	err := chat_repo.NewMessage().FlipSubagentStatus(ctx, 3, "tu-missing", "completed")
+	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/repository/chat_repo/mock_chat_repo/mock_message.go
+++ b/internal/repository/chat_repo/mock_chat_repo/mock_message.go
@@ -86,17 +86,17 @@ func (mr *MockMessageRepoMockRecorder) Find(ctx, id any) *gomock.Call {
 }
 
 // FlipSubagentStatus mocks base method.
-func (m *MockMessageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error {
+func (m *MockMessageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status, summary string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FlipSubagentStatus", ctx, sessionID, toolUseID, status)
+	ret := m.ctrl.Call(m, "FlipSubagentStatus", ctx, sessionID, toolUseID, status, summary)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FlipSubagentStatus indicates an expected call of FlipSubagentStatus.
-func (mr *MockMessageRepoMockRecorder) FlipSubagentStatus(ctx, sessionID, toolUseID, status any) *gomock.Call {
+func (mr *MockMessageRepoMockRecorder) FlipSubagentStatus(ctx, sessionID, toolUseID, status, summary any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlipSubagentStatus", reflect.TypeOf((*MockMessageRepo)(nil).FlipSubagentStatus), ctx, sessionID, toolUseID, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlipSubagentStatus", reflect.TypeOf((*MockMessageRepo)(nil).FlipSubagentStatus), ctx, sessionID, toolUseID, status, summary)
 }
 
 // List mocks base method.

--- a/internal/repository/chat_repo/mock_chat_repo/mock_message.go
+++ b/internal/repository/chat_repo/mock_chat_repo/mock_message.go
@@ -85,6 +85,20 @@ func (mr *MockMessageRepoMockRecorder) Find(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockMessageRepo)(nil).Find), ctx, id)
 }
 
+// FlipSubagentStatus mocks base method.
+func (m *MockMessageRepo) FlipSubagentStatus(ctx context.Context, sessionID int64, toolUseID, status string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlipSubagentStatus", ctx, sessionID, toolUseID, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FlipSubagentStatus indicates an expected call of FlipSubagentStatus.
+func (mr *MockMessageRepoMockRecorder) FlipSubagentStatus(ctx, sessionID, toolUseID, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlipSubagentStatus", reflect.TypeOf((*MockMessageRepo)(nil).FlipSubagentStatus), ctx, sessionID, toolUseID, status)
+}
+
 // List mocks base method.
 func (m *MockMessageRepo) List(ctx context.Context, sessionID int64) ([]*chat_entity.Message, error) {
 	m.ctrl.T.Helper()

--- a/internal/service/chat_svc/autonomous_turn.go
+++ b/internal/service/chat_svc/autonomous_turn.go
@@ -14,6 +14,7 @@ import (
 	"agentre/internal/model/entity/chat_entity"
 	"agentre/internal/pkg/agentruntime"
 	"agentre/internal/repository/chat_repo"
+	"agentre/internal/service/chat_svc/handlers"
 	"agentre/internal/service/chat_svc/turn"
 )
 
@@ -92,6 +93,18 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 		return
 	}
 
+	// 若本自主轮由后台命令完成触发,带上完成任务身份,供前端即时翻转上一条消息里
+	// 的 subagent_state 块,并在收尾后落库定向翻转。remote 转发当前不携带 CompletedTask
+	// (v1 已知限制),此处对 nil/空 ToolUseID 全程 no-op。
+	var completedRef *CompletedTaskRef
+	if at.CompletedTask != nil && at.CompletedTask.ToolUseID != "" {
+		st := at.CompletedTask.Status
+		if st == "" {
+			st = "completed"
+		}
+		completedRef = &CompletedTaskRef{ToolUseID: at.CompletedTask.ToolUseID, Status: st}
+	}
+
 	stream := StreamName(sessionID, assistantMsg.ID)
 	logger.Ctx(ctx).Info("chat_svc: autonomous turn started",
 		zap.Int64("sessionId", sessionID),
@@ -103,6 +116,7 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 		Stream:           stream,
 		Trigger:          at.Trigger,
 		AssistantMessage: chatMessageForEvent(sess, assistantMsg),
+		CompletedTask:    completedRef,
 	})
 
 	acc := turn.New()
@@ -119,6 +133,11 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 	}
 
 	finalBlocks := acc.Finalize()
+	// 镜像 Send 路径(chat.go):本自主轮结束时仍 running 的 subagent(没等到
+	// SubagentDone,如轮被中断)翻成 "canceled",否则原样落 DB 让前端后台任务芯片
+	// 永远 spin。只动本轮 finalBlocks,不碰更早消息里的后台 bash 块(那条由
+	// FlipSubagentStatus 定向翻转)。
+	handlers.MarkRunningSubagentsCancelled(finalBlocks)
 	_ = assistantMsg.SetBlocks(finalBlocks)
 	if at.Result != nil {
 		if at.Result.Usage != nil {
@@ -147,6 +166,18 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 		zap.Int64("sessionId", sessionID),
 		zap.Int64("assistantMsgId", assistantMsg.ID),
 		zap.String("agentStatus", sess.AgentStatus))
+
+	// 后台命令在本自主轮才完成:它发起的 subagent_state 块住在更早的消息里,过不了
+	// per-turn accumulator,只能定向重写持久化态。completedRef 为 nil(含 remote
+	// 不携带 CompletedTask 的情形)时跳过。
+	if completedRef != nil {
+		if err := chat_repo.Message().FlipSubagentStatus(finalCtx, sessionID, completedRef.ToolUseID, completedRef.Status); err != nil {
+			logger.Ctx(finalCtx).Warn("chat_svc.driveAutonomousTurn: FlipSubagentStatus failed",
+				zap.Int64("sessionId", sessionID),
+				zap.String("toolUseId", completedRef.ToolUseID),
+				zap.Error(err))
+		}
+	}
 
 	final := chatMessageForEvent(sess, assistantMsg)
 	s.emitter.Emit(finalCtx, stream, ChatStreamEvent{Kind: StreamDone, Message: final})

--- a/internal/service/chat_svc/autonomous_turn.go
+++ b/internal/service/chat_svc/autonomous_turn.go
@@ -102,7 +102,11 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 		if st == "" {
 			st = "completed"
 		}
-		completedRef = &CompletedTaskRef{ToolUseID: at.CompletedTask.ToolUseID, Status: st}
+		completedRef = &CompletedTaskRef{
+			ToolUseID: at.CompletedTask.ToolUseID,
+			Status:    st,
+			Summary:   at.CompletedTask.Summary,
+		}
 	}
 
 	stream := StreamName(sessionID, assistantMsg.ID)
@@ -171,7 +175,7 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 	// per-turn accumulator,只能定向重写持久化态。completedRef 为 nil(含 remote
 	// 不携带 CompletedTask 的情形)时跳过。
 	if completedRef != nil {
-		if err := chat_repo.Message().FlipSubagentStatus(finalCtx, sessionID, completedRef.ToolUseID, completedRef.Status); err != nil {
+		if err := chat_repo.Message().FlipSubagentStatus(finalCtx, sessionID, completedRef.ToolUseID, completedRef.Status, completedRef.Summary); err != nil {
 			logger.Ctx(finalCtx).Warn("chat_svc.driveAutonomousTurn: FlipSubagentStatus failed",
 				zap.Int64("sessionId", sessionID),
 				zap.String("toolUseId", completedRef.ToolUseID),

--- a/internal/service/chat_svc/autonomous_turn_test.go
+++ b/internal/service/chat_svc/autonomous_turn_test.go
@@ -166,9 +166,9 @@ func TestDriveAutonomousTurn_BackgroundTaskCompletionFlipsAndEmits(t *testing.T)
 		m.dbMock.ExpectCommit()
 		m.message.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		// 关键断言:finalize 后定向翻转上一条消息里的 subagent_state。
+		// 关键断言:finalize 后定向翻转上一条消息里的 subagent_state（含 summary）。
 		m.message.EXPECT().
-			FlipSubagentStatus(gomock.Any(), int64(100), "tu1", "completed").
+			FlipSubagentStatus(gomock.Any(), int64(100), "tu1", "completed", "Background command completed").
 			Return(nil).Times(1)
 
 		evs := make(chan agentruntime.Event, 1)
@@ -181,6 +181,7 @@ func TestDriveAutonomousTurn_BackgroundTaskCompletionFlipsAndEmits(t *testing.T)
 			CompletedTask: &agentruntime.CompletedBackgroundTask{
 				ToolUseID: "tu1",
 				Status:    "completed",
+				Summary:   "Background command completed",
 			},
 		}
 
@@ -198,11 +199,12 @@ func TestDriveAutonomousTurn_BackgroundTaskCompletionFlipsAndEmits(t *testing.T)
 			}
 		}
 
-		convey.Convey("emit 的 StreamAutonomousStarted 携带 CompletedTask 身份", func() {
+		convey.Convey("emit 的 StreamAutonomousStarted 携带 CompletedTask 身份(含 summary)", func() {
 			require.NotNil(t, started, "应 emit StreamAutonomousStarted")
 			require.NotNil(t, started.CompletedTask, "应携带 CompletedTask")
 			assert.Equal(t, "tu1", started.CompletedTask.ToolUseID)
 			assert.Equal(t, "completed", started.CompletedTask.Status)
+			assert.Equal(t, "Background command completed", started.CompletedTask.Summary)
 		})
 	})
 }

--- a/internal/service/chat_svc/autonomous_turn_test.go
+++ b/internal/service/chat_svc/autonomous_turn_test.go
@@ -2,6 +2,7 @@ package chat_svc_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -138,6 +139,153 @@ func TestDriveAutonomousTurn_PersistsPureAssistantTurn(t *testing.T) {
 			assert.Equal(t, "idle", sess.AgentStatus)
 		})
 	})
+}
+
+// TestDriveAutonomousTurn_BackgroundTaskCompletionFlipsAndEmits 验证 Phase 3:
+// 自主轮带 CompletedTask 时,(a) emit 的 StreamAutonomousStarted 携带 CompletedTask
+// 身份(toolUseId+status),(b) finalize 后定向调 FlipSubagentStatus 把上一条消息里
+// 的 subagent_state 块翻成 completed。
+func TestDriveAutonomousTurn_BackgroundTaskCompletionFlipsAndEmits(t *testing.T) {
+	convey.Convey("后台任务完成的自主轮回流完成 + 定向翻转", t, func() {
+		m := setupChatTest(t)
+		ctx := m.ctx
+
+		sess := &chat_entity.Session{ID: 100, AgentID: 7, AgentStatus: "idle", ProviderSessionID: "sess-abc"}
+		be := &agent_backend_entity.AgentBackend{ID: 12, Type: "claudecode"}
+
+		m.session.EXPECT().Find(gomock.Any(), int64(100)).Return(sess, nil).AnyTimes()
+
+		m.dbMock.ExpectBegin()
+		m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(5, nil)
+		m.message.EXPECT().Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, msg *chat_entity.Message) error {
+				msg.ID = 2001
+				return nil
+			}).Times(1)
+		m.session.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		m.dbMock.ExpectCommit()
+		m.message.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		// 关键断言:finalize 后定向翻转上一条消息里的 subagent_state。
+		m.message.EXPECT().
+			FlipSubagentStatus(gomock.Any(), int64(100), "tu1", "completed").
+			Return(nil).Times(1)
+
+		evs := make(chan agentruntime.Event, 1)
+		evs <- agentruntime.TextDelta{Text: "autonomous:done"}
+		close(evs)
+		at := agentruntime.AutonomousTurn{
+			Events:  evs,
+			Result:  &agentruntime.RunResult{ProviderSessionID: "sess-abc"},
+			Trigger: "background_task",
+			CompletedTask: &agentruntime.CompletedBackgroundTask{
+				ToolUseID: "tu1",
+				Status:    "completed",
+			},
+		}
+
+		chat_svc.DriveAutonomousTurnForTest(ctx, m.svc, 100, be, at)
+
+		var started *chat_svc.ChatStreamEvent
+		for _, ev := range m.events {
+			p, ok := ev.Payload.(chat_svc.ChatStreamEvent)
+			if !ok {
+				continue
+			}
+			if p.Kind == chat_svc.StreamAutonomousStarted {
+				cp := p
+				started = &cp
+			}
+		}
+
+		convey.Convey("emit 的 StreamAutonomousStarted 携带 CompletedTask 身份", func() {
+			require.NotNil(t, started, "应 emit StreamAutonomousStarted")
+			require.NotNil(t, started.CompletedTask, "应携带 CompletedTask")
+			assert.Equal(t, "tu1", started.CompletedTask.ToolUseID)
+			assert.Equal(t, "completed", started.CompletedTask.Status)
+		})
+	})
+}
+
+// TestDriveAutonomousTurn_CancelsInFlightSubagent 验证 Fix 2:自主轮结束时仍 running
+// 的 subagent_state(没等到 SubagentDone)被翻成 "canceled" 落库,镜像 Send 路径的
+// MarkRunningSubagentsCancelled,避免后台任务芯片永远 spin。
+func TestDriveAutonomousTurn_CancelsInFlightSubagent(t *testing.T) {
+	convey.Convey("自主轮收尾把 in-flight subagent 翻成 canceled", t, func() {
+		m := setupChatTest(t)
+		ctx := m.ctx
+
+		sess := &chat_entity.Session{ID: 100, AgentID: 7, AgentStatus: "idle", ProviderSessionID: "sess-abc"}
+		be := &agent_backend_entity.AgentBackend{ID: 12, Type: "claudecode"}
+
+		m.session.EXPECT().Find(gomock.Any(), int64(100)).Return(sess, nil).AnyTimes()
+
+		m.dbMock.ExpectBegin()
+		m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(5, nil)
+		m.message.EXPECT().Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, msg *chat_entity.Message) error {
+				msg.ID = 2001
+				return nil
+			}).Times(1)
+		m.session.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		m.dbMock.ExpectCommit()
+
+		// 捕获最终落库的 blocks_json(收尾 Update)。
+		var finalBlocksJSON string
+		m.message.EXPECT().Update(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, msg *chat_entity.Message) error {
+				finalBlocksJSON = msg.BlocksJSON
+				return nil
+			}).AnyTimes()
+
+		// 事件流:起一个 subagent,但没有对应 SubagentDone → 块停在 running。
+		evs := make(chan agentruntime.Event, 2)
+		evs <- agentruntime.SubagentStarted{
+			ToolCallID: "sub-1",
+			Info:       agentruntime.SubagentInfo{Kind: "local_agent", TaskDescription: "do work"},
+		}
+		evs <- agentruntime.TextDelta{Text: "working"}
+		close(evs)
+		at := agentruntime.AutonomousTurn{
+			Events:  evs,
+			Result:  &agentruntime.RunResult{ProviderSessionID: "sess-abc"},
+			Trigger: "background_task",
+		}
+
+		chat_svc.DriveAutonomousTurnForTest(ctx, m.svc, 100, be, at)
+
+		convey.Convey("in-flight subagent_state 落库为 canceled 而非 running", func() {
+			require.NotEmpty(t, finalBlocksJSON, "应落库 assistant blocks")
+			st := subagentStatusInBlocks(t, finalBlocksJSON, "sub-1")
+			assert.Equal(t, "canceled", st)
+		})
+	})
+}
+
+// subagentStatusInBlocks 从 blocks_json 里取 parent_tool_call_id==toolUseID 的
+// subagent_state 块的 status。
+func subagentStatusInBlocks(t *testing.T, blocksJSON, toolUseID string) string {
+	t.Helper()
+	var stored []struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(blocksJSON), &stored))
+	for _, sb := range stored {
+		if sb.Type != "subagent_state" {
+			continue
+		}
+		var data struct {
+			ParentToolCallID string `json:"parent_tool_call_id"`
+			Status           string `json:"status"`
+		}
+		require.NoError(t, json.Unmarshal(sb.Data, &data))
+		if data.ParentToolCallID == toolUseID {
+			return data.Status
+		}
+	}
+	t.Fatalf("no subagent_state block for %s in %s", toolUseID, blocksJSON)
+	return ""
 }
 
 // TestStartAutonomousWatcher_DedupesAndExitsOnClose 验证 watcher 生命周期:每会话

--- a/internal/service/chat_svc/blocks/subagent_state.go
+++ b/internal/service/chat_svc/blocks/subagent_state.go
@@ -9,6 +9,8 @@ import cagoblocks "github.com/cago-frame/agents/agent/blocks"
 type SubagentStateBlock struct {
 	ParentToolCallID  string   `json:"parent_tool_call_id"`
 	TaskID            string   `json:"task_id,omitempty"`
+	Kind              string   `json:"kind,omitempty"`        // local_bash | local_agent
+	Description       string   `json:"description,omitempty"` // 任务名（task_started.description）
 	TotalTokens       int      `json:"total_tokens,omitempty"`
 	DurationMs        int      `json:"duration_ms,omitempty"`
 	Status            string   `json:"status"` // running | completed | failed | canceled

--- a/internal/service/chat_svc/blocks/subagent_state.go
+++ b/internal/service/chat_svc/blocks/subagent_state.go
@@ -13,7 +13,7 @@ type SubagentStateBlock struct {
 	Description       string   `json:"description,omitempty"` // 任务名（task_started.description）
 	TotalTokens       int      `json:"total_tokens,omitempty"`
 	DurationMs        int      `json:"duration_ms,omitempty"`
-	Status            string   `json:"status"` // running | completed | failed | canceled
+	Status            string   `json:"status"`            // running | completed | failed | canceled
 	Summary           string   `json:"summary,omitempty"` // CLI task_notification.summary（如退出码说明）
 	LastToolName      string   `json:"last_tool_name,omitempty"`
 	ToolUses          int      `json:"tool_uses,omitempty"`

--- a/internal/service/chat_svc/blocks/subagent_state.go
+++ b/internal/service/chat_svc/blocks/subagent_state.go
@@ -14,6 +14,7 @@ type SubagentStateBlock struct {
 	TotalTokens       int      `json:"total_tokens,omitempty"`
 	DurationMs        int      `json:"duration_ms,omitempty"`
 	Status            string   `json:"status"` // running | completed | failed | canceled
+	Summary           string   `json:"summary,omitempty"` // CLI task_notification.summary（如退出码说明）
 	LastToolName      string   `json:"last_tool_name,omitempty"`
 	ToolUses          int      `json:"tool_uses,omitempty"`
 	NestedToolCallIDs []string `json:"nested_tool_call_ids,omitempty"`

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -595,6 +595,22 @@ func toChatMessage(m *chat_entity.Message) (ChatMessage, error) {
 		Createtime:          m.Createtime,
 		Blocks:              make([]ChatBlock, 0, len(bs)),
 	}
+	// 预扫一遍,把 SubagentStateBlock 按 ParentToolCallID 索引起来,
+	// 后续 tool_use 命中时把元数据合入 .Subagent,实现持久化/重载路径与
+	// live 路径(dispatcher_emitter mergeSubagentMeta)形态一致。
+	subByParent := make(map[string]*chatblocks.SubagentStateBlock)
+	for _, b := range bs {
+		switch sb := b.(type) {
+		case chatblocks.SubagentStateBlock:
+			cp := sb
+			subByParent[sb.ParentToolCallID] = &cp
+		case *chatblocks.SubagentStateBlock:
+			if sb != nil {
+				subByParent[sb.ParentToolCallID] = sb
+			}
+		}
+	}
+
 	for _, b := range bs {
 		switch tb := b.(type) {
 		case blocks.TextBlock:
@@ -612,9 +628,17 @@ func toChatMessage(m *chat_entity.Message) (ChatMessage, error) {
 		case *blocks.ThinkingBlock:
 			out.Blocks = append(out.Blocks, ChatBlock{Type: "thinking", Text: tb.Text})
 		case blocks.ToolUseBlock:
-			out.Blocks = append(out.Blocks, toolUseToChatBlock(tb.ID, tb.Name, tb.Input))
+			cb := toolUseToChatBlock(tb.ID, tb.Name, tb.Input)
+			if sb := subByParent[tb.ID]; sb != nil {
+				cb.Subagent = subagentStateToChatBlockSubagent(sb)
+			}
+			out.Blocks = append(out.Blocks, cb)
 		case *blocks.ToolUseBlock:
-			out.Blocks = append(out.Blocks, toolUseToChatBlock(tb.ID, tb.Name, tb.Input))
+			cb := toolUseToChatBlock(tb.ID, tb.Name, tb.Input)
+			if sb := subByParent[tb.ID]; sb != nil {
+				cb.Subagent = subagentStateToChatBlockSubagent(sb)
+			}
+			out.Blocks = append(out.Blocks, cb)
 		case blocks.ToolResultBlock:
 			out.Blocks = append(out.Blocks, toolResultToChatBlock(tb.ToolUseID, tb.Content, tb.IsError))
 		case *blocks.ToolResultBlock:
@@ -629,12 +653,9 @@ func toChatMessage(m *chat_entity.Message) (ChatMessage, error) {
 			out.Blocks = append(out.Blocks, nestedToolResultToChatBlock(&tb))
 		case *chatblocks.SubagentStateBlock, chatblocks.SubagentStateBlock,
 			*chatblocks.PermissionModeChangeBlock, chatblocks.PermissionModeChangeBlock:
-			// SubagentStateBlock: 累计态(tokens/duration/status),前端 AgentSpawnCard
-			// 通过外层 Task tool 的 canonical.agentSpawn 读 —— live 路径靠
-			// dispatcher_emitter 注入,replay 不重算,STEPS / SUMMARY 仍完整,
-			// 只是 badge 缺失(明确接受)。
-			// PermissionModeChangeBlock: 审计 block,无 UI 元素。两者一并 skip,
-			// 不下行到前端(否则会被打成 type=unknown 让用户看到 debug 卡)。
+			// SubagentStateBlock: 元数据已在预扫阶段合入对应 tool_use 块的 .Subagent 字段,
+			// 不再作为独立 block 下行前端(否则会被打成 type=unknown 让用户看到 debug 卡)。
+			// PermissionModeChangeBlock: 审计 block,无 UI 元素,一并 skip。
 		case *chatblocks.CompactBoundaryBlock:
 			if tb != nil {
 				out.Blocks = append(out.Blocks, ChatBlock{
@@ -685,6 +706,22 @@ func toolUseToChatBlock(id, name string, input map[string]any) ChatBlock {
 		cb.Canonical = view.FromCanonical(c)
 	}
 	return cb
+}
+
+func subagentStateToChatBlockSubagent(sb *chatblocks.SubagentStateBlock) *ChatBlockSubagent {
+	if sb == nil {
+		return nil
+	}
+	return &ChatBlockSubagent{
+		TaskID:          sb.TaskID,
+		Kind:            sb.Kind,
+		TaskDescription: sb.Description,
+		LastToolName:    sb.LastToolName,
+		ToolUses:        sb.ToolUses,
+		TotalTokens:     sb.TotalTokens,
+		DurationMs:      sb.DurationMs,
+		Status:          sb.Status,
+	}
 }
 
 func imageBlockToChatBlock(img blocks.ImageBlock) ChatBlock {

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -721,6 +721,7 @@ func subagentStateToChatBlockSubagent(sb *chatblocks.SubagentStateBlock) *ChatBl
 		TotalTokens:     sb.TotalTokens,
 		DurationMs:      sb.DurationMs,
 		Status:          sb.Status,
+		Summary:         sb.Summary,
 	}
 }
 

--- a/internal/service/chat_svc/chat_internal_test.go
+++ b/internal/service/chat_svc/chat_internal_test.go
@@ -162,6 +162,65 @@ func TestToChatMessage_SkipsSubagentStateAndPermissionModeChange(t *testing.T) {
 	assert.Equal(t, "after", cm.Blocks[1].Text)
 }
 
+// TestToChatMessage_SubagentStateMergedOntoToolUseBlock 回归后台任务跨轮/重载后
+// 不可见的问题:SubagentStateBlock 的元数据必须附到匹配的 tool_use ChatBlock 的
+// .Subagent 字段上,不能再作为独立 block 下行前端(否则出 debug 卡)。
+func TestToChatMessage_SubagentStateMergedOntoToolUseBlock(t *testing.T) {
+	m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
+	require.NoError(t, m.SetBlocks([]blocks.ContentBlock{
+		blocks.ToolUseBlock{ID: "tu1", Name: "Bash", Input: map[string]any{"command": "sleep 20"}},
+		chatblocks.SubagentStateBlock{
+			ParentToolCallID: "tu1",
+			Kind:             "local_bash",
+			Description:      "sleep 20",
+			Status:           "running",
+			TaskID:           "task-abc",
+			TotalTokens:      100,
+			DurationMs:       500,
+			LastToolName:     "computer",
+			ToolUses:         3,
+		},
+	}))
+
+	cm, err := toChatMessage(m)
+	require.NoError(t, err)
+	// 只有 1 个 block(tool_use),不能有独立的 subagent_state 或 unknown 卡。
+	require.Len(t, cm.Blocks, 1, "SubagentStateBlock 不能作为独立 block 下行,只能合入 tool_use")
+
+	tb := cm.Blocks[0]
+	assert.Equal(t, "tool_use", tb.Type)
+	assert.Equal(t, "tu1", tb.ToolUseID)
+
+	require.NotNil(t, tb.Subagent, "tool_use 块必须携带 .Subagent 元数据")
+	assert.Equal(t, "local_bash", tb.Subagent.Kind)
+	assert.Equal(t, "sleep 20", tb.Subagent.TaskDescription)
+	assert.Equal(t, "running", tb.Subagent.Status)
+	assert.Equal(t, "task-abc", tb.Subagent.TaskID)
+	assert.Equal(t, 100, tb.Subagent.TotalTokens)
+	assert.Equal(t, 500, tb.Subagent.DurationMs)
+	assert.Equal(t, "computer", tb.Subagent.LastToolName)
+	assert.Equal(t, 3, tb.Subagent.ToolUses)
+}
+
+// TestToChatMessage_SubagentStateWithNoMatchingToolUse 无匹配 tool_use 时
+// SubagentStateBlock 仍然被 skip(不产生独立 block)。
+func TestToChatMessage_SubagentStateWithNoMatchingToolUse(t *testing.T) {
+	m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
+	require.NoError(t, m.SetBlocks([]blocks.ContentBlock{
+		blocks.TextBlock{Text: "hello"},
+		chatblocks.SubagentStateBlock{
+			ParentToolCallID: "no-match",
+			Kind:             "local_bash",
+			Status:           "completed",
+		},
+	}))
+
+	cm, err := toChatMessage(m)
+	require.NoError(t, err)
+	require.Len(t, cm.Blocks, 1, "无匹配 tool_use 时 SubagentStateBlock 仍 skip")
+	assert.Equal(t, "text", cm.Blocks[0].Type)
+}
+
 func TestToChatMessage_UnknownBlockFallback(t *testing.T) {
 	m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
 	// NoticeBlock has Audience=ToUI; toChatMessage doesn't have a dedicated case for it,

--- a/internal/service/chat_svc/handlers/subagent.go
+++ b/internal/service/chat_svc/handlers/subagent.go
@@ -33,6 +33,8 @@ func (SubagentStartedHandler) Apply(ctx context.Context, ev agentruntime.Event, 
 	r := ev.(agentruntime.SubagentStarted)
 	blk := &blocks.SubagentStateBlock{
 		ParentToolCallID: r.ToolCallID,
+		Kind:             r.Info.Kind,
+		Description:      r.Info.TaskDescription,
 		Status:           "running",
 	}
 	acc.AddBlock(blk, "subagent_state:"+r.ToolCallID)

--- a/internal/service/chat_svc/handlers/subagent_test.go
+++ b/internal/service/chat_svc/handlers/subagent_test.go
@@ -36,6 +36,28 @@ func TestSubagentLifecycle(t *testing.T) {
 	})
 }
 
+func TestSubagentStarted_PersistsKindAndDescription(t *testing.T) {
+	Convey("SubagentStarted 落 kind/description + running", t, func() {
+		acc := turn.New()
+		err := SubagentStartedHandler{}.Apply(context.Background(),
+			agentruntime.SubagentStarted{
+				ToolCallID: "tu1",
+				Info: agentruntime.SubagentInfo{
+					Kind:            "local_bash",
+					TaskDescription: "sleep 20",
+				},
+			}, acc, nil, nil, &turn.TurnContext{})
+		So(err, ShouldBeNil)
+
+		blks := acc.Finalize()
+		So(blks, ShouldHaveLength, 1)
+		sb := blks[0].(*blocks.SubagentStateBlock)
+		So(sb.Kind, ShouldEqual, "local_bash")
+		So(sb.Description, ShouldEqual, "sleep 20")
+		So(sb.Status, ShouldEqual, "running")
+	})
+}
+
 func TestSubagentDone_DefaultStatus(t *testing.T) {
 	Convey("SubagentDone info.Status 空时默认 completed", t, func() {
 		acc := turn.New()

--- a/internal/service/chat_svc/types.go
+++ b/internal/service/chat_svc/types.go
@@ -155,11 +155,12 @@ type ChatStreamEvent struct {
 }
 
 // CompletedTaskRef 标识触发本自主轮的后台命令身份。镜像 agentruntime.CompletedBackgroundTask
-// 中前端需要的两个字段:ToolUseID 关联到上一条消息里的 subagent_state 块,Status 指明
-// 该块要翻成的终态。
+// 中前端需要的字段:ToolUseID 关联到上一条消息里的 subagent_state 块,Status 指明
+// 该块要翻成的终态,Summary 是 CLI 下发的完成摘要文本（如退出码说明）。
 type CompletedTaskRef struct {
 	ToolUseID string `json:"toolUseId"`
-	Status    string `json:"status"` // completed | failed
+	Status    string `json:"status"`              // completed | failed
+	Summary   string `json:"summary,omitempty"`   // CLI task_notification.summary
 }
 
 // ChatCompactBoundary 是 StreamCompactBoundary 事件的 payload。MessageID 是 boundary
@@ -320,7 +321,8 @@ type ChatBlockSubagent struct {
 	ToolUses        int    `json:"toolUses,omitempty"`
 	TotalTokens     int    `json:"totalTokens,omitempty"`
 	DurationMs      int    `json:"durationMs,omitempty"`
-	Status          string `json:"status,omitempty"` // running | completed | failed
+	Status          string `json:"status,omitempty"`  // running | completed | failed
+	Summary         string `json:"summary,omitempty"` // CLI task_notification.summary（如退出码说明）
 }
 
 type ChatMessage struct {

--- a/internal/service/chat_svc/types.go
+++ b/internal/service/chat_svc/types.go
@@ -148,6 +148,18 @@ type ChatStreamEvent struct {
 	// AssistantMessage 复用上面的字段携带要插入的新 assistant 行。
 	Stream  string `json:"stream,omitempty"`
 	Trigger string `json:"trigger,omitempty"`
+
+	// StreamAutonomousStarted 时,若该自主轮由后台命令完成触发,带上完成任务身份,
+	// 前端据此把对应 subagent_state(上一条消息里)即时翻成 completed/failed。
+	CompletedTask *CompletedTaskRef `json:"completedTask,omitempty"`
+}
+
+// CompletedTaskRef 标识触发本自主轮的后台命令身份。镜像 agentruntime.CompletedBackgroundTask
+// 中前端需要的两个字段:ToolUseID 关联到上一条消息里的 subagent_state 块,Status 指明
+// 该块要翻成的终态。
+type CompletedTaskRef struct {
+	ToolUseID string `json:"toolUseId"`
+	Status    string `json:"status"` // completed | failed
 }
 
 // ChatCompactBoundary 是 StreamCompactBoundary 事件的 payload。MessageID 是 boundary
@@ -300,6 +312,7 @@ type ChatBlockToolPermission struct {
 // task_notification 给 status + 最终 usage。所有字段对老数据自动为零值，向前兼容。
 type ChatBlockSubagent struct {
 	TaskID          string `json:"taskId,omitempty"`
+	Kind            string `json:"kind,omitempty"` // local_bash | local_agent（区分后台 bash 与 subagent；空=未知/旧帧）
 	SubagentType    string `json:"subagentType,omitempty"`
 	TaskDescription string `json:"taskDescription,omitempty"`
 	Prompt          string `json:"prompt,omitempty"`

--- a/internal/service/chat_svc/types.go
+++ b/internal/service/chat_svc/types.go
@@ -159,8 +159,8 @@ type ChatStreamEvent struct {
 // 该块要翻成的终态,Summary 是 CLI 下发的完成摘要文本（如退出码说明）。
 type CompletedTaskRef struct {
 	ToolUseID string `json:"toolUseId"`
-	Status    string `json:"status"`              // completed | failed
-	Summary   string `json:"summary,omitempty"`   // CLI task_notification.summary
+	Status    string `json:"status"`            // completed | failed
+	Summary   string `json:"summary,omitempty"` // CLI task_notification.summary
 }
 
 // ChatCompactBoundary 是 StreamCompactBoundary 事件的 payload。MessageID 是 boundary

--- a/internal/service/chat_svc/view/project.go
+++ b/internal/service/chat_svc/view/project.go
@@ -68,9 +68,9 @@ func ProjectMessageBlocks(bs []cagoblocks.ContentBlock) []ChatBlock {
 		case blocks.ToolPermissionBlock:
 			out = append(out, ChatBlock{Type: "tool_permission", ToolPermission: &t})
 		case *blocks.SubagentStateBlock:
-			out = append(out, ChatBlock{Type: "subagent_state", Subagent: t})
+			out = append(out, ChatBlock{Type: "subagent_state", ParentToolCallID: t.ParentToolCallID, Subagent: t})
 		case blocks.SubagentStateBlock:
-			out = append(out, ChatBlock{Type: "subagent_state", Subagent: &t})
+			out = append(out, ChatBlock{Type: "subagent_state", ParentToolCallID: t.ParentToolCallID, Subagent: &t})
 		case *blocks.PermissionModeChangeBlock, blocks.PermissionModeChangeBlock:
 			out = append(out, ChatBlock{Type: "permission_mode_change"})
 		case *blocks.CompactBoundaryBlock:

--- a/internal/service/chat_svc/view/project.go
+++ b/internal/service/chat_svc/view/project.go
@@ -68,9 +68,9 @@ func ProjectMessageBlocks(bs []cagoblocks.ContentBlock) []ChatBlock {
 		case blocks.ToolPermissionBlock:
 			out = append(out, ChatBlock{Type: "tool_permission", ToolPermission: &t})
 		case *blocks.SubagentStateBlock:
-			out = append(out, ChatBlock{Type: "subagent_state", ParentToolCallID: t.ParentToolCallID, Subagent: t})
+			out = append(out, ChatBlock{Type: "subagent_state", Subagent: t})
 		case blocks.SubagentStateBlock:
-			out = append(out, ChatBlock{Type: "subagent_state", ParentToolCallID: t.ParentToolCallID, Subagent: &t})
+			out = append(out, ChatBlock{Type: "subagent_state", Subagent: &t})
 		case *blocks.PermissionModeChangeBlock, blocks.PermissionModeChangeBlock:
 			out = append(out, ChatBlock{Type: "permission_mode_change"})
 		case *blocks.CompactBoundaryBlock:

--- a/internal/service/chat_svc/view/project_test.go
+++ b/internal/service/chat_svc/view/project_test.go
@@ -46,26 +46,6 @@ func TestProjectMessageBlocks_NestedTool(t *testing.T) {
 	})
 }
 
-func TestProjectMessageBlocks_SubagentState(t *testing.T) {
-	Convey("SubagentStateBlock 投影带 kind/description + ParentToolCallID", t, func() {
-		out := ProjectMessageBlocks([]cagoblocks.ContentBlock{
-			&blocks.SubagentStateBlock{
-				ParentToolCallID: "tu1",
-				Kind:             "local_bash",
-				Description:      "sleep 20",
-				Status:           "running",
-			},
-		})
-		So(out, ShouldHaveLength, 1)
-		So(out[0].Type, ShouldEqual, "subagent_state")
-		So(out[0].ParentToolCallID, ShouldEqual, "tu1")
-		So(out[0].Subagent, ShouldNotBeNil)
-		So(out[0].Subagent.Kind, ShouldEqual, "local_bash")
-		So(out[0].Subagent.Description, ShouldEqual, "sleep 20")
-		So(out[0].Subagent.Status, ShouldEqual, "running")
-	})
-}
-
 func TestProjectMessageBlocks_UserAsk(t *testing.T) {
 	Convey("UserAskBlock 投影到 type=user_ask + UserAsk 子字段", t, func() {
 		out := ProjectMessageBlocks([]cagoblocks.ContentBlock{

--- a/internal/service/chat_svc/view/project_test.go
+++ b/internal/service/chat_svc/view/project_test.go
@@ -46,6 +46,26 @@ func TestProjectMessageBlocks_NestedTool(t *testing.T) {
 	})
 }
 
+func TestProjectMessageBlocks_SubagentState(t *testing.T) {
+	Convey("SubagentStateBlock 投影带 kind/description + ParentToolCallID", t, func() {
+		out := ProjectMessageBlocks([]cagoblocks.ContentBlock{
+			&blocks.SubagentStateBlock{
+				ParentToolCallID: "tu1",
+				Kind:             "local_bash",
+				Description:      "sleep 20",
+				Status:           "running",
+			},
+		})
+		So(out, ShouldHaveLength, 1)
+		So(out[0].Type, ShouldEqual, "subagent_state")
+		So(out[0].ParentToolCallID, ShouldEqual, "tu1")
+		So(out[0].Subagent, ShouldNotBeNil)
+		So(out[0].Subagent.Kind, ShouldEqual, "local_bash")
+		So(out[0].Subagent.Description, ShouldEqual, "sleep 20")
+		So(out[0].Subagent.Status, ShouldEqual, "running")
+	})
+}
+
 func TestProjectMessageBlocks_UserAsk(t *testing.T) {
 	Convey("UserAskBlock 投影到 type=user_ask + UserAsk 子字段", t, func() {
 		out := ProjectMessageBlocks([]cagoblocks.ContentBlock{

--- a/pkg/claudecode/autoturn.go
+++ b/pkg/claudecode/autoturn.go
@@ -20,6 +20,7 @@ type CompletedBackgroundTask struct {
 	ToolUseID string
 	TaskID    string
 	Status    string // "completed" / "failed"(空 → 视为 completed)
+	Summary   string // CLI task_notification.summary,如 "Background command \"…\" completed (exit code 0)"
 }
 
 // triggerBackgroundTask 是目前唯一的 AutoTurn 触发原因。

--- a/pkg/claudecode/autoturn.go
+++ b/pkg/claudecode/autoturn.go
@@ -10,6 +10,16 @@ type AutoTurn struct {
 	Events    <-chan Event
 	SessionID string
 	Trigger   string // 当前固定 "background_task"
+	// CompletedTask 仅 background_task 触发的自主轮带:那个完成的后台任务的身份,
+	// 供上层把对应 subagent_state 翻成 completed/failed。
+	CompletedTask *CompletedBackgroundTask
+}
+
+// CompletedBackgroundTask 是触发本自主轮的后台命令完成信息(从 task_notification 帧抽出)。
+type CompletedBackgroundTask struct {
+	ToolUseID string
+	TaskID    string
+	Status    string // "completed" / "failed"(空 → 视为 completed)
 }
 
 // triggerBackgroundTask 是目前唯一的 AutoTurn 触发原因。

--- a/pkg/claudecode/event.go
+++ b/pkg/claudecode/event.go
@@ -111,6 +111,7 @@ type ToolEvent struct {
 //
 //	TaskID          ← 三类 system 帧共通字段 task_id
 //	SubagentType    ← 三类共通字段 subagent_type
+//	TaskType        ← 三类共通字段 task_type（"local_bash" / "local_agent"）
 //	TaskDescription ← task_started.description（任务名）/ task_progress.description（实时摘要）
 //	Prompt          ← 仅 task_started.prompt（任务说明，长文本）
 //	LastToolName    ← task_progress.last_tool_name
@@ -121,6 +122,7 @@ type ToolEvent struct {
 type SubagentMeta struct {
 	TaskID          string
 	SubagentType    string
+	TaskType        string // ← task_started/progress/notification.task_type（local_bash / local_agent）
 	TaskDescription string
 	Prompt          string
 	LastToolName    string

--- a/pkg/claudecode/session.go
+++ b/pkg/claudecode/session.go
@@ -270,7 +270,16 @@ func (s *Session) currentTurn(f rawFrame) *activeTurn {
 		at := newActiveTurn(true)
 		s.active = at
 		s.sinkMu.Unlock()
-		s.autoCh <- &AutoTurn{Events: at.ch, SessionID: s.sessionID, Trigger: triggerBackgroundTask}
+		s.autoCh <- &AutoTurn{
+			Events:    at.ch,
+			SessionID: s.sessionID,
+			Trigger:   triggerBackgroundTask,
+			CompletedTask: &CompletedBackgroundTask{
+				ToolUseID: f.ToolUseID,
+				TaskID:    f.TaskID,
+				Status:    f.Status,
+			},
+		}
 		return nil
 	}
 	if isNonTurnFrame(f) {
@@ -881,6 +890,7 @@ func parseSystemTask(f rawFrame, sid string) (Event, bool) {
 	meta := &SubagentMeta{
 		TaskID:          f.TaskID,
 		SubagentType:    f.SubagentType,
+		TaskType:        f.TaskType,
 		TaskDescription: f.Description,
 		Prompt:          f.Prompt,
 		LastToolName:    f.LastToolName,

--- a/pkg/claudecode/session.go
+++ b/pkg/claudecode/session.go
@@ -286,18 +286,33 @@ func (s *Session) currentTurn(f rawFrame) *activeTurn {
 }
 
 // isNonTurnFrame 判定一帧是否「不归属任何一轮」—— 即便在轮间(空闲)到达,也不该认领
-// 一个排队的 user Turn。当前两类:
+// 一个排队的 user Turn。三类:
 //   - control_response:control_request(Interrupt / SetPermissionMode)的回执,已在
 //     parseLine 阶段按 request_id dispatch 给等待者,不携带 turn 事件。
 //   - system{subtype:"status"}:会话级状态推送(permissionMode / 运行态),从不作为某
 //     一轮的起始帧 —— 轮内到达由 active 轮承接(currentTurn 在 active!=nil 时已先返回),
 //     空闲到达则无归属轮,其事件随 route 的 nil 返回被丢弃(set_permission_mode 的回执
 //     已由 SetPermissionMode 调用方拿到,主动切 mode 不依赖这条空闲 status)。
+//   - system{subtype:"task_started"/"task_updated"/"task_progress"}:后台任务(及
+//     subagent)生命周期的状态推送。真 CLI 2.1.162 在后台任务完成、自主续轮的
+//     task_notification 之前先吐一帧 task_updated(状态 patch);它空闲到达时既非
+//     后台 task_notification 也非 status,旧逻辑会把读循环卡死在 <-pendingTurns,
+//     后续 task_notification / 自主续轮永远读不到(sess-429「续不上对话」复发)。
+//     这些状态帧从不作为一轮的起始帧:轮内到达由 active 轮承接,空闲到达直接丢弃。
+//     注意后台型 task_notification 不在此列 —— 它正是自主轮的起始标记(见
+//     isBackgroundTaskNotification),由 currentTurn 在本判定之前优先处理。
 func isNonTurnFrame(f rawFrame) bool {
 	if f.Type == "control_response" {
 		return true
 	}
-	return f.Type == "system" && f.Subtype == "status"
+	if f.Type != "system" {
+		return false
+	}
+	switch f.Subtype {
+	case "status", "task_started", "task_updated", "task_progress":
+		return true
+	}
+	return false
 }
 
 // feed 把事件投给 at.ch;at 已被消费方放弃(abandon)时丢弃余帧,避免 reader 阻塞。

--- a/pkg/claudecode/session.go
+++ b/pkg/claudecode/session.go
@@ -278,6 +278,7 @@ func (s *Session) currentTurn(f rawFrame) *activeTurn {
 				ToolUseID: f.ToolUseID,
 				TaskID:    f.TaskID,
 				Status:    f.Status,
+				Summary:   f.Summary,
 			},
 		}
 		return nil

--- a/pkg/claudecode/session_test.go
+++ b/pkg/claudecode/session_test.go
@@ -985,4 +985,5 @@ func TestBackgroundTaskAutonomousTurn_CarriesCompletedTask(t *testing.T) {
 	assert.Equal(t, "tu1", at.CompletedTask.ToolUseID)
 	assert.Equal(t, "bg1", at.CompletedTask.TaskID)
 	assert.Equal(t, "completed", at.CompletedTask.Status)
+	assert.Equal(t, "Background command completed", at.CompletedTask.Summary)
 }

--- a/pkg/claudecode/session_test.go
+++ b/pkg/claudecode/session_test.go
@@ -812,7 +812,13 @@ func TestSession_TurnReturnsExitErrWhenProcessDied(t *testing.T) {
 
 // fakeBackgroundTask 复刻真实 CLI 2.1.162 抓到的「后台任务 + 自主续轮」帧序。
 // turn1:启动 run_in_background → result#1;随后不等 stdin 自主吐
-// task_notification(后台型) + 续轮(init+text+result#2);turn2:正常回声。
+// task_updated(后台任务收尾状态推送) → task_notification(后台型) → 续轮
+// (init+text+result#2);turn2:正常回声。
+//
+// 关键:真实 CLI 在 result#1 之后、task_notification 之前先吐一帧
+// system{subtype:"task_updated"}(后台任务完成的状态 patch)。它空闲到达、既非
+// 后台 task_notification 也非已知非 turn 帧 —— 若 readLoop 把它当 turn 起始帧卡在
+// <-pendingTurns 上,后面的 task_notification / 续轮就永远读不到(见 sess-429)。
 func fakeBackgroundTask(stdin io.Reader, stdout io.Writer) {
 	const sid = "sess-bgtask"
 	sc := bufio.NewScanner(stdin)
@@ -829,6 +835,8 @@ func fakeBackgroundTask(stdin io.Reader, stdout io.Writer) {
 			writeFrame(stdout, `{"type":"assistant","message":{"id":"a2","content":[{"type":"text","text":"started:%s"}]}}`, reply)
 			writeFrame(stdout, `{"type":"result","subtype":"success","session_id":%q,"usage":{"input_tokens":1,"output_tokens":1}}`, sid)
 			// —— 不等下一条 stdin,自主吐后台完成续轮 ——
+			// 真 CLI 先吐一帧 task_updated(后台任务收尾的状态 patch),再吐 task_notification。
+			writeFrame(stdout, `{"type":"system","subtype":"task_updated","task_id":"bg1","patch":{"status":"completed","end_time":1780625678929},"session_id":%q}`, sid)
 			writeFrame(stdout, `{"type":"system","subtype":"task_notification","task_id":"bg1","tool_use_id":"tu1","status":"completed","output_file":"/tmp/tasks/bg1.output","summary":"Background command completed"}`)
 			writeFrame(stdout, `{"type":"system","subtype":"init","session_id":%q,"cwd":"/tmp","model":"m","tools":[]}`, sid)
 			writeFrame(stdout, `{"type":"assistant","message":{"id":"a3","content":[{"type":"text","text":"autonomous:listing"}]}}`)

--- a/pkg/claudecode/session_test.go
+++ b/pkg/claudecode/session_test.go
@@ -948,3 +948,41 @@ func TestSession_IdleSetPermissionModeKeepsReaderAlive(t *testing.T) {
 	assert.Equal(t, "background_task", at.Trigger)
 	assert.Equal(t, "autonomous:listing", drainText(t, at.Events))
 }
+
+func TestParseSystemTask_CarriesTaskType(t *testing.T) {
+	f := rawFrame{
+		Type: "system", Subtype: "task_started",
+		TaskID: "bg1", ToolUseID: "tu1", Description: "Sleep for 5 seconds",
+		TaskType: "local_bash",
+	}
+	ev, ok := parseSystemTask(f, "sx")
+	require.True(t, ok)
+	require.NotNil(t, ev.Tool)
+	require.NotNil(t, ev.Tool.Subagent)
+	assert.Equal(t, "local_bash", ev.Tool.Subagent.TaskType)
+	assert.Equal(t, "Sleep for 5 seconds", ev.Tool.Subagent.TaskDescription)
+}
+
+func TestBackgroundTaskAutonomousTurn_CarriesCompletedTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := New(WithBinary("fake"), pipeSpawner(t, fakeBackgroundTask))
+	sess, err := c.OpenSession(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close(context.Background()) }()
+
+	ch1, err := sess.Turn(ctx, "alpha")
+	require.NoError(t, err)
+	_ = drainText(t, ch1)
+
+	var at *AutoTurn
+	select {
+	case at = <-sess.AutonomousTurns():
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected autonomous turn")
+	}
+	require.NotNil(t, at.CompletedTask)
+	assert.Equal(t, "tu1", at.CompletedTask.ToolUseID)
+	assert.Equal(t, "bg1", at.CompletedTask.TaskID)
+	assert.Equal(t, "completed", at.CompletedTask.Status)
+}

--- a/pkg/claudecode/stream.go
+++ b/pkg/claudecode/stream.go
@@ -133,6 +133,10 @@ type rawFrame struct {
 	// SubagentType。见 isBackgroundTaskNotification。
 	OutputFile string `json:"output_file,omitempty"`
 
+	// Summary 仅「后台命令完成」型 task_notification 帧带，CLI 填充完成摘要文本
+	// 如 "Background command \"…\" completed (exit code 0)"。
+	Summary string `json:"summary,omitempty"`
+
 	// system.subtype == "api_retry" 的字段：CLI 把 Anthropic SDK 的可重试错误（429/5xx 等）
 	// 包成 first-class 协议帧推到 stdout。字段直接放在帧顶层，不嵌在 usage / message 里。
 	// ErrorField 字段名避开内置 error。

--- a/pkg/claudecode/stream.go
+++ b/pkg/claudecode/stream.go
@@ -122,7 +122,9 @@ type rawFrame struct {
 	ToolUseID    string `json:"tool_use_id,omitempty"`
 	Description  string `json:"description,omitempty"`
 	SubagentType string `json:"subagent_type,omitempty"`
-	Prompt       string `json:"prompt,omitempty"`
+	// TaskType 区分 task 帧来源:"local_bash"(run_in_background bash)/ "local_agent"(subagent)。
+	TaskType string `json:"task_type,omitempty"`
+	Prompt   string `json:"prompt,omitempty"`
 	LastToolName string `json:"last_tool_name,omitempty"`
 	Status       string `json:"status,omitempty"`
 

--- a/pkg/claudecode/stream.go
+++ b/pkg/claudecode/stream.go
@@ -123,8 +123,8 @@ type rawFrame struct {
 	Description  string `json:"description,omitempty"`
 	SubagentType string `json:"subagent_type,omitempty"`
 	// TaskType 区分 task 帧来源:"local_bash"(run_in_background bash)/ "local_agent"(subagent)。
-	TaskType string `json:"task_type,omitempty"`
-	Prompt   string `json:"prompt,omitempty"`
+	TaskType     string `json:"task_type,omitempty"`
+	Prompt       string `json:"prompt,omitempty"`
 	LastToolName string `json:"last_tool_name,omitempty"`
 	Status       string `json:"status,omitempty"`
 


### PR DESCRIPTION
## Summary

会话头部新增一个**胶囊**显示当前运行中后台任务数,点开是**只读弹层**,列出本会话的后台任务(类型图标 / 描述 / **耗时** / 状态 / **退出码摘要**),统一覆盖 `local_bash`(run_in_background bash)+ `local_agent`(subagent)。

复用 #11 的自主续轮机器,无新能力 / 无新前向接口。

**数据链(live + 持久化两条路同形 `tool_use.subagent`):**
- `pkg/claudecode`:`task_type` 解析 + `AutoTurn.CompletedTask{ToolUseID,TaskID,Status,Summary}`
- `agentruntime`:`SubagentInfo.Kind` + `AutonomousTurn.CompletedTask`(mirror+bridge,层不反向依赖)
- `chat_svc`:`subagent_state` 块补 `kind`/`description`/`summary`;新 `chat_repo.FlipSubagentStatus`(倒序拉 assistant 消息、`json.Decoder`+`UseNumber` 防数字 float64 化、定向重写块 status+summary);`driveAutonomousTurn` emit `completedTask` + 落库翻转;`toChatMessage` 把 `.subagent` 折叠到持久化 `tool_use` 块(跨轮 / 重载可见)
- 前端:`deriveBackgroundTasks` 从 `tool_use.subagent` derive;胶囊(0 运行中隐藏)+ 弹层(耗时实时 tick / 完成定格 / 退出码摘要);`completedTask` 即时翻转;i18n 双语

**顺带修掉的缺陷:**
- 后台 bash 的 `subagent_state` 块永远停在 `running`(完成信号现经自主轮回流 + 落库翻转)
- 自主轮中途断时在飞 subagent 永远 running(`MarkRunningSubagentsCancelled`)
- 含独立线上 bug fix `76337f8`:`isNonTurnFrame` 认 `task_started/task_updated/task_progress`,修 sess-429「后台任务完成续不上对话」复发

## 非目标(v1)

output 查看 / 停止任务 / 远端(agentred)转发(本案 nil-safe 降级)/ 全局跨会话托盘 / codex·builtin backend。无 DB schema 改动(纯 JSON `omitempty` 字段增补)。

## Test Plan

- [x] 后端 `-race` 全包绿(claudecode / agentruntime+runtimes / chat_svc+子包 / chat_repo)
- [x] `golangci-lint` 0 issues + gofmt 干净
- [x] 前端 1180 Vitest 全绿 + `tsc --noEmit` 0 + ESLint 0 error(i18n 双语 key 对齐)
- [x] 逐任务 spec + code-quality 双审 + 整体集成终审(6 条数据链全通)
- [ ] **手验(需本地,GUI 难无头跑)**:真 app 跑 `sleep 20` 后台 bash → 胶囊「1 运行中」+ 耗时 tick → 完成翻「已完成」+ 弹层显示退出码摘要;reload 后仍正确

## 设计 / 计划

- spec: `docs/superpowers/specs/2026-06-05-background-tasks-panel-design.md`
- plan: `docs/superpowers/plans/2026-06-05-background-tasks-panel.md`