### PR TITLE
✨ 会话文件面板：目录树 + canonical diff 角标 + 打开文件按钮

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .superpowers/
-/docs/specs/
 /docs/superpowers/
 
 # dev-kit runtime: plans, verification evidence and reports, isolated workspaces — local

--- a/docs/specs/2026-08-06-session-files-tree.md
+++ b/docs/specs/2026-08-06-session-files-tree.md
@@ -1,0 +1,101 @@
+# 会话文件面板：目录树 + 打开文件按钮
+
+> Status: Draft
+> Owner: chat experience / frontend
+> Last updated: 2026-08-06
+
+**Objective:** 把会话「文件」面板从扁平列表升级为**可折叠的目录树**，把「编辑次数」角标替换为 **+/− 行数（绿/红）** 的 diff 标注，并在**本地会话**的每个文件行上提供一个「用系统默认应用打开」的图标按钮。
+
+**Hard invariants:**
+
+1. **行点击跳转不回归：** 点击文件行仍跳转到该文件 `lastTurn` 对应轮次的 user 消息（现状为 `FilesView` 行点击 → `onJumpToTurn(lastTurn)` → `turnToMessageId` → `onJumpToMessage`）。打开按钮是并列的独立元素，点击它不触发跳转、也不被行跳转吞掉。
+2. **远端会话绝不出现打开按钮：** 会话 `deviceID` 非空（agentred 远端）时不渲染打开按钮；本机不得对远端路径调用 `OpenPath`。`cwd` 缺失/为空时同样不渲染。
+3. **+/− 行数来自 producer，不重复实现统计：** 每文件的 `plus`/`minus` 直接读 `block.canonical`（`file.edit` 的 `fileEdit.files[].plus/minus` 汇总、`file.write` 的 `fileWrite.lines` 计入 `plus`），不在前端重复解析 old/new 字符串。
+4. **新增 UI 文案全部走 i18n：** 新增 key 必须同时覆盖 `frontend/src/i18n/locales/zh-CN/common.json` 与 `.../en/common.json`，不得硬编码中文；`src/__tests__/i18n.test.ts` 校验 key 覆盖。
+5. **树构建是可单测的纯函数：** 层级组织逻辑位于 `derive.ts` 的 `deriveFileTree()`，不在组件内拼装。
+6. 不修改 `deriveFiles()` 的路径提取逻辑（legacy 兼容）；排序键由「编辑次数」改为「+/− 行数」。
+
+## Problem
+
+1. **会话文件面板无法按目录浏览。** `frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx` 把 `deriveFiles()` 产出的相对路径渲染成扁平列表，且 `shortPath` 只显示路径后两段；深目录、多文件时会话看不出目录归属，也难以收拢/定位。
+2. **面板无法直接打开文件。** 打开本地路径的能力 `OpenPath` 已存在（`rich-link.tsx:24,106` 用系统默认应用打开），但 sidebar 从未拿到 `session.cwd`，也没有打开入口；用户只能自己去找文件路径。
+3. **编辑角标只显示次数、不显示改动量。** 现状 `FileEntry.edits` 只统计编辑工具调用次数；用户想看到每个文件的**新增/删除行数**。后端 `internal/pkg/diff` + `canonical` 已算出每文件 `plus`/`minus`（replay 时 `chat.go:809` / `event_convert.go:40` 重建 `block.canonical`），前端 `chat_svc.ChatBlock.canonical.fileEdit.files[].plus/minus` 可直接消费，无需重复统计。
+
+## Actors and user stories
+
+1. 作为用户，我希望会话文件按目录层级展示成树、可折叠，以便在大会话中快速定位改动文件。
+2. 作为本地会话用户，我希望每个文件行有一个图标按钮，一键用系统默认应用打开文件。
+3. 作为远端会话用户，我不希望看到一个必然失效的打开按钮。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | 可折叠目录树，默认全部展开，展开状态仅存组件内、不持久化 | 常见文件树交互，深路径可收拢。拒绝静态分组——240px 窄栏下深路径无法收拢；拒绝持久化——超出本任务价值 |
+| 2 | 打开按钮仅本地（`deviceID` 为空）且 `cwd` 非空时渲染，点击 `OpenPath(cwd + "/" + path)` | `OpenPath` 已有先例（`rich-link`）。拒绝「始终显示 + 失败 toast」——远端必然失败、体验差；拒绝走 `remote_fs_svc` 下载/打开远端文件——需要后端配合，明显超出本任务 |
+| 3 | `deriveFileTree(files)` 作为纯函数放 `derive.ts`：目录节点按名称字母序，文件节点保持 `deriveFiles()` 传入顺序（编辑次数降序、同数按 lastTurn 降序） | 层级与排序职责分离：`deriveFiles` 只负责排序、`deriveFileTree` 只负责层级，两者各自单测。拒绝在组件内建树——不可测；拒绝目录也按编辑权重排——目录位置不稳定 |
+| 4 | 文件行拆成两个并列独立按钮：跳转按钮（图标+文件名+diff 角标，flex-1）与打开按钮（ExternalLink 图标） | 行是 `<button>`、内部再嵌 `<button>` 是非法 HTML；拆成并列按钮既合法又可独立聚焦。拒绝「整行点击=打开」——会与既有跳转行为冲突 |
+| 5 | 打开按钮始终可见（hover 加深），而非仅 hover 行时出现 | 用户明确要「icon 按钮」，常显可发现性更好。拒绝「hover 才出现」——窄栏下不易发现 |
+| 6 | 每文件 `plus`/`minus` 直接读 `block.canonical`（`file.edit` 汇总、`file.write` 计 `lines`），UI 显示 `+N`（绿 `text-status-running`）/ `−N`（红 `text-destructive`）；两者为 0 时不显示角标 | 后端 `internal/pkg/diff` 已产出并经 replay 持久化，前端只消费。拒绝前端重复解析 old/new 字符串（违反 producer 归一化）；拒绝保留编辑次数角标——用户明确要换成行数。颜色复用 `file-edit/card.tsx` 既有 diff 绿/红 |
+| 7 | 排序键由「编辑次数」改为「`plus + minus` 行数，同数按 `lastTurn` 降序」 | 保持「改动最多者优先」的既有排序语义。拒绝按字母序重排——丢失改动权重信息 |
+
+## 数据与派生
+
+- `FileEntry` 由 `{ path, edits, reads, lastTurn }` 改为 `{ path, plus, minus, lastTurn }`（`reads` 无 UI 用途，随类型改动移除）。
+- 新增纯函数 `deriveFileTree(files: FileEntry[]): FileTreeNode[]`，其中：
+
+  ```ts
+  type FileTreeNode =
+    | { kind: "dir"; name: string; children: FileTreeNode[] }
+    | { kind: "file"; entry: FileEntry };
+  ```
+
+- 按 `FileEntry.path` 的 `/` 分段建树；空输入返回空数组；根目录下的文件成为根级 `file` 节点。目录节点按名称字母序（`localeCompare`）排序；文件节点保持输入顺序（即 `deriveFiles()` 的排序结果），`deriveFileTree` 不重排文件。
+- `deriveFiles()` 的路径/轮次提取逻辑不变（`extractToolPaths` 仍覆盖编辑+读取工具、各后端与 legacy）；`plus`/`minus` 改为直接消费 `block.canonical`：`canonical.kind === "file.edit"` 时按 `fileEdit.files[].path` 汇总该文件的 `plus`/`minus`；`canonical.kind === "file.write"` 时 `plus += fileWrite.lines`。无 `canonical` 的 legacy 块不产生 `plus`/`minus`（该文件角标不显示）。
+- 排序：`(plus + minus)` 降序，同数按 `lastTurn` 降序（替代原 `edits` 排序键）。
+
+## 树渲染与交互
+
+- `FilesView` 接收新增 props `cwd: string` 与 `remote: boolean`（`chat-panel` 通过 `ChatContextSidebar` 传入 `cwd={session?.cwd ?? ""}`、`remote={Boolean(session?.deviceID)}`，恒有值），组件内 `useMemo(() => deriveFileTree(files), [files])` 建树（`files` prop 保持 `FileEntry[]` 不变）。
+- **目录节点**：整行可点击，左侧 chevron（展开态 `ChevronDown` / 收起态 `ChevronRight`）+ 文件夹图标 + 目录名（等宽字体、truncate），点击切换该目录展开/收起；行有 hover 反馈，`aria-expanded` 表达当前状态。
+- **文件节点**：与现状一致的文件图标（`FileCode`）+ 文件名（basename、等宽、truncate）+ **diff 角标**（仅当 `plus > 0` 或 `minus > 0` 时显示：`+N` 绿色 `text-status-running`、`−N` 红色 `text-destructive`，与 `canonical-tool/file-edit/card.tsx` 的 diff 颜色一致，`aria-hidden`）。行内跳转按钮点击调用 `onJumpToTurn(lastTurn)`，行为与现状完全一致。
+- **默认全部展开**；展开状态是组件内 state，文件集合变化时重置为全部展开，不写入 localStorage。
+- 每层目录缩进固定步长；层级过深时名称以省略号截断，不压缩缩进，不换行。
+- 空文件列表沿用现有空态（`chatContext.files.empty`）。
+
+## 打开文件按钮
+
+- 前提（三者同时满足才渲染）：会话为本地（`remote === false`）、`cwd` 非空、`deriveFiles` 有该文件。
+- 位置：文件行右侧、diff 角标之后；图标 `ExternalLink`（约 size-3，`text-muted-foreground`，hover 加深到 foreground）。
+- 点击 → `OpenPath(cwd + "/" + path)`；成功无额外反馈；失败（reject）→ `toast.error` 提示新增文案 `chatContext.files.openFailed`，包含错误信息。
+- 无障碍：打开按钮与跳转按钮是**两个并列的独立 `<button>`**（不嵌套），都可 Tab 聚焦、可独立点击；打开按钮带 `aria-label`（新增 `chatContext.files.openFile`，中文「打开文件」/英文「Open file」）。点击打开按钮不触发行跳转。
+
+## 新增 i18n key
+
+- `chatContext.files.openFile`（打开按钮 aria-label）：zh「打开文件」/ en「Open file」
+- `chatContext.files.openFailed`（失败 toast，含 `{{error}}`）：zh「打开文件失败：{{error}}」/ en「Failed to open file: {{error}}」
+- `chatContext.files.expandFolder` / `chatContext.files.collapseFolder`（目录 chevron aria-label）：zh「展开 {{name}}」/「收起 {{name}}」，en「Expand {{name}}」/「Collapse {{name}}」
+
+## Out of scope
+
+- 远端会话（`deviceID` 非空）的文件打开/下载（含 `remote_fs_svc` 集成），本轮仅隐藏打开按钮。
+- 树展开状态的持久化（localStorage）与「全部收起/全部展开」工具按钮。
+- 目录节点聚合显示 +/− 行数（当前仅文件行显示 diff 角标）。
+- 为无 `canonical` 的 legacy 块实现前端行数统计（历史会话不显示 diff 角标）。
+- 其他面板（大纲）的任何改动。
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| `deriveFiles()` 的 `plus`/`minus`（`__tests__/derive.test.ts`） | `file.edit` 多 hunk 汇总、`file.write` 计 `lines`、多后端路径命中、无 `canonical` 的 legacy 块为 0、排序按 `plus+minus` | `derive.test.ts` 现有 `deriveFiles` 用例（改造 `edits` 断言为 `plus`/`minus`） |
+| `deriveFileTree()`（`__tests__/derive.test.ts`） | 目录/文件层级构建、根目录文件、目录字母序、文件保持传入顺序、深路径、空输入 | 无（新增） |
+| `FilesView`（`__tests__/files-view.test.tsx`） | 树渲染、目录折叠/展开、行点击跳转不回归、diff 角标 `+N`/`−N` 绿红配色、打开按钮在「本地+cwd」下渲染并调用 `OpenPath(cwd+path)`、远端或 cwd 缺失时不渲染、OpenPath reject 时 toast | `files-view.test.tsx` 现有用例 + `rich-link.test.tsx` 的 `OpenPath` mock 模式 |
+| i18n key 覆盖 | 新增 4 个 key 双语言覆盖 | `src/__tests__/i18n.test.ts` |
+| chat-panel 接线（`cwd`/`remote` 传入 sidebar） | 接线正确性 | chat-panel 为大型集成组件、不单测；由 `make lint` / `make test-frontend` + 运行时手动观察覆盖 |
+
+不可自动化部分：chat-panel 到 sidebar 的单行接线由运行时观察覆盖（本地会话渲染打开按钮、远端会话不渲染）。
+
+## Open questions
+
+<!-- 无。决策 1-A + 2-A 已获用户确认（2026-08-06）。 -->

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { deriveFiles, deriveOutline, type FileEntry } from "../derive";
+import {
+  deriveFileTree,
+  deriveFiles,
+  deriveOutline,
+  type FileEntry,
+} from "../derive";
 
 import type { chat_svc } from "../../../../../wailsjs/go/models";
 
@@ -38,6 +43,58 @@ function assistantWithEdits(id: number, files: string[], errored = false): Msg {
     completionTokens: 0,
     durationMs: 0,
     errorText: errored ? "boom" : "",
+    seq: 0,
+    createtime: 0,
+  } as unknown as Msg;
+}
+
+function editBlock(
+  toolName: string,
+  file_path: string,
+  canonicalFiles: Array<{ path: string; plus?: number; minus?: number }>,
+) {
+  return {
+    type: "tool_use",
+    toolName,
+    toolInput: { file_path },
+    canonical: {
+      kind: "file.edit",
+      fileEdit: {
+        files: canonicalFiles.map((f) => ({
+          kind: "patch",
+          hunks: [],
+          path: f.path,
+          plus: f.plus,
+          minus: f.minus,
+        })),
+      },
+    },
+  };
+}
+
+function writeBlock(toolName: string, path: string, lines: number) {
+  return {
+    type: "tool_use",
+    toolName,
+    toolInput: { file_path: path },
+    canonical: {
+      kind: "file.write",
+      fileWrite: { path, content: "", lines, bytes: 0 },
+    },
+  };
+}
+
+function assistantWithBlocks(id: number, blocks: unknown[]): Msg {
+  return {
+    id,
+    role: "assistant",
+    sessionId: 1,
+    blocks,
+    model: "",
+    promptTokens: 0,
+    completionTokens: 0,
+    durationMs: 0,
+    errorText: "",
     seq: 0,
     createtime: 0,
   } as unknown as Msg;
@@ -83,20 +140,88 @@ describe("deriveOutline", () => {
 });
 
 describe("deriveFiles", () => {
-  it("aggregates Edit/Write/MultiEdit by file_path across turns", () => {
+  it("sums plus/minus from file.edit canonical across hunks and files", () => {
     const msgs = [
       userMsg(1, "u1"),
-      assistantWithEdits(2, ["a.go", "a.go", "b.go"]),
-      userMsg(3, "u2"),
-      assistantWithEdits(4, ["a.go"]),
+      assistantWithBlocks(2, [
+        editBlock("Edit", "a.go", [
+          { path: "a.go", plus: 5, minus: 2 },
+          { path: "a.go", plus: 3, minus: 0 },
+          { path: "b.go", plus: 1, minus: 1 },
+        ]),
+      ]),
     ];
     const files = deriveFiles(msgs);
     const a = files.find((f: FileEntry) => f.path === "a.go")!;
     const b = files.find((f: FileEntry) => f.path === "b.go")!;
-    expect(a.edits).toBe(3);
-    expect(b.edits).toBe(1);
-    expect(a.lastTurn).toBe(2);
-    expect(b.lastTurn).toBe(1);
+    expect(a.plus).toBe(8);
+    expect(a.minus).toBe(2);
+    expect(a.lastTurn).toBe(1);
+    expect(b.plus).toBe(1);
+    expect(b.minus).toBe(1);
+  });
+
+  it("counts file.write canonical lines as plus for that path", () => {
+    const msgs = [
+      userMsg(1, "u1"),
+      assistantWithBlocks(2, [writeBlock("Write", "new.go", 42)]),
+    ];
+    const files = deriveFiles(msgs);
+    const f = files.find((x: FileEntry) => x.path === "new.go")!;
+    expect(f.plus).toBe(42);
+    expect(f.minus).toBe(0);
+    expect(f.lastTurn).toBe(1);
+  });
+
+  it("keeps legacy blocks without canonical but with 0 plus/minus", () => {
+    const msgs = [
+      userMsg(1, "u1"),
+      assistantWithBlocks(2, [
+        {
+          type: "tool_use",
+          toolName: "Edit",
+          toolInput: { file_path: "a.go" },
+        },
+      ]),
+    ];
+    const files = deriveFiles(msgs);
+    const a = files.find((f: FileEntry) => f.path === "a.go")!;
+    expect(a.plus).toBe(0);
+    expect(a.minus).toBe(0);
+    expect(a.lastTurn).toBe(1);
+  });
+
+  it("keeps read-tool paths in the list with 0 plus/minus", () => {
+    const msgs = [
+      userMsg(1, "u1"),
+      assistantWithBlocks(2, [
+        { type: "tool_use", toolName: "read", toolInput: { path: "a.go" } },
+      ]),
+    ];
+    const files = deriveFiles(msgs);
+    const a = files.find((f: FileEntry) => f.path === "a.go")!;
+    expect(a.plus).toBe(0);
+    expect(a.minus).toBe(0);
+    expect(a.lastTurn).toBe(1);
+  });
+
+  it("sorts by plus+minus desc, ties broken by lastTurn desc", () => {
+    const msgs = [
+      userMsg(1, "u1"),
+      assistantWithBlocks(2, [
+        editBlock("Edit", "a.go", [{ path: "a.go", plus: 1, minus: 1 }]),
+      ]),
+      userMsg(3, "u2"),
+      assistantWithBlocks(4, [
+        editBlock("Edit", "b.go", [{ path: "b.go", plus: 3, minus: 0 }]),
+      ]),
+      userMsg(5, "u3"),
+      assistantWithBlocks(6, [
+        editBlock("Edit", "c.go", [{ path: "c.go", plus: 2, minus: 0 }]),
+      ]),
+    ];
+    const files = deriveFiles(msgs);
+    expect(files.map((f) => f.path)).toEqual(["b.go", "c.go", "a.go"]);
   });
 
   it("Given Claude mutation blocks, When files are derived, Then Edit, Write, and MultiEdit paths are listed", () => {
@@ -129,17 +254,6 @@ describe("deriveFiles", () => {
     ]);
   });
 
-  it("sorts files by edits desc, ties broken by recency (lastTurn desc)", () => {
-    const msgs = [
-      userMsg(1, "u1"),
-      assistantWithEdits(2, ["a.go"]),
-      userMsg(3, "u2"),
-      assistantWithEdits(4, ["b.go"]),
-    ];
-    const files = deriveFiles(msgs);
-    expect(files[0].path).toBe("b.go"); // tie on edits, b.go more recent
-  });
-
   it("Given a Codex file_change block, When files are derived, Then every changed path is listed", () => {
     const msgs = [
       userMsg(1, "u1"),
@@ -169,48 +283,116 @@ describe("deriveFiles", () => {
     expect(deriveFiles(msgs).map((f) => f.path)).toEqual(["a.go", "b.go"]);
   });
 
-  it("Given Pi edit/write/read blocks, When files are derived, Then edits and reads use the path field", () => {
-    const msgs = [
-      userMsg(1, "u1"),
+  it("returns empty array for empty input", () => {
+    expect(deriveFiles([])).toEqual([]);
+  });
+});
+
+describe("deriveFileTree", () => {
+  const e = (path: string): FileEntry => ({
+    path,
+    plus: 0,
+    minus: 0,
+    lastTurn: 1,
+  });
+
+  it("builds nested dir/file hierarchy, dirs before files, files in input order", () => {
+    const tree = deriveFileTree([e("a/b/c.go"), e("a/d.go"), e("e.go")]);
+    expect(tree).toEqual([
       {
-        id: 2,
-        role: "assistant",
-        sessionId: 1,
-        blocks: [
+        kind: "dir",
+        name: "a",
+        children: [
           {
-            type: "tool_use",
-            toolName: "edit",
-            toolInput: { path: "a.go" },
+            kind: "dir",
+            name: "b",
+            children: [
+              {
+                kind: "file",
+                entry: { path: "a/b/c.go", plus: 0, minus: 0, lastTurn: 1 },
+              },
+            ],
           },
           {
-            type: "tool_use",
-            toolName: "write",
-            toolInput: { path: "b.go" },
-          },
-          {
-            type: "tool_use",
-            toolName: "read",
-            toolInput: { path: "a.go" },
+            kind: "file",
+            entry: { path: "a/d.go", plus: 0, minus: 0, lastTurn: 1 },
           },
         ],
-        model: "",
-        promptTokens: 0,
-        completionTokens: 0,
-        durationMs: 0,
-        errorText: "",
-        seq: 0,
-        createtime: 0,
-      } as unknown as Msg,
+      },
+      { kind: "file", entry: { path: "e.go", plus: 0, minus: 0, lastTurn: 1 } },
+    ]);
+  });
+
+  it("sorts dir nodes alphabetically, keeps file input order", () => {
+    const files = [
+      e("x/b.go"),
+      e("a/c.go"),
+      e("m/f.go"),
+      e("a/z.go"),
+      e("a/a.go"),
     ];
-    const files = deriveFiles(msgs);
-    const a = files.find((f: FileEntry) => f.path === "a.go")!;
-    const b = files.find((f: FileEntry) => f.path === "b.go")!;
-    expect(a.edits).toBe(1);
-    expect(a.reads).toBe(1);
-    expect(b.edits).toBe(1);
+    const tree = deriveFileTree(files);
+    expect(tree.filter((n) => n.kind === "dir").map((n) => n.name)).toEqual([
+      "a",
+      "m",
+      "x",
+    ]);
+    const a = tree.find((n) => n.kind === "dir" && n.name === "a")!;
+    expect(a.kind).toBe("dir");
+    if (a.kind === "dir") {
+      expect(
+        a.children.map((n) => (n.kind === "file" ? n.entry.path : n.name)),
+      ).toEqual(["a/c.go", "a/z.go", "a/a.go"]);
+    }
+  });
+
+  it("keeps root files as root-level file nodes", () => {
+    expect(deriveFileTree([e("only.go")])).toEqual([
+      {
+        kind: "file",
+        entry: { path: "only.go", plus: 0, minus: 0, lastTurn: 1 },
+      },
+    ]);
+  });
+
+  it("handles deep paths with nested dirs at every level", () => {
+    const tree = deriveFileTree([e("a/b/c/d/f.go")]);
+    expect(tree[0]).toEqual({
+      kind: "dir",
+      name: "a",
+      children: [
+        {
+          kind: "dir",
+          name: "b",
+          children: [
+            {
+              kind: "dir",
+              name: "c",
+              children: [
+                {
+                  kind: "dir",
+                  name: "d",
+                  children: [
+                    {
+                      kind: "file",
+                      entry: {
+                        path: "a/b/c/d/f.go",
+                        plus: 0,
+                        minus: 0,
+                        lastTurn: 1,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
   });
 
   it("returns empty array for empty input", () => {
-    expect(deriveFiles([])).toEqual([]);
+    expect(deriveFileTree([])).toEqual([]);
   });
 });

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
@@ -346,6 +346,32 @@ describe("deriveFileTree", () => {
     }
   });
 
+  it("splits Windows path separators into collapsible directories", () => {
+    expect(deriveFileTree([e("src\\components\\file.tsx")])).toEqual([
+      {
+        kind: "dir",
+        name: "src",
+        children: [
+          {
+            kind: "dir",
+            name: "components",
+            children: [
+              {
+                kind: "file",
+                entry: {
+                  path: "src\\components\\file.tsx",
+                  plus: 0,
+                  minus: 0,
+                  lastTurn: 1,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("keeps root files as root-level file nodes", () => {
     expect(deriveFileTree([e("only.go")])).toEqual([
       {

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/derive.test.ts
@@ -191,6 +191,35 @@ describe("deriveFiles", () => {
     expect(a.lastTurn).toBe(1);
   });
 
+  it("ignores empty raw and canonical paths so malformed tool blocks cannot create an openable project-directory row", () => {
+    const msgs = [
+      userMsg(1, "u1"),
+      assistantWithBlocks(2, [
+        {
+          type: "tool_use",
+          toolName: "Edit",
+          toolInput: { file_path: "" },
+          canonical: {
+            kind: "file.edit",
+            fileEdit: {
+              files: [
+                {
+                  kind: "patch",
+                  hunks: [],
+                  path: "",
+                  plus: 1,
+                  minus: 0,
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    ];
+
+    expect(deriveFiles(msgs)).toEqual([]);
+  });
+
   it("keeps read-tool paths in the list with 0 plus/minus", () => {
     const msgs = [
       userMsg(1, "u1"),

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -43,6 +43,7 @@ const CWD = "/Users/me/proj";
 
 beforeEach(() => {
   openPathMock.mockReset();
+  openPathMock.mockResolvedValue(undefined);
   sonnerMocks.toast.error.mockReset();
 });
 
@@ -73,6 +74,33 @@ describe("FilesView", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a Windows path as folders with its basename on the file row", () => {
+    const windowsFiles: FileEntry[] = [
+      {
+        path: "src\\components\\file.tsx",
+        plus: 0,
+        minus: 0,
+        lastTurn: 1,
+      },
+    ];
+    render(
+      <FilesView
+        files={windowsFiles}
+        cwd="C:\\proj"
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Collapse src" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Collapse components" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("file.tsx")).toBeInTheDocument();
+  });
+
   it("collapses and expands a folder on row click, aria-expanded reflects state", async () => {
     render(
       <FilesView
@@ -99,6 +127,31 @@ describe("FilesView", () => {
     expect(
       screen.getByRole("button", { name: /chat\.go/ }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps a collapsed folder closed when an equivalent files array rerenders", async () => {
+    const { rerender } = render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /internal/ }));
+
+    rerender(
+      <FilesView
+        files={[...files]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /chat\.go/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("file row click still jumps to lastTurn", async () => {
@@ -165,6 +218,36 @@ describe("FilesView", () => {
       "/Users/me/proj/internal/service/chat_svc/chat.go",
     );
     expect(onJump).not.toHaveBeenCalled();
+  });
+
+  it("opens an absolute tool path directly instead of prefixing cwd", async () => {
+    const absoluteFiles: FileEntry[] = [
+      {
+        path: "/Users/me/proj/internal/service/chat_svc/chat.go",
+        plus: 0,
+        minus: 0,
+        lastTurn: 1,
+      },
+    ];
+    render(
+      <FilesView
+        files={absoluteFiles}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+
+    const chatGoRow = screen.getByRole("button", { name: /chat\.go/ });
+    await userEvent.click(
+      within(chatGoRow.parentElement!).getByRole("button", {
+        name: /Open file/i,
+      }),
+    );
+
+    expect(openPathMock).toHaveBeenCalledWith(
+      "/Users/me/proj/internal/service/chat_svc/chat.go",
+    );
   });
 
   it("hides open buttons when remote is true", () => {

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -124,6 +124,23 @@ describe("FilesView", () => {
     expect(screen.getByText("file.tsx")).toBeInTheDocument();
   });
 
+  it("left-aligns folder names with explicit text-left (matches the file-row pattern)", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    // 目录按钮必须显式 text-left：app 存在把 button 文字居中的全局规则，
+    // 文件行按钮原本就带 text-left 绕开；目录按钮漏掉会导致文件夹名与图标拉开大间隔。
+    for (const name of ["internal", "frontend"]) {
+      const btn = screen.getByRole("button", { name: `Collapse ${name}` });
+      expect(btn.className).toContain("text-left");
+    }
+  });
+
   it("collapses and expands a folder on row click, aria-expanded reflects state", async () => {
     render(
       <FilesView

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -154,6 +154,31 @@ describe("FilesView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("resets a collapsed folder when the ordered file paths change", async () => {
+    const { rerender } = render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /internal/ }));
+
+    rerender(
+      <FilesView
+        files={[...files].reverse()}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /chat\.go/ }),
+    ).toBeInTheDocument();
+  });
+
   it("file row click still jumps to lastTurn", async () => {
     const onJump = vi.fn();
     render(

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -74,6 +74,29 @@ describe("FilesView", () => {
     ).toBeInTheDocument();
   });
 
+  it("reserves a chevron-width slot on file rows so dir/file icon and name columns align", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    // 文件行跳转按钮的第一个子元素是与目录 chevron 同宽(size-3.5)的空槽位，
+    // 使同级目录文件夹图标/文件名与文件图标/文件名在水平上对齐。
+    const fileRow = screen.getByRole("button", { name: /chat\.go/ });
+    const firstChild = fileRow.firstElementChild;
+    expect(firstChild).not.toBeNull();
+    expect(firstChild!.className).toContain("size-3.5");
+    expect(firstChild!.textContent).toBe("");
+    expect(firstChild!.getAttribute("aria-hidden")).toBe("true");
+    // 空槽位之后紧跟文件图标（FileCode svg），再是文件名。
+    const icon = fileRow.querySelector("svg");
+    expect(icon).not.toBeNull();
+    expect(icon!.nextElementSibling?.textContent).toBe("chat.go");
+  });
+
   it("renders a Windows path as folders with its basename on the file row", () => {
     const windowsFiles: FileEntry[] = [
       {

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -1,8 +1,18 @@
 import "@testing-library/jest-dom/vitest";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sonnerMocks = vi.hoisted(() => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+vi.mock("sonner", () => sonnerMocks);
+
+const openPathMock = vi.fn();
+vi.mock("@/../wailsjs/go/app/App", () => ({
+  OpenPath: (p: string) => openPathMock(p),
+}));
 
 import { FilesView } from "../views/files-view";
 
@@ -11,34 +21,201 @@ import type { FileEntry } from "../derive";
 const files: FileEntry[] = [
   {
     path: "internal/service/chat_svc/chat.go",
-    edits: 5,
-    reads: 1,
+    plus: 5,
+    minus: 2,
     lastTurn: 3,
   },
   {
     path: "frontend/src/components/chat-panel.tsx",
-    edits: 2,
-    reads: 0,
+    plus: 0,
+    minus: 3,
     lastTurn: 2,
+  },
+  {
+    path: "README.md",
+    plus: 0,
+    minus: 0,
+    lastTurn: 1,
   },
 ];
 
+const CWD = "/Users/me/proj";
+
+beforeEach(() => {
+  openPathMock.mockReset();
+  sonnerMocks.toast.error.mockReset();
+});
+
 describe("FilesView", () => {
-  it("renders each file with edits count", () => {
-    render(<FilesView files={files} onJumpToTurn={() => {}} />);
-    expect(screen.getByText(/chat\.go/)).toBeInTheDocument();
-    expect(screen.getByText("5")).toBeInTheDocument();
+  it("renders the directory tree with folder rows and file basenames", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /internal/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /frontend/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /chat\.go/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /chat-panel\.tsx/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /README\.md/ }),
+    ).toBeInTheDocument();
   });
 
-  it("calls onJumpToTurn with lastTurn when row clicked", async () => {
+  it("collapses and expands a folder on row click, aria-expanded reflects state", async () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    const internalRow = screen.getByRole("button", { name: /internal/ });
+    expect(internalRow).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /chat\.go/ }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(internalRow);
+    expect(internalRow).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", { name: /chat\.go/ }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(internalRow);
+    expect(internalRow).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /chat\.go/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("file row click still jumps to lastTurn", async () => {
     const onJump = vi.fn();
-    render(<FilesView files={files} onJumpToTurn={onJump} />);
-    await userEvent.click(screen.getByText(/chat\.go/));
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={onJump}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /chat\.go/ }));
     expect(onJump).toHaveBeenCalledWith(3);
   });
 
+  it("renders +N in text-status-running and −N in text-destructive badges", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    const chatGo = screen.getByRole("button", { name: /chat\.go/ });
+    expect(within(chatGo).getByText("+5")).toHaveClass("text-status-running");
+    expect(within(chatGo).getByText("−2")).toHaveClass("text-destructive");
+
+    const panel = screen.getByRole("button", { name: /chat-panel\.tsx/ });
+    expect(within(panel).getByText("−3")).toHaveClass("text-destructive");
+    expect(within(panel).queryByText(/\+/)).not.toBeInTheDocument();
+  });
+
+  it("omits diff badge when plus and minus are both 0", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    const readme = screen.getByRole("button", { name: /README\.md/ });
+    expect(within(readme).queryByText(/[+\u2212]\d/)).not.toBeInTheDocument();
+  });
+
+  it("renders open button and calls OpenPath(cwd + path), without jumping", async () => {
+    const onJump = vi.fn();
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={onJump}
+      />,
+    );
+    const chatGoRow = screen.getByRole("button", { name: /chat\.go/ });
+    const openBtn = within(chatGoRow.parentElement!).getByRole("button", {
+      name: /Open file/i,
+    });
+    await userEvent.click(openBtn);
+    expect(openPathMock).toHaveBeenCalledWith(
+      "/Users/me/proj/internal/service/chat_svc/chat.go",
+    );
+    expect(onJump).not.toHaveBeenCalled();
+  });
+
+  it("hides open buttons when remote is true", () => {
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={true}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Open file/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides open buttons when cwd is empty", () => {
+    render(
+      <FilesView files={files} cwd="" remote={false} onJumpToTurn={() => {}} />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Open file/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toasts openFailed with the error when OpenPath rejects", async () => {
+    openPathMock.mockRejectedValue(new Error("boom"));
+    render(
+      <FilesView
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    const chatGoRow = screen.getByRole("button", { name: /chat\.go/ });
+    const openBtn = within(chatGoRow.parentElement!).getByRole("button", {
+      name: /Open file/i,
+    });
+    await userEvent.click(openBtn);
+    await vi.waitFor(() => {
+      expect(sonnerMocks.toast.error).toHaveBeenCalledWith(
+        "Failed to open file: boom",
+      );
+    });
+  });
+
   it("shows empty state when files is empty", () => {
-    render(<FilesView files={[]} onJumpToTurn={() => {}} />);
+    render(
+      <FilesView files={[]} cwd={CWD} remote={false} onJumpToTurn={() => {}} />,
+    );
     expect(
       screen.getByText(/No files have been changed in this session/),
     ).toBeInTheDocument();

--- a/frontend/src/components/agentre/chat-context-sidebar/derive.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/derive.ts
@@ -15,10 +15,14 @@ export type OutlineItem = {
 
 export type FileEntry = {
   path: string;
-  edits: number;
-  reads: number;
+  plus: number;
+  minus: number;
   lastTurn: number;
 };
+
+export type FileTreeNode =
+  | { kind: "dir"; name: string; children: FileTreeNode[] }
+  | { kind: "file"; entry: FileEntry };
 
 // 工具名按后端各自的原样大小写收录:claudecode 用 PascalCase,codex 用
 // file_change(历史消息可能仍是 apply_patch),pi agent 全小写(edit / write / read)。
@@ -40,6 +44,32 @@ function textOf(m: Msg): string {
     }
   }
   return "";
+}
+
+// 从 block.canonical 汇总某条 tool_use 的 plus/minus（producer 已算好行数，前端不重复解析）。
+// file.edit 按 fileEdit.files[].path 汇总 plus/minus；file.write 把 fileWrite.lines 计入 plus。
+function canonicalDeltas(
+  block: chat_svc.ChatBlock,
+): Array<{ path: string; plus: number; minus: number }> {
+  const canonical = block.canonical;
+  if (!canonical) return [];
+  if (canonical.kind === "file.edit") {
+    return (canonical.fileEdit?.files ?? []).map((f) => ({
+      path: f.path,
+      plus: f.plus ?? 0,
+      minus: f.minus ?? 0,
+    }));
+  }
+  if (canonical.kind === "file.write" && canonical.fileWrite?.path) {
+    return [
+      {
+        path: canonical.fileWrite.path,
+        plus: canonical.fileWrite.lines ?? 0,
+        minus: 0,
+      },
+    ];
+  }
+  return [];
 }
 
 function extractToolPaths(
@@ -102,21 +132,86 @@ export function deriveFiles(messages: Msg[]): FileEntry[] {
     }
     for (const block of m.blocks ?? []) {
       const ext = extractToolPaths(block);
-      if (!ext) continue;
-      const isEdit = EDIT_TOOLS.has(ext.name);
-      const isRead = READ_TOOLS.has(ext.name);
-      if (!isEdit && !isRead) continue;
-      for (const p of ext.paths) {
-        const cur = map.get(p) ?? { path: p, edits: 0, reads: 0, lastTurn: 0 };
-        if (isEdit) cur.edits += 1;
-        if (isRead) cur.reads += 1;
+      if (ext) {
+        const isEdit = EDIT_TOOLS.has(ext.name);
+        const isRead = READ_TOOLS.has(ext.name);
+        if (isEdit || isRead) {
+          for (const p of ext.paths) {
+            const cur = map.get(p) ?? {
+              path: p,
+              plus: 0,
+              minus: 0,
+              lastTurn: 0,
+            };
+            cur.lastTurn = Math.max(cur.lastTurn, turn);
+            map.set(p, cur);
+          }
+        }
+      }
+      // canonical 路径可能与 toolInput 的 path 不同（如 apply_patch），两者取并集。
+      for (const d of canonicalDeltas(block)) {
+        const cur = map.get(d.path) ?? {
+          path: d.path,
+          plus: 0,
+          minus: 0,
+          lastTurn: 0,
+        };
+        cur.plus += d.plus;
+        cur.minus += d.minus;
         cur.lastTurn = Math.max(cur.lastTurn, turn);
-        map.set(p, cur);
+        map.set(d.path, cur);
       }
     }
   }
   return [...map.values()].sort((a, b) => {
-    if (b.edits !== a.edits) return b.edits - a.edits;
+    const da = a.plus + a.minus;
+    const db = b.plus + b.minus;
+    if (db !== da) return db - da;
     return b.lastTurn - a.lastTurn;
   });
+}
+
+// 按 "/" 分段把扁平文件列表组织成目录树：目录节点字母序、文件节点保持传入顺序、
+// 根目录下的文件成为根级 file 节点；同一层目录排在文件之前。空输入返回空数组。
+export function deriveFileTree(files: FileEntry[]): FileTreeNode[] {
+  if (files.length === 0) return [];
+
+  const root: FileTreeNode[] = [];
+  const dirByPath = new Map<string, Extract<FileTreeNode, { kind: "dir" }>>();
+
+  for (const entry of files) {
+    const segs = entry.path.split("/").filter(Boolean);
+    let dirPath = "";
+    let container = root;
+    for (let i = 0; i < segs.length - 1; i++) {
+      const parentPath = dirPath;
+      dirPath = dirPath ? `${dirPath}/${segs[i]}` : segs[i];
+      let dir = dirByPath.get(dirPath);
+      if (!dir) {
+        dir = { kind: "dir", name: segs[i], children: [] };
+        dirByPath.set(dirPath, dir);
+        if (parentPath === "") {
+          root.push(dir);
+        } else {
+          dirByPath.get(parentPath)!.children.push(dir);
+        }
+      }
+      container = dir.children;
+    }
+    container.push({ kind: "file", entry });
+  }
+
+  const sortDir = (node: FileTreeNode) => {
+    if (node.kind !== "dir") return;
+    node.children.sort((a, b) => {
+      if (a.kind === "dir" && b.kind === "dir")
+        return a.name.localeCompare(b.name);
+      if (a.kind === "dir") return -1;
+      if (b.kind === "dir") return 1;
+      return 0; // 文件保持输入顺序（稳定排序）
+    });
+    node.children.forEach(sortDir);
+  };
+  sortDir({ kind: "dir", name: "", children: root });
+  return root;
 }

--- a/frontend/src/components/agentre/chat-context-sidebar/derive.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/derive.ts
@@ -54,11 +54,13 @@ function canonicalDeltas(
   const canonical = block.canonical;
   if (!canonical) return [];
   if (canonical.kind === "file.edit") {
-    return (canonical.fileEdit?.files ?? []).map((f) => ({
-      path: f.path,
-      plus: f.plus ?? 0,
-      minus: f.minus ?? 0,
-    }));
+    return (canonical.fileEdit?.files ?? [])
+      .filter((f) => f.path !== "")
+      .map((f) => ({
+        path: f.path,
+        plus: f.plus ?? 0,
+        minus: f.minus ?? 0,
+      }));
   }
   if (canonical.kind === "file.write" && canonical.fileWrite?.path) {
     return [
@@ -78,12 +80,16 @@ function extractToolPaths(
   if (block.type !== "tool_use" || !block.toolName) return null;
   const input = block.toolInput ?? {};
   const paths: string[] = [];
-  if (typeof input.file_path === "string") paths.push(input.file_path);
-  if (typeof input.path === "string") paths.push(input.path);
+  if (typeof input.file_path === "string" && input.file_path !== "") {
+    paths.push(input.file_path);
+  }
+  if (typeof input.path === "string" && input.path !== "") {
+    paths.push(input.path);
+  }
   const changes = (input as { changes?: Array<{ path?: string }> }).changes;
   if (Array.isArray(changes)) {
     for (const c of changes) {
-      if (typeof c?.path === "string") paths.push(c.path);
+      if (typeof c?.path === "string" && c.path !== "") paths.push(c.path);
     }
   }
   return paths.length > 0 ? { name: block.toolName, paths } : null;

--- a/frontend/src/components/agentre/chat-context-sidebar/derive.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/derive.ts
@@ -180,7 +180,7 @@ export function deriveFileTree(files: FileEntry[]): FileTreeNode[] {
   const dirByPath = new Map<string, Extract<FileTreeNode, { kind: "dir" }>>();
 
   for (const entry of files) {
-    const segs = entry.path.split("/").filter(Boolean);
+    const segs = entry.path.split(/[\\/]/).filter(Boolean);
     let dirPath = "";
     let container = root;
     for (let i = 0; i < segs.length - 1; i++) {

--- a/frontend/src/components/agentre/chat-context-sidebar/index.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/index.tsx
@@ -19,6 +19,8 @@ type Props = {
   messages: Msg[];
   activeMessageId: number | null;
   onJumpToMessage: (messageId: number) => void;
+  cwd?: string;
+  remote?: boolean;
 };
 
 export function ChatContextSidebar({
@@ -26,6 +28,8 @@ export function ChatContextSidebar({
   messages,
   activeMessageId,
   onJumpToMessage,
+  cwd = "",
+  remote = false,
 }: Props) {
   const { t } = useTranslation();
   const activeTab = useChatSidebarStore((s) => s.activeTab);
@@ -100,6 +104,8 @@ export function ChatContextSidebar({
         ) : (
           <FilesView
             files={files}
+            cwd={cwd}
+            remote={remote}
             onJumpToTurn={(turn) => {
               const mid = turnToMessageId.get(turn);
               if (mid != null) onJumpToMessage(mid);

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -108,7 +108,7 @@ export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
               ? t("chatContext.files.expandFolder", { name: node.name })
               : t("chatContext.files.collapseFolder", { name: node.name })
           }
-          className="flex items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50"
+          className="flex items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
           style={indentStyle(depth)}
         >
           {isCollapsed ? (

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { OpenPath } from "@/../wailsjs/go/app/App";
+import { classifyLink } from "@/lib/link-classify";
 
 import { deriveFileTree, type FileEntry, type FileTreeNode } from "../derive";
 
@@ -34,7 +35,7 @@ function DiffBadge({ plus, minus }: { plus: number; minus: number }) {
 }
 
 function basename(path: string): string {
-  const parts = path.split("/");
+  const parts = path.split(/[\\/]/);
   return parts[parts.length - 1] ?? path;
 }
 
@@ -42,15 +43,24 @@ function indentStyle(depth: number): React.CSSProperties {
   return { paddingLeft: `${8 + depth * 14}px` };
 }
 
+function openTarget(path: string, cwd: string): string {
+  const link = classifyLink(path, cwd);
+  if (link.kind === "local-internal" || link.kind === "local-external") {
+    return link.fullPath;
+  }
+  return `${cwd}/${path}`;
+}
+
 export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
   const { t } = useTranslation();
   const tree = React.useMemo(() => deriveFileTree(files), [files]);
+  const filePathsKey = files.map((file) => file.path).join("\u0000");
 
   // 展开状态仅存组件内、不持久化；文件集合变化时重置为全部展开。
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
   React.useEffect(() => {
     setCollapsed(new Set());
-  }, [files]);
+  }, [filePathsKey]);
 
   const toggleCollapse = (dirPath: string) => {
     setCollapsed((prev) => {
@@ -64,7 +74,7 @@ export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
   const canOpen = cwd !== "" && !remote;
 
   const openFile = (path: string) => {
-    OpenPath(`${cwd}/${path}`).catch((err: unknown) => {
+    OpenPath(openTarget(path, cwd)).catch((err: unknown) => {
       toast.error(
         t("chatContext.files.openFailed", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -144,9 +144,11 @@ export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
       <button
         type="button"
         onClick={() => onJumpToTurn(entry.lastTurn)}
-        className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
         title={entry.path}
       >
+        {/* 预留与目录 chevron 等宽的槽位，让同级目录名/文件名、图标列对齐 */}
+        <span className="size-3.5 shrink-0" aria-hidden="true" />
         <FileCode
           className="size-3.5 shrink-0 text-muted-foreground"
           aria-hidden="true"

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -1,20 +1,77 @@
-import { FileCode, Pencil } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  FileCode,
+  Folder,
+} from "lucide-react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
-import type { FileEntry } from "../derive";
+import { OpenPath } from "@/../wailsjs/go/app/App";
+
+import { deriveFileTree, type FileEntry, type FileTreeNode } from "../derive";
 
 type Props = {
   files: FileEntry[];
+  cwd: string;
+  remote: boolean;
   onJumpToTurn: (turn: number) => void;
 };
 
-function shortPath(p: string): string {
-  const parts = p.split("/");
-  return parts.length <= 2 ? p : parts.slice(-2).join("/");
+function DiffBadge({ plus, minus }: { plus: number; minus: number }) {
+  if (plus <= 0 && minus <= 0) return null;
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] font-medium"
+    >
+      {plus > 0 ? <span className="text-status-running">+{plus}</span> : null}
+      {minus > 0 ? <span className="text-destructive">−{minus}</span> : null}
+    </span>
+  );
 }
 
-export function FilesView({ files, onJumpToTurn }: Props) {
+function basename(path: string): string {
+  const parts = path.split("/");
+  return parts[parts.length - 1] ?? path;
+}
+
+function indentStyle(depth: number): React.CSSProperties {
+  return { paddingLeft: `${8 + depth * 14}px` };
+}
+
+export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
   const { t } = useTranslation();
+  const tree = React.useMemo(() => deriveFileTree(files), [files]);
+
+  // 展开状态仅存组件内、不持久化；文件集合变化时重置为全部展开。
+  const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
+  React.useEffect(() => {
+    setCollapsed(new Set());
+  }, [files]);
+
+  const toggleCollapse = (dirPath: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(dirPath)) next.delete(dirPath);
+      else next.add(dirPath);
+      return next;
+    });
+  };
+
+  const canOpen = cwd !== "" && !remote;
+
+  const openFile = (path: string) => {
+    OpenPath(`${cwd}/${path}`).catch((err: unknown) => {
+      toast.error(
+        t("chatContext.files.openFailed", {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    });
+  };
 
   if (files.length === 0) {
     return (
@@ -23,29 +80,93 @@ export function FilesView({ files, onJumpToTurn }: Props) {
       </div>
     );
   }
-  return (
-    <div className="flex flex-col gap-0.5 px-2 py-2.5">
-      {files.map((f) => (
+
+  const renderDir = (
+    node: Extract<FileTreeNode, { kind: "dir" }>,
+    dirPath: string,
+    depth: number,
+  ) => {
+    const isCollapsed = collapsed.has(dirPath);
+    return (
+      <div key={dirPath} className="flex flex-col">
         <button
-          key={f.path}
           type="button"
-          onClick={() => onJumpToTurn(f.lastTurn)}
-          className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
-          title={f.path}
+          onClick={() => toggleCollapse(dirPath)}
+          aria-expanded={!isCollapsed}
+          aria-label={
+            isCollapsed
+              ? t("chatContext.files.expandFolder", { name: node.name })
+              : t("chatContext.files.collapseFolder", { name: node.name })
+          }
+          className="flex items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50"
+          style={indentStyle(depth)}
         >
-          <FileCode
+          {isCollapsed ? (
+            <ChevronRight className="size-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+          )}
+          <Folder
             className="size-3.5 shrink-0 text-muted-foreground"
             aria-hidden="true"
           />
-          <span className="flex-1 truncate font-mono">{shortPath(f.path)}</span>
-          {f.edits > 0 ? (
-            <span className="inline-flex shrink-0 items-center gap-0.5 text-[10px] font-medium text-foreground">
-              <Pencil className="size-2.5" aria-hidden="true" />
-              {f.edits}
-            </span>
-          ) : null}
+          <span className="flex-1 truncate font-mono">{node.name}</span>
         </button>
-      ))}
+        {!isCollapsed ? (
+          <div className="flex flex-col">
+            {node.children.map((child) =>
+              child.kind === "dir"
+                ? renderDir(child, `${dirPath}/${child.name}`, depth + 1)
+                : renderFile(child.entry, depth + 1),
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderFile = (entry: FileEntry, depth: number) => (
+    <div
+      key={entry.path}
+      className="flex items-center"
+      style={indentStyle(depth)}
+    >
+      <button
+        type="button"
+        onClick={() => onJumpToTurn(entry.lastTurn)}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
+        title={entry.path}
+      >
+        <FileCode
+          className="size-3.5 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1 truncate font-mono">
+          {basename(entry.path)}
+        </span>
+        <DiffBadge plus={entry.plus} minus={entry.minus} />
+      </button>
+      {canOpen ? (
+        <button
+          type="button"
+          aria-label={t("chatContext.files.openFile")}
+          title={t("chatContext.files.openFile")}
+          onClick={() => openFile(entry.path)}
+          className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ExternalLink className="size-3" aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-0.5 px-2 py-2.5">
+      {tree.map((node) =>
+        node.kind === "dir"
+          ? renderDir(node, node.name, 0)
+          : renderFile(node.entry, 0),
+      )}
     </div>
   );
 }

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -2814,6 +2814,8 @@ function ChatPanel({
                 sessionId={session?.id ?? 0}
                 messages={messages}
                 activeMessageId={activeMessageId}
+                cwd={session?.cwd ?? ""}
+                remote={Boolean(session?.deviceID)}
                 onJumpToMessage={(mid) => {
                   transcriptHandleRef.current?.scrollToMessage(mid);
                 }}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -525,7 +525,11 @@
   "chatContext": {
     "files": {
       "empty": "No files have been changed in this session",
-      "label": "Files"
+      "label": "Files",
+      "openFile": "Open file",
+      "openFailed": "Failed to open file: {{error}}",
+      "expandFolder": "Expand {{name}}",
+      "collapseFolder": "Collapse {{name}}"
     },
     "outline": {
       "empty": "No messages in this session",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -525,7 +525,11 @@
   "chatContext": {
     "files": {
       "empty": "本会话还没有改过任何文件",
-      "label": "文件"
+      "label": "文件",
+      "openFile": "打开文件",
+      "openFailed": "打开文件失败：{{error}}",
+      "expandFolder": "展开 {{name}}",
+      "collapseFolder": "收起 {{name}}"
     },
     "outline": {
       "empty": "本会话还没有消息",


### PR DESCRIPTION
## 概要

把会话「文件」面板从扁平列表升级为**可折叠目录树**，编辑角标改为 **`+N`/`−N` 绿红 diff 行数**，并为本地会话的每个文件行提供**打开文件**图标按钮。

- 树：`deriveFileTree()` 纯函数建树，目录字母序、文件保持编辑权重序；目录 chevron 展开/收起、默认全部展开、组件内折叠态。
- diff 角标：`+N` 绿（`text-status-running`）/ `−N` 红（`text-destructive`），数据直接消费后端 `block.canonical`（`file.edit` 汇总 plus/minus、`file.write` 计 lines），前端不重复统计。
- 打开按钮：仅本地会话（`deviceID` 空）且 `cwd` 非空时渲染，点击 `OpenPath(cwd+path)`，失败 toast。
- i18n：新增 `openFile` / `openFailed` / `expandFolder` / `collapseFolder`（中英双语）。

## 验收结论（运行时验证，真实 app via `wails dev -tags e2e`）

| # | 标准 | 结论 |
|---|---|---|
| V1 | 可折叠目录树（默认全展开、chevron 收起/展开） | holds |
| V2 | `+N` 绿 / `−N` 红 diff 角标，数据来自真实 `block.canonical`（真实 replay/IPC 链路） | holds |
| V3 | 行点击跳转不回归；打开按钮并列独立、点击不触发跳转 | holds |
| V4 | 本地会话显示打开按钮 | holds |
| V5 | 远端会话隐藏打开按钮 | not observed（e2e fake 仅本地 backend；单测覆盖，已接受） |
| V6 | 打开按钮调用 `OpenPath`；失败 toast | holds |

证据：`e2e/scratch/2026-08-06-session-files-tree/`（report.md + 截图，gitignored）。

## 测试

- 前端全量：`204 files / 1899 tests` 通过；`tsc -b --noEmit`、ESLint 通过
- e2e 真实 app：目录树渲染/折叠、diff 角标（真实 replay→canonical）、打开按钮/错误 toast、目录名-文件名同级对齐（像素断言）

## 附带变更

- `docs/specs/2026-08-06-session-files-tree.md`：新增 spec（含 `docs/specs/` 不再被 `.gitignore` 忽略，恢复版本管理，同 `2026-08-01-agentred-session-durability.md` 先例）。

## 提交

1. `5a94b23a` 🙈 `docs/specs/` 纳入版本管理
2. `28933c74` 📝 spec
3. `03c656b8` ✨ feat: 目录树 + canonical diff 角标 + 打开按钮
4. `db4c721e` 🐛 fix: 路径兼容（绝对路径/Windows 分隔符/折叠 key）
5. `b411b367` 🐛 fix: 忽略空路径文件项
6. `98d48464` 🎨 同级目录名/文件名对齐（文件行 chevron 槽位）
7. `260769e8` 🎨 目录行显式 `text-left`（修复文件夹名被全局居中规则拉离图标）
