### PR TITLE
⚡️ perf: 超长思考流只渲染有界尾巴,消除 streaming 期 O(n²) 卡死

### DIFF
--- a/frontend/src/components/agentre/__tests__/thinking-block.test.tsx
+++ b/frontend/src/components/agentre/__tests__/thinking-block.test.tsx
@@ -179,6 +179,45 @@ describe("ThinkingBlock", () => {
     });
   });
 
+  // 防御性能 bug:超长思考流时,streaming 视图若把整段 text 都塞进 DOM,每个 chunk
+  // 都要 O(n) 重排 whitespace-pre-wrap 文本 → 整轮流式 O(n²) → 主线程卡死。streaming
+  // body 本就 max-h-[132px] overflow-hidden 并贴底,头部根本看不见,所以只需要渲染
+  // 末尾一段「尾巴」。这里锁定契约:streaming 时 DOM 里只含有界尾巴,头部 marker 不在;
+  // done 时仍渲染完整文本(落库/展开要用)。
+  describe("long streaming text renders only a bounded tail", () => {
+    const headMarker = "XHEAD-MARKER-X";
+
+    it("does not put the head / full text in the streaming DOM", () => {
+      const longText = headMarker + "思".repeat(20000);
+      const { container } = render(<ThinkingBlock text={longText} streaming />);
+      const body = container.querySelector(
+        '[data-slot="thinking-streaming-body"]',
+      );
+      expect(body).not.toBeNull();
+      const rendered = body?.textContent ?? "";
+      expect(rendered).not.toContain(headMarker);
+      expect(rendered.length).toBeLessThan(longText.length);
+      // 有界常数:不能只砍一半,得砍到一个固定窗口量级。
+      expect(rendered.length).toBeLessThan(2000);
+    });
+
+    it("still renders short text in full while streaming", () => {
+      render(<ThinkingBlock text="正在分析这个问题" streaming />);
+      expect(screen.getByText("正在分析这个问题")).toBeInTheDocument();
+    });
+
+    it("renders the full text in the done state", () => {
+      const longText = headMarker + "尾".repeat(20000);
+      const { container } = render(
+        <ThinkingBlock text={longText} streaming={false} />,
+      );
+      const content = container.querySelector(
+        '[data-slot="thinking-block-content"]',
+      );
+      expect(content?.textContent ?? "").toContain(headMarker);
+    });
+  });
+
   // 防御真实 bug:Claude Code CLI 把 thinking 整段一次性发出来,合成块只活几 ms,
   // 自计时只能拿到 0s。让外部传入 stream 起始时刻,从「按发送」开始算才有意义。
   describe("external startedAt", () => {

--- a/frontend/src/components/agentre/thinking-block.tsx
+++ b/frontend/src/components/agentre/thinking-block.tsx
@@ -12,6 +12,26 @@ import {
 } from "./transcript-card";
 import { useTranscriptBooleanState } from "./transcript-ui-state";
 
+// STREAMING_TAIL_MAX_CHARS 限制 streaming 视图实际渲染的思考文本长度。streaming body
+// 本就是 max-h-[132px] overflow-hidden 并贴底显示 —— 头部永远看不见。若把整段 text 都
+// 塞进 DOM,每个 chunk 都要 O(n) 重排 whitespace-pre-wrap 文本块,一整轮流式下来是
+// O(n²),长思考流会卡死主线程(用户可见症状:app 卡死/卡顿)。只渲染末尾一个窗口量级
+// 的尾巴,单 chunk 渲染降到 O(1)。完整 text 仍由 store 累积,done/落库态照常使用全文。
+const STREAMING_TAIL_MAX_CHARS = 1200;
+
+// streamingTail 取 text 末尾不超过 STREAMING_TAIL_MAX_CHARS 的一段。cut 落在代理对
+// 后半时回退一格,避免开头出现半个代理对被渲染成替换符。
+function streamingTail(text: string): string {
+  if (text.length <= STREAMING_TAIL_MAX_CHARS) return text;
+  const cut = text.length - STREAMING_TAIL_MAX_CHARS;
+  let start = cut;
+  if (start > 0) {
+    const code = text.charCodeAt(start);
+    if (code >= 0xdc00 && code <= 0xdfff) start -= 1;
+  }
+  return text.slice(start);
+}
+
 type ThinkingBlockProps = {
   text: string;
   /** 该 block 是否正处在流式输出中。父组件根据 stream 上下文判断后传入。 */
@@ -172,9 +192,10 @@ export function ThinkingBlock({
             {streaming ? (
               <div
                 ref={streamingBodyRef}
+                data-slot="thinking-streaming-body"
                 className="max-h-[132px] overflow-hidden whitespace-pre-wrap break-words px-3.5 py-3 text-aux italic text-muted-foreground"
               >
-                {text}
+                {streamingTail(text)}
               </div>
             ) : (
               <div className="whitespace-pre-wrap break-words px-3.5 py-3 text-aux italic text-muted-foreground">

--- a/internal/pkg/agentruntime/runtimes/fake/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/fake/runtime.go
@@ -53,6 +53,12 @@ const HookCreateDirectivePrefix = "e2e-hook-create:"
 // 到 AutonomousTurns(sessionID) 的 channel(详见 autoturn.go)。
 const BackgroundTaskDirectivePrefix = "e2e-bg-task:"
 
+// LongThinkingDirectivePrefix 触发「超长思考流」接缝的用户指令:e2e-long-thinking:<runes>。
+// emit <runes> 个思考字符(8 rune 一片,受 AGENTRE_E2E_FAKE_CHUNK_DELAY_MS 节奏控制)后
+// 接一段短文本再 Done。仅用于本地 e2e 验证:超长思考流时前端 streaming 视图是否还会
+// 卡死(thinking block 应只渲染有界尾巴,而非每个 chunk 重排整段文本)。仅 e2e 构建存在。
+const LongThinkingDirectivePrefix = "e2e-long-thinking:"
+
 // Runtime 实现 agentruntime.Runtime + agentruntime.AutonomousTurnSource(见 autoturn.go)。
 type Runtime struct {
 	// mu 保护 autoTurns。Run(每轮)与 AutonomousTurns(chat_svc 每会话订阅一次)
@@ -108,6 +114,29 @@ func (r *Runtime) Run(ctx context.Context, req agentruntime.RunRequest) (<-chan 
 	go func() {
 		defer close(out)
 		defer r.leaveTurn(req.SessionID)
+		// 超长思考流接缝(e2e-long-thinking:<runes>):先流式发一大段 thinking,再发短文本
+		// 收尾,用于本地验证前端长思考流不再卡死。提前 return,跳过下面的回显/工具接缝。
+		if rawRunes, found := parseOnePartDirective(req.UserText, LongThinkingDirectivePrefix); found {
+			n, _ := strconv.Atoi(rawRunes)
+			if n > 0 {
+				if err := r.emitLongThinking(ctx, out, n, chunkDelay); err != nil {
+					return
+				}
+			}
+			for _, chunk := range splitChunks("e2e-fake-reply: long-thinking-done", 8) {
+				select {
+				case <-ctx.Done():
+					return
+				case out <- agentruntime.TextDelta{Text: chunk}:
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- agentruntime.Done{}:
+			}
+			return
+		}
 		for i, chunk := range splitChunks(reply, 8) {
 			if i > 0 && chunkDelay > 0 {
 				timer := time.NewTimer(chunkDelay)
@@ -281,9 +310,35 @@ func configuredChunkDelay() time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
+// emitLongThinking 流式发送 runes 个思考字符(8 rune 一片),供长思考流压测。filler
+// 混入 CJK(宽字符,加重 whitespace-pre-wrap 重排成本)+ 空格 + 少量换行,贴近真实思考文本。
+func (r *Runtime) emitLongThinking(ctx context.Context, out chan<- agentruntime.Event, runes int, chunkDelay time.Duration) error {
+	filler := []rune("思考流压力测试 thinking stream padding text 持续输出用于触发前端重排 ")
+	var b []rune
+	for i := 0; i < runes; i++ {
+		b = append(b, filler[i%len(filler)])
+	}
+	for i, chunk := range splitChunks(string(b), 8) {
+		if i > 0 && chunkDelay > 0 {
+			timer := time.NewTimer(chunkDelay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- agentruntime.ThinkingDelta{Text: chunk}:
+		}
+	}
+	return nil
+}
+
 // splitChunks 按 rune 边界把 s 切成最多 n 个 rune 的片段。
-func splitChunks(s string, n int) []string {
-	if n <= 0 || s == "" {
+func splitChunks(s string, n int) []string {	if n <= 0 || s == "" {
 		return nil
 	}
 	runes := []rune(s)


### PR DESCRIPTION
## 问题
AI 思考流(thinking stream)很长时,app 卡死/卡顿。

## 根因
streaming 期 \`ThinkingBlock\` 把**整段累积 thinking 文本**作为单个 \`whitespace-pre-wrap\` 节点,每个 chunk 整段重渲,再加一个 \`useLayoutEffect\` 同步读 \`scrollHeight\` 强制重排 → 整轮流式 **O(n²) 浏览器文本布局**。渲染范围本身已隔离(WeakMap 行缓存 + \`React.memo(TranscriptRowView)\`,只有 live thinking 行每 chunk 重渲),代价全集中在本块。\`StreamingMarkdown\` 早已用「定稿段 + 活跃尾巴」解决同类问题,thinking 一直没这待遇。streaming body 本就 \`max-h-132px\` 贴底,头部根本看不见。

## 修复
streaming 视图只渲染末尾有界尾巴(\`STREAMING_TAIL_MAX_CHARS = 1200\`),单 chunk 渲染 O(n)→O(1);全文仍由 store 累积,done/落库态照常使用全文。

## 验证(真 app + 真浏览器布局,jsdom 测不出布局卡顿)
给 fake runtime 加 e2e-only \`e2e-long-thinking:<runes>\` 指令驱动超长思考流,Long Tasks + 收尾时长量化:

| 指标 (40k chars) | 修复前 | 修复后 |
| --- | ---: | ---: |
| 收尾 wallMs | 107458 | **17670** |
| >50ms 主线程任务数 | 274 | **5** |
| 累计阻塞 ms | 19135 | **280** |

随文本长度:修复前 20k→40k wallMs 20s→107s(二次方爆炸),修复后 10.4s→17.7s(~线性)。

## 测试
- \`thinking-block.test.tsx\` 新增契约测试:streaming DOM 不含头部且有界、done 态仍渲染全文(修复前红 / 修复后绿)。
- 全量 vitest 1941 通过 + tsc + eslint 全绿。
- Go 侧仅 \`//go:build e2e\` 的 fake 变更(\`-tags e2e\` 构建/测试通过),不进默认构建。

## 文件
- \`frontend/src/components/agentre/thinking-block.tsx\` — 修复
- \`frontend/src/components/agentre/__tests__/thinking-block.test.tsx\` — 契约测试(持久回归守卫)
- \`internal/pkg/agentruntime/runtimes/fake/runtime.go\` — e2e-only \`e2e-long-thinking\` 指令(验证脚手架,与既有 \`e2e-bg-task\`/\`e2e-ask\` 同款接缝)