### PR TITLE
🐛 修复 Windows CLI 后端测试连接问题

### DIFF
--- a/frontend/src/components/agentre/__tests__/agent-backends.test.tsx
+++ b/frontend/src/components/agentre/__tests__/agent-backends.test.tsx
@@ -122,6 +122,10 @@ function installAppMock(overrides: Partial<AppMockShape> = {}) {
   return merged;
 }
 
+function cliPathInput(dialog: HTMLElement, bin: string) {
+  return within(dialog).getByPlaceholderText(bin) as HTMLInputElement;
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -480,9 +484,7 @@ describe("AgentBackendsPanel", () => {
       within(dialog).getByRole("button", { name: /Pi Agent CLI/ }),
     );
 
-    const input = within(dialog).getByPlaceholderText(
-      "/usr/local/bin/pi",
-    ) as HTMLInputElement;
+    const input = cliPathInput(dialog, "pi");
     await waitFor(() => expect(input.value).toBe("/opt/homebrew/bin/pi"));
     expect(
       within(dialog).getByText(/Pi Agent standalone config/),
@@ -917,11 +919,27 @@ describe("AgentBackendsPanel", () => {
       expect(resolveFn).toHaveBeenCalledWith(
         expect.objectContaining({ type: "claudecode" }),
       );
-      const input = within(dialog).getByPlaceholderText(
-        "/usr/local/bin/claude",
-      ) as HTMLInputElement;
+      const input = cliPathInput(dialog, "claude");
       expect(input.value).toBe("/opt/homebrew/bin/claude");
     });
+  });
+
+  it("CLI 路径 placeholder 使用 binary 名而不是 Unix 绝对路径", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+    render(<AgentBackendsPanel />);
+
+    await screen.findByRole("table", { name: "Agent backend list" });
+    await user.click(screen.getByRole("button", { name: /New Backend/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+    );
+
+    expect(cliPathInput(dialog, "claude")).toBeInTheDocument();
+    expect(
+      within(dialog).queryByPlaceholderText("/usr/local/bin/claude"),
+    ).not.toBeInTheDocument();
   });
 
   it("切到 codex 时自动识别命中 → input 显示 codex 的绝对路径", async () => {
@@ -941,9 +959,7 @@ describe("AgentBackendsPanel", () => {
       expect(resolveFn).toHaveBeenCalledWith(
         expect.objectContaining({ type: "codex" }),
       );
-      const input = within(dialog).getByPlaceholderText(
-        "/usr/local/bin/codex",
-      ) as HTMLInputElement;
+      const input = cliPathInput(dialog, "codex");
       expect(input.value).toBe("/usr/local/bin/codex");
     });
   });
@@ -1002,9 +1018,7 @@ describe("AgentBackendsPanel", () => {
     );
 
     // 给一点时机让 ResolveCLIPath 的 Promise 完成；命中分支已被其它用例覆盖，这里仅断终态。
-    const input = within(dialog).getByPlaceholderText(
-      "/usr/local/bin/claude",
-    ) as HTMLInputElement;
+    const input = cliPathInput(dialog, "claude");
     await waitFor(() => expect(input.value).toBe(""));
   });
 
@@ -1024,9 +1038,7 @@ describe("AgentBackendsPanel", () => {
       within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
     );
 
-    const input = within(dialog).getByPlaceholderText(
-      "/usr/local/bin/claude",
-    ) as HTMLInputElement;
+    const input = cliPathInput(dialog, "claude");
     await waitFor(() => expect(input.value).toBe("/first/claude"));
 
     // 用户手改了值，然后点按钮重识别 → 按钮要覆盖手填值。
@@ -1052,9 +1064,7 @@ describe("AgentBackendsPanel", () => {
     const dialog = await screen.findByRole("dialog");
     await user.click(within(dialog).getByRole("button", { name: /Codex CLI/ }));
 
-    const input = within(dialog).getByPlaceholderText(
-      "/usr/local/bin/codex",
-    ) as HTMLInputElement;
+    const input = cliPathInput(dialog, "codex");
     fireEvent.change(input, { target: { value: "/manual/codex" } });
 
     await user.click(within(dialog).getByRole("button", { name: /Detect/ }));

--- a/frontend/src/components/agentre/__tests__/llm-providers.test.tsx
+++ b/frontend/src/components/agentre/__tests__/llm-providers.test.tsx
@@ -214,4 +214,28 @@ describe("LlmProvidersPanel", () => {
 
     expect(dialog).not.toHaveTextContent("Save failed");
   });
+
+  it("Given provider form has typed values, When clicking outside, Then keeps the dialog open", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+    render(<LlmProvidersPanel />);
+
+    await screen.findByRole("table", { name: "LLM provider list" });
+    await user.click(screen.getByRole("button", { name: "New Provider" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const nameInput = screen.getByPlaceholderText(
+      "Example: production / local Ollama",
+    ) as HTMLInputElement;
+    await user.type(nameInput, "Draft provider");
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as Element);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(nameInput.value).toBe("Draft provider");
+    expect(dialog).toContainElement(nameInput);
+  });
 });

--- a/frontend/src/components/agentre/agent-backends.tsx
+++ b/frontend/src/components/agentre/agent-backends.tsx
@@ -1682,7 +1682,7 @@ function CliPathField({
         <Input
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={`/usr/local/bin/${bin}`}
+          placeholder={bin}
           className="font-mono"
         />
         <Button

--- a/frontend/src/components/agentre/llm-providers.tsx
+++ b/frontend/src/components/agentre/llm-providers.tsx
@@ -694,7 +694,10 @@ function ProviderFormDialog({
         if (!next) onClose();
       }}
     >
-      <DialogContent className="max-w-[560px]">
+      <DialogContent
+        className="max-w-[560px]"
+        onPointerDownOutside={(event) => event.preventDefault()}
+      >
         {editor.kind !== "closed" ? (
           <ProviderForm
             key={

--- a/internal/pkg/agentruntime/clienv.go
+++ b/internal/pkg/agentruntime/clienv.go
@@ -98,11 +98,10 @@ func BuildCodexEnv(b *agent_backend_entity.AgentBackend, deps CLIDeps) (map[stri
 }
 
 // BuildPiAgentEnv 装配 pi-agent 子进程环境变量：
-//   - 默认 PI_OFFLINE=1，避免桌面启动路径触发 update/network startup；
 //   - Pi 自行读取 ~/.pi/agent/models.json / settings.json / auth.json，不走 Agentre gateway；
 //   - 用户自定义 env_json 追加（保留键已被 entity.Check 拒入）。
 func BuildPiAgentEnv(b *agent_backend_entity.AgentBackend) (map[string]string, error) {
-	env := map[string]string{"PI_OFFLINE": "1"}
+	env := map[string]string{}
 	user, err := agent_backend_entity.ParseEnvJSON(b.EnvJSON)
 	if err != nil {
 		return nil, fmt.Errorf("parse env_json: %w", err)

--- a/internal/pkg/agentruntime/clienv_test.go
+++ b/internal/pkg/agentruntime/clienv_test.go
@@ -73,6 +73,16 @@ func TestBuildCodexEnv_Basic(t *testing.T) {
 	})
 }
 
+func TestBuildPiAgentEnv_Basic(t *testing.T) {
+	t.Run("不默认注入 PI_OFFLINE，让 pi 测试和运行使用 CLI 自身在线能力", func(t *testing.T) {
+		env, err := BuildPiAgentEnv(&agent_backend_entity.AgentBackend{EnvJSON: `{"PI_CODING_AGENT_DIR":"C:\\pi-agentre"}`})
+		require.NoError(t, err)
+		assert.Equal(t, `C:\pi-agentre`, env["PI_CODING_AGENT_DIR"])
+		_, hasOffline := env["PI_OFFLINE"]
+		assert.False(t, hasOffline, "PI_OFFLINE 会让 pi 进入 offline mode，测试连接会卡到超时")
+	})
+}
+
 // TestCodexReasoningEffortConfigValue 锁住 codex 启动层的 reasoning effort 转译：
 // xhigh 直传；max 属于其它后端的更高档语义，在 codex 下兼容折叠到 high；
 // off / 未知值 → 空串（不下发）。

--- a/internal/pkg/agentruntime/launch_command_test.go
+++ b/internal/pkg/agentruntime/launch_command_test.go
@@ -263,7 +263,7 @@ func TestBuildLaunchCommand_PiAgentWithThinking(t *testing.T) {
 
 	assert.NotContains(t, cmd, "\n", "命令必须是单行")
 	assert.True(t, strings.HasPrefix(cmd, "cd '"+cwd+"' && "), "前缀应为 cd '<cwd>' && ，got %q", cmd)
-	assert.Contains(t, cmd, "PI_OFFLINE='1'")
+	assert.NotContains(t, cmd, "PI_OFFLINE", "pi backend must stay online for model requests")
 	assert.Contains(t, cmd, "PI_CODING_AGENT_DIR='/tmp/pi-agentre'")
 	assert.Contains(t, cmd, "pi --mode rpc --no-context-files --thinking high")
 	assert.NotContains(t, cmd, "--model", "pi backend should use the user's ~/.pi/agent default model unless explicitly configured")

--- a/internal/pkg/clienv/clienv.go
+++ b/internal/pkg/clienv/clienv.go
@@ -98,16 +98,55 @@ func ResolveBinaryInPath(binary, searchPath string) (string, bool) {
 		if dir == "" {
 			dir = "."
 		}
-		candidate := filepath.Join(dir, binary)
-		if !IsExecutableFile(candidate) {
-			continue
+		for _, name := range executableLookupNames(binary) {
+			candidate := filepath.Join(dir, name)
+			if !IsExecutableFile(candidate) {
+				continue
+			}
+			if IsAppBundleWrapper(candidate) {
+				continue
+			}
+			return candidate, true
 		}
-		if IsAppBundleWrapper(candidate) {
-			continue
-		}
-		return candidate, true
 	}
 	return "", false
+}
+
+func executableLookupNames(binary string) []string {
+	if runtime.GOOS != "windows" || filepath.Ext(binary) != "" {
+		return []string{binary}
+	}
+	names := make([]string, 0, len(windowsExecutableExtensions())+1)
+	for _, ext := range windowsExecutableExtensions() {
+		names = append(names, binary+ext)
+	}
+	names = append(names, binary)
+	return names
+}
+
+func windowsExecutableExtensions() []string {
+	raw := strings.TrimSpace(os.Getenv("PATHEXT"))
+	if raw == "" {
+		raw = ".COM;.EXE;.BAT;.CMD"
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, ext := range strings.Split(raw, string(os.PathListSeparator)) {
+		ext = strings.TrimSpace(ext)
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		ext = strings.ToLower(ext)
+		if _, ok := seen[ext]; ok {
+			continue
+		}
+		seen[ext] = struct{}{}
+		out = append(out, ext)
+	}
+	return out
 }
 
 // SearchPathFrom returns basePath plus CLI locations that GUI-launched macOS

--- a/internal/pkg/clienv/clienv_test.go
+++ b/internal/pkg/clienv/clienv_test.go
@@ -64,3 +64,37 @@ func TestResolveBinaryForEnvUsesAugmentedPATH(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, binary, got)
 }
+
+func TestResolveBinaryInPathUsesWindowsPATHEXT(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows PATHEXT lookup only applies on Windows")
+	}
+
+	binDir := t.TempDir()
+	want := filepath.Join(binDir, "claude.exe")
+	require.NoError(t, os.WriteFile(want, []byte{}, 0o644))
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	got, ok := ResolveBinaryInPath("claude", binDir)
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestResolveBinaryInPathPrefersWindowsPATHEXTOverExtensionlessShim(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows PATHEXT lookup only applies on Windows")
+	}
+
+	binDir := t.TempDir()
+	posixShim := filepath.Join(binDir, "pi")
+	want := filepath.Join(binDir, "pi.cmd")
+	require.NoError(t, os.WriteFile(posixShim, []byte("#!/bin/sh\nexit 0\n"), 0o644))
+	require.NoError(t, os.WriteFile(want, []byte("@echo off\r\nexit /b 0\r\n"), 0o644))
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	got, ok := ResolveBinaryInPath("pi", binDir)
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}

--- a/pkg/codex/client.go
+++ b/pkg/codex/client.go
@@ -421,9 +421,10 @@ func (c *Client) defaultRunSpec() runSpec {
 }
 
 func (c *Client) startApp(ctx context.Context) (*appClient, error) {
+	config := appendLegacyPriorityServiceTierOverride(c.config, c.env)
 	return newAppClient(ctx, c.runner, procOptions{
 		Binary: c.binary,
-		Args:   buildAppServerArgs(c.config, c.extraArgs),
+		Args:   buildAppServerArgs(config, c.extraArgs),
 		Cwd:    c.cwd,
 		Env:    buildEnv(c.env),
 	})

--- a/pkg/codex/client_test.go
+++ b/pkg/codex/client_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +18,8 @@ import (
 )
 
 func TestClientStream_StartThreadAndMapsEvents(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+
 	// Given a Codex app-server that accepts a fresh thread and streams one turn.
 	runner := &fakeAppServerRunner{t: t}
 	runner.handler = func(t *testing.T, h *fakeAppServerHandle) {
@@ -100,6 +103,51 @@ func TestClientStream_StartThreadAndMapsEvents(t *testing.T) {
 	assert.Equal(t, "codex-test", runner.opts[0].Binary)
 	assert.Equal(t, []string{"app-server", "--listen", "stdio://"}, runner.opts[0].Args)
 	assert.Equal(t, "/tmp/work", runner.opts[0].Cwd)
+}
+
+func TestClientStream_OverridesLegacyPriorityServiceTier(t *testing.T) {
+	// Given a Codex home with a legacy service_tier value no longer accepted by
+	// newer app-server builds.
+	codexHome := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(`service_tier = "priority"`+"\n"), 0o600))
+	runner := &fakeAppServerRunner{t: t}
+	runner.handler = func(t *testing.T, h *fakeAppServerHandle) {
+		sc := bufio.NewScanner(h.stdinR)
+		respondRPC(h, readRPCReq(t, sc), map[string]any{})
+		_ = readRPCReq(t, sc)
+		startReq := readRPCReq(t, sc)
+		assert.Equal(t, "thread/start", startReq.Method)
+		respondRPC(h, startReq, map[string]any{"thread": map[string]any{"id": "thread-new"}})
+		turnReq := readRPCReq(t, sc)
+		assert.Equal(t, "turn/start", turnReq.Method)
+		respondRPC(h, turnReq, map[string]any{"turn": map[string]any{"id": "turn-1", "status": "inProgress"}})
+		h.send(map[string]any{
+			"method": "turn/completed",
+			"params": map[string]any{"threadId": "thread-new", "turnId": "turn-1", "turn": map[string]any{"id": "turn-1", "status": "completed"}},
+		})
+	}
+
+	client := New(
+		WithEnv(map[string]string{"CODEX_HOME": codexHome}),
+		WithAppServerRunnerForTesting(runner),
+	)
+
+	// When the app-server is started through Agentre.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	stream, err := client.Stream(ctx, "hello")
+	require.NoError(t, err)
+	for stream.Next() {
+	}
+	require.NoError(t, stream.Close(ctx))
+
+	// Then Agentre adds a process-local compatibility override instead of
+	// requiring the user's config.toml to be rewritten.
+	require.Len(t, runner.opts, 1)
+	assert.Equal(t, []string{
+		"app-server", "--listen", "stdio://",
+		"--config", `service_tier="fast"`,
+	}, runner.opts[0].Args)
 }
 
 func TestClientStream_ResumeThread(t *testing.T) {
@@ -434,6 +482,8 @@ func TestClientGoal_RequiresThreadID(t *testing.T) {
 }
 
 func TestClientStream_PassesModelAndConfigOverrides(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+
 	runner := &fakeAppServerRunner{t: t}
 	runner.handler = func(t *testing.T, h *fakeAppServerHandle) {
 		sc := bufio.NewScanner(h.stdinR)

--- a/pkg/codex/config_compat.go
+++ b/pkg/codex/config_compat.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const legacyPriorityServiceTierOverride = `service_tier="fast"`
+
+func appendLegacyPriorityServiceTierOverride(config []string, env map[string]string) []string {
+	if hasConfigKey(config, "service_tier") || !usesLegacyPriorityServiceTier(env) {
+		return config
+	}
+	out := append([]string{}, config...)
+	return append(out, legacyPriorityServiceTierOverride)
+}
+
+func hasConfigKey(config []string, key string) bool {
+	for _, expr := range config {
+		left, _, ok := strings.Cut(strings.TrimSpace(expr), "=")
+		if ok && strings.TrimSpace(left) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func usesLegacyPriorityServiceTier(env map[string]string) bool {
+	path := codexConfigPath(env)
+	if path == "" {
+		return false
+	}
+	//nolint:gosec // Reading the user's Codex config locally to add a process-scoped compatibility override.
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if beforeComment, _, ok := strings.Cut(line, "#"); ok {
+			line = strings.TrimSpace(beforeComment)
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "service_tier" {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		return value == "priority"
+	}
+	return false
+}
+
+func codexConfigPath(env map[string]string) string {
+	if home := strings.TrimSpace(env["CODEX_HOME"]); home != "" {
+		return filepath.Join(home, "config.toml")
+	}
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return filepath.Join(home, "config.toml")
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(userHome) == "" {
+		return ""
+	}
+	return filepath.Join(userHome, ".codex", "config.toml")
+}

--- a/pkg/piagent/client.go
+++ b/pkg/piagent/client.go
@@ -75,6 +75,7 @@ func (c *Client) Text(ctx context.Context, prompt string, opts ...RunOption) (st
 	}
 	var b strings.Builder
 	var stopErr error
+	completed := false
 	for stream.Next() {
 		ev := stream.Event()
 		switch ev.Kind {
@@ -84,9 +85,11 @@ func (c *Client) Text(ctx context.Context, prompt string, opts ...RunOption) (st
 			if ev.Err != nil {
 				stopErr = ev.Err
 			}
+		case EventDone:
+			completed = true
 		}
 	}
-	if err := stream.Close(ctx); err != nil && stopErr == nil {
+	if err := stream.Close(ctx); err != nil && stopErr == nil && !completed {
 		stopErr = err
 	}
 	if stopErr != nil {
@@ -159,6 +162,7 @@ func (p *rpcProcess) terminate(ctx context.Context, grace time.Duration) error {
 	if p == nil || p.handle == nil {
 		return nil
 	}
+	p.closeInput()
 	_ = p.handle.Signal(interruptSignal())
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
@@ -171,6 +175,14 @@ func (p *rpcProcess) terminate(ctx context.Context, grace time.Duration) error {
 	case <-ctx.Done():
 		_ = p.handle.Kill()
 		return ctx.Err()
+	}
+}
+
+func (p *rpcProcess) closeInput() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if closer, ok := p.stdin.(io.Closer); ok {
+		_ = closer.Close()
 	}
 }
 

--- a/pkg/piagent/client.go
+++ b/pkg/piagent/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -181,7 +182,7 @@ func wrapExitError(err error, stderr string) error {
 }
 
 func wrapTerminateExitError(err error, stderr string) error {
-	if err == nil || isInterruptExit(err) {
+	if err == nil || isInterruptExit(err) || isWindowsCmdInterruptExit(err, stderr) {
 		return nil
 	}
 	return wrapExitError(err, stderr)
@@ -192,6 +193,13 @@ func isInterruptExit(err error) bool {
 		return false
 	}
 	return strings.TrimSpace(err.Error()) == "signal: interrupt"
+}
+
+func isWindowsCmdInterruptExit(err error, stderr string) bool {
+	if runtime.GOOS != "windows" || err == nil || strings.TrimSpace(stderr) != "" {
+		return false
+	}
+	return strings.TrimSpace(err.Error()) == "exit status 1"
 }
 
 func failureResponseError(r rpcResponse) error {

--- a/pkg/piagent/stream_close_test.go
+++ b/pkg/piagent/stream_close_test.go
@@ -5,14 +5,12 @@ import (
 	"errors"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStreamClose(t *testing.T) {
@@ -64,6 +62,24 @@ func TestStreamClose(t *testing.T) {
 
 			convey.So(err, convey.ShouldNotBeNil)
 			assert.Contains(t, err.Error(), "exit status 2")
+			assert.True(t, proc.signaled, "running process should be interrupted during Close")
+		})
+	})
+
+	convey.Convey("Given a running pi-agent RPC stream behind a Windows npm cmd shim", t, func() {
+		proc := newFakeProcess(t)
+		stream := newStream(proc.rpcProcess(), time.Second)
+
+		convey.Convey("When Close interrupts it and the shim reports exit status 1 without stderr, then Close treats cleanup as successful", func() {
+			proc.finishOnSignal(errors.New("exit status 1"))
+
+			err := stream.Close(context.Background())
+
+			if isWindowsCmdInterruptExit(errors.New("exit status 1"), "") {
+				convey.So(err, convey.ShouldBeNil)
+			} else {
+				convey.So(err, convey.ShouldNotBeNil)
+			}
 			assert.True(t, proc.signaled, "running process should be interrupted during Close")
 		})
 	})
@@ -133,10 +149,7 @@ func (f *fakeProcess) Signal(sig os.Signal) error {
 
 func interruptExitError(t *testing.T) error {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", "kill -INT $$")
-	err := cmd.Run()
-	require.Error(t, err)
-	return err
+	return errors.New("signal: interrupt")
 }
 
 type fakeRunner struct {

--- a/pkg/piagent/stream_close_test.go
+++ b/pkg/piagent/stream_close_test.go
@@ -37,6 +37,28 @@ func TestStreamClose(t *testing.T) {
 		})
 	})
 
+	convey.Convey("Given a completed pi-agent text probe whose cleanup exits non-zero", t, func() {
+		runner := &fakeRunner{process: newFakeProcess(t)}
+		runner.process.stdout = strings.NewReader(strings.Join([]string{
+			`{"type":"response","command":"prompt","success":true}`,
+			`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"pong"}}`,
+			`{"type":"agent_end","messages":[]}`,
+			"",
+		}, "\n"))
+		runner.process.finishOnStdinClose(errors.New("exit status 0xc0000409"))
+		client := New(
+			WithRPCProcessRunnerForTesting(runner),
+			WithKillGrace(time.Second),
+		)
+
+		convey.Convey("When Text already observed Done, then cleanup failure does not replace the successful result", func() {
+			text, err := client.Text(context.Background(), "ping")
+
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(text, convey.ShouldEqual, "pong")
+		})
+	})
+
 	convey.Convey("Given a running pi-agent RPC stream", t, func() {
 		proc := newFakeProcess(t)
 		stream := newStream(proc.rpcProcess(), time.Second)
@@ -83,33 +105,54 @@ func TestStreamClose(t *testing.T) {
 			assert.True(t, proc.signaled, "running process should be interrupted during Close")
 		})
 	})
+
+	convey.Convey("Given a running pi-agent RPC process that exits on stdin EOF", t, func() {
+		proc := newFakeProcess(t)
+		stream := newStream(proc.rpcProcess(), 20*time.Millisecond)
+
+		convey.Convey("When Close terminates it, then stdin is closed before force-killing the process", func() {
+			proc.finishOnStdinClose(nil)
+			proc.finishOnKill(errors.New("exit status 1"))
+
+			err := stream.Close(context.Background())
+
+			convey.So(err, convey.ShouldBeNil)
+			assert.True(t, proc.stdin.closed, "Close should close RPC stdin so Node-based shims can exit")
+			assert.False(t, proc.killed, "process should not need a forced kill after stdin EOF")
+		})
+	})
 }
 
 type fakeProcess struct {
 	t       *testing.T
+	stdin   *fakeStdin
 	stdout  *strings.Reader
 	stderr  *strings.Reader
 	done    chan error
 	signalC chan os.Signal
+	killC   chan struct{}
 
 	signaled bool
+	killed   bool
 }
 
 func newFakeProcess(t *testing.T) *fakeProcess {
 	t.Helper()
 	return &fakeProcess{
 		t:       t,
+		stdin:   newFakeStdin(),
 		stdout:  strings.NewReader(""),
 		stderr:  strings.NewReader(""),
 		done:    make(chan error, 1),
 		signalC: make(chan os.Signal, 1),
+		killC:   make(chan struct{}, 1),
 	}
 }
 
 func (f *fakeProcess) rpcProcess() *rpcProcess {
 	return &rpcProcess{
 		handle: f,
-		stdin:  io.Discard,
+		stdin:  f.stdin,
 		lines:  nil,
 		stderr: &lockedBuffer{},
 		done:   f.done,
@@ -124,7 +167,23 @@ func (f *fakeProcess) finishOnSignal(err error) {
 	}()
 }
 
-func (f *fakeProcess) Stdin() io.Writer  { return io.Discard }
+func (f *fakeProcess) finishOnStdinClose(err error) {
+	f.t.Helper()
+	go func() {
+		<-f.stdin.closeC
+		f.done <- err
+	}()
+}
+
+func (f *fakeProcess) finishOnKill(err error) {
+	f.t.Helper()
+	go func() {
+		<-f.killC
+		f.done <- err
+	}()
+}
+
+func (f *fakeProcess) Stdin() io.Writer  { return f.stdin }
 func (f *fakeProcess) Stdout() io.Reader { return f.stdout }
 func (f *fakeProcess) Stderr() io.Reader { return f.stderr }
 
@@ -136,7 +195,14 @@ func (f *fakeProcess) Wait() error {
 	return err
 }
 
-func (f *fakeProcess) Kill() error { return nil }
+func (f *fakeProcess) Kill() error {
+	f.killed = true
+	select {
+	case f.killC <- struct{}{}:
+	default:
+	}
+	return nil
+}
 
 func (f *fakeProcess) Signal(sig os.Signal) error {
 	f.signaled = true
@@ -162,4 +228,23 @@ func (r *fakeRunner) Start(context.Context, procOptions) (processHandle, error) 
 
 func TestFakeProcessImplementsProcessHandle(t *testing.T) {
 	var _ processHandle = (*fakeProcess)(nil)
+}
+
+type fakeStdin struct {
+	closeC chan struct{}
+	closed bool
+}
+
+func newFakeStdin() *fakeStdin {
+	return &fakeStdin{closeC: make(chan struct{})}
+}
+
+func (s *fakeStdin) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *fakeStdin) Close() error {
+	if !s.closed {
+		s.closed = true
+		close(s.closeC)
+	}
+	return nil
 }


### PR DESCRIPTION
## 变更说明 / Summary

- 修复设置页 Provider / Agent 后端表单外点关闭导致输入丢失的问题。
- 优化 CLI 路径提示与 Windows `PATHEXT` 可执行文件识别。
- 修复 Windows 下 PiAgent / Claude Code / Codex CLI 测试连接异常：
  - PiAgent 完成 `pong` 后不再让清理阶段非零退出覆盖成功结果。
  - PiAgent 关闭时先关闭 stdin，允许 Node/cmd shim 正常退出。
  - Codex 启动 app-server 时兼容旧 `service_tier = "priority"` 配置，使用进程级覆盖，不改写用户配置。

## 关联 Issue / Related Issue

无

## 截图 / Screenshots

无截图。UI 改动为设置页交互行为，已在本地 dev 页面验证：表单弹窗外点不关闭；PiAgent、Claude Code、Codex 后端测试连接均返回 `pong`。

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试

验证命令：

```bash
go test ./internal/pkg/clienv ./internal/pkg/agentruntime ./pkg/piagent ./pkg/codex ./internal/pkg/cliprober ./internal/service/agent_backend_svc -count=1
pnpm test -- src/components/agentre/__tests__/agent-backends.test.tsx src/components/agentre/__tests__/llm-providers.test.tsx
```