### PR TITLE
🐛 Turn 中断安全：Aborter per-turn token + 有界 interrupt + 中断后会话状态归属

### DIFF
--- a/docs/specs/2026-08-07-turn-abort-safety.md
+++ b/docs/specs/2026-08-07-turn-abort-safety.md
@@ -1,0 +1,138 @@
+# Turn 中断安全：跨轮 abort race / 无界 interrupt / 带外中断后的会话状态归属
+
+> Status: Draft
+> Owner: Agentre 桌面端
+> Last updated: 2026-08-07
+
+**Objective:** 让「中断（abort / interrupt）」在跨轮切换、CLI 不回应、带外轮三种边界下都不再伤害错误的轮次、不再挂起 goroutine、不再让会话状态无人 reconcile——三条来自 `docs/specs/2026-08-07-autonomous-turn-resilience.md` 落库后的已知残留风险，用一个统一的 `Aborter` 接口变更 + 两处运行时内部改动闭合。
+
+**Hard invariant:**
+- 失败处置不得阻塞 watcher goroutine（`startAutonomousWatcher` 是每会话单 goroutine 顺序处理，一轮处置卡住会波及该会话所有后续自主轮；`TestDriveAutonomousTurn_PersistFailure_InterruptDoesNotBlockWatcher` 明令禁止）。
+- `driveAutonomousTurn` / `driveSubagentActivity` 在 drain 事件期间绝不持 chat 会话锁（与 `pkg/claudecode.Session` 常驻 reader 死锁）。
+- 不得为「修中断超时」而把错误升级成 `handle.Close()` + 逐出缓存——那会杀掉一个活着的子进程。
+
+## Problem
+
+1. **跨轮 abort race：`Aborter` 没有轮身份，迟到的中断会打到错的轮上。** `internal/pkg/agentruntime/runner.go:552` 的 `Abort(ctx, sessionID)` 只按 sessionID 寻址，语义是「中断该会话**当前活跃的那一轮**」（claudecode `runtimes/claudecode/runtime.go:242` 用 `inTurn || outOfBandActive()` 判定，无任何轮标识）。`failAutonomousTurnPersist` 的中断是异步发出的（`autonomous_turn.go:281` `go func() { _ = s.requestRuntimeAbort(ctx, be, sessionID) }()`），与第 4 步 `drainAndDiscard` 无先后约束：若 drain 结束、CLI 起了**下一轮**（另一个自主轮 / 用户刚发的新消息）后这条迟到中断才落地，它会把错的一轮杀掉。`Stop` 的 `abortOutOfBandTurn`（`chat.go:1822`）同理：`session.Find` 到 Abort 落地之间发生轮切换就打偏。piagent 已有「generation 不得被旧代清理误删」的运行时内防（`runtimes/piagent/runtime_test.go:456` `TestRun_StaleCleanupCannotUnregisterNewerGeneration`），但那是**运行时内部**的陈旧清理保护，调用方依然无法表达「中断某一轮」——接口层没有任何轮身份。
+
+2. **无界 interrupt ctx：不回应中断的 CLI 会把 goroutine 挂到子进程死。** `pkg/claudecode/session.go:769` 的 `Interrupt` 写完 `control_request{interrupt}` 后阻塞在 `select { ctx.Done() / readerDone / 回执 }`，**没有 deadline**。调用方两个都无界：`failAutonomousTurnPersist` 传的是 `context.Background()`（来自 `startAutonomousWatcher`），CLI 不回执就泄漏一个 goroutine 直到子进程死；`Stop` 传的是 Wails 的 `a.ctx`（`internal/app/chat.go:107`），同样无 deadline。**直接加 deadline 更糟**：`runtimes/claudecode/runtime.go:248-252` 把**任何** `Interrupt` 错误（含超时）升级成 `_ = a.handle.Close(ctx)` + `r.cache.Remove(...)`，超时等于杀掉一个活着的子进程。唯一的有界先例 `piStopAbortWriteBound = 500ms`（`chat.go:70`）只用在 Pi 的 graceful aborter 上。
+
+3. **带外中断后会话状态无人 reconcile：中断 subagent 活动轮会让会话停在 running/waiting。** `reconcileOrphanStop`（`chat.go:1791`）对带外轮走「中断它，状态留给那一轮自己收尾」：`abortOutOfBandTurn` 成功即返回 `{Stopped: true}`、**不落库**。该假设对自主轮成立（`driveAutonomousTurn` 收尾翻 idle/error），对 **subagent 活动轮不成立**——`driveSubagentActivity` 按设计不碰会话状态（`subagent_activity.go:56-57`「不翻 session running——会话保持 idle」，全文件不写 `AgentStatus`）。于是中断了一个 subagent 活动轮后，running/waiting 的会话停在原态，要再点一次停止（此时轮已结束 → `ErrNoActiveTurn` → reconcile 回 idle）才恢复。现有测试 `TestStop_OutOfBandTurnIsInterruptedNotReconciled`（`chat_test.go:8613`）用通用 `abortRecordingRunner`，只断言「中断下发 + 不 reconcile」，**不区分自主轮 / subagent 活动轮**，该缺口既存在也没被钉死。
+
+## Actors and user stories
+
+1. 作为使用 Agentre 的开发者，当一轮自主续轮落库失败被中断时，我要这条中断**只作用于失败的那一轮**，这样我不会刚发出一条新消息就被一条迟到的旧中断杀掉。
+2. 作为使用 Agentre 的开发者，当 CLI 不回应中断时，我要中断路径**有界返回**且**不杀子进程**，这样桌面端不会泄漏 goroutine、也不会把健康子进程逐出缓存。
+3. 作为使用 Agentre 的开发者，当我在带外轮在飞时点「停止」，我要会话状态**一次点停就收干净**，这样我不必再点一次停止才能让侧栏脱离 running/waiting。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | `Aborter.Abort` 增加 per-turn token：`Abort(ctx, sessionID, turnToken uint64)`，`0` = 当前活跃轮（用户点停止语义不变），非 0 = 仅当该轮仍是当前轮才中断、否则 stale no-op；token 由各 runtime 按轮递增并随 `RunResult` / `AutonomousTurn` / `SubagentActivity` 暴露给调用方 | 只有目标明确的内部中断（`failAutonomousTurnPersist`）需要精确寻址；用户面向的 Stop 语义本就是「停当前活跃轮」，用 0 保持。**拒绝**：不改接口、drain 后 join goroutine —— 会重新阻塞 watcher，被 `InterruptDoesNotBlockWatcher` 明令禁止（见问题 2 的挂起）；**拒绝**：在 consumer 加「abort 前再查当前轮」防御 —— runtime 不暴露轮身份，consumer 无从判断，治标不治本；**拒绝**：另加 `AbortTurn` 方法 —— 与既有 `Abort` 语义重叠，调用方还得先判断轮类型，同 #28 拒绝 `AbortOutOfBand` 的理由 |
+| 2 | `pkg/claudecode.Session.Interrupt` 的 ack 等待加**有界**超时（`interruptAckBound = 500ms`，与 `piStopAbortWriteBound` 同值，真实 CLI 观察只做校准），超时返回**独立错误** `ErrInterruptPending`；`claudecode.Runtime.Abort` 把 `ErrInterruptPending` 当作「中断已下发、ack 异步到」→ 返回 nil、**不** Close+evict；只有真正的错误（写帧失败 / session closed / CLI 拒绝）才保留 Close+evict 兜底 | 关键事实：ack 回执只能由常驻 readLoop 派发，而 readLoop 可能正停在给本轮 feed 事件上——ack 天然晚于 drain 完成。有界 ack + 不杀子进程后，超时路径变成「中断已发、drain 继续、readLoop 追上来后 ack 到、turn 自然收尾」，正好闭合 `failAutonomousTurnPersist` 的异步形态。**拒绝**：在调用方包 `context.WithTimeout` —— 超时是普通 error，`runtime.go:248` 直接 Close+evict 杀活子进程；**拒绝**：维持现状（无 deadline）—— background ctx 永久挂 goroutine；**拒绝**：Interrupt 完全 fire-and-forget（写完帧即返）—— 丢掉「CLI 拒绝 / 无活跃轮」信号，`reconcileOrphanStop` 的 `ErrNoActiveTurn` 判据失效 |
+| 3 | `Abort` 返回值从 `error` 扩为「被中断轮的类型」，`reconcileOrphanStop` 按类型接管会话状态：中断的是自主轮 → 保持「留给轮自己收尾」；中断的是 subagent 活动轮 → 自己 reconcile 回 idle；`ErrNoActiveTurn` → 既有遗孤路径不变 | 让「谁拥有会话状态」显式化：自主轮自己收尾（`driveAutonomousTurn` 翻 idle/error）、subagent 活动轮不碰状态、缺口由发起中断的 `reconcileOrphanStop` 补上。**拒绝**：让 `driveSubagentActivity` 收尾时无条件 reconcile —— 它正常发生在 idle 态（no-op），但 running/waiting 态可能是合法状态（`awaitingPlanAction` / 自动接续窗口），盲目翻 idle 会 clobber；**拒绝**：`reconcileOrphanStop` 中断后无条件立即 reconcile（反向推翻 #28 的 deferral）—— 与自主轮收尾 race（自主轮可能翻 error，被后写的 idle 盖掉），且 CLI 尾帧还在流时就谎报 idle |
+| 4 | 决策 1 与决策 3 的接口变更**合并为一次** `Aborter` 变更（token + 被中断轮类型），不拆成两次 | 二者都落在同一个接口的同一批实现（6 个真 runtime + mock + `remote/wire` + daemon handler）上，合并只改一次。**拒绝**：分两次独立改 —— 同一批文件动两遍，中间态还要维护兼容 |
+
+## 决策 1：Aborter 增加 per-turn token（接口 / 行为变更 + 反例）
+
+**行为契约（变更后）**
+
+- `Abort(ctx, sessionID, turnToken)`：`turnToken == 0` → 「中断该会话当前活跃的那一轮」（等价于现行为，用户点停止的语义与 UX 不变）；`turnToken != 0` → 「仅当该轮仍是当前活跃轮时才中断」，否则视为 stale、返回 nil（no-op），不触碰任何其它轮。
+- token 由 runtime 按轮生成：每个 `Run`（用户轮）、每轮自主续轮、每轮 subagent 活动入口递增一次会话级计数器（claudecode 在 `claudeActive` 上加 `turnSeq atomic.Uint64`；codex / builtin / openclaw 在各自的 `active[sessionID]` 上加同款；remote 透传 token 并落在 wire 上）。生成的 token 随 `agentruntime.RunResult` / `AutonomousTurn` / `SubagentActivity` 暴露给 `chat_svc`。
+- 唯一需要**精确寻址**的调用方是 `failAutonomousTurnPersist`：在落库失败时捕获 `at.Token`，异步 abort 携带它——drain 完成后即使新轮已起，迟到中断也只会 no-op，不会杀掉新轮。用户面向路径（`Stop` 的活跃用户轮 / `abortOutOfBandTurn`）一律传 `0`。
+
+**接口波及面（合并决策 1 + 3 一次改完）**
+
+- `internal/pkg/agentruntime/runner.go:552` `Aborter`：签名 + 返回值。
+- 6 个真 runtime 的 `Abort`：claudecode / codex / builtin / piagent / openclaw / remote（外加 `mock_agentruntime` 的 `MockAborter`）。
+- 远端链路：`remote/wire/wire.go:303` `AbortParams` 加 token 字段 + `internal/daemon/handlers/runtime.go:955` daemon 侧 Abort 透传。
+- `chat_svc` 三处调用点：`Stop`（活跃用户轮）、`abortOutOfBandTurn`、`failAutonomousTurnPersist`。
+
+**反例（rejected）**
+
+- **drain 后 join 异步 abort goroutine**：那条 goroutine 阻塞在 `Interrupt` 的 ack 等待（问题 2 的无界形态），在 watcher 里 join 它 = 把 watcher 挂死，违反 Hard invariant，且被本轮既有测试 `InterruptDoesNotBlockWatcher` 明令禁止。
+- **consumer 侧防御（abort 前再查当前轮是否同一轮）**：runtime 不暴露轮身份，`chat_svc` 无从比较；且这是在消费方掩盖生产者（runtime）缺身份的问题，违反「修根因不掩蔽」。
+- **不改接口、接受「迟到的中断杀掉新轮」**：正是本次要修的可观察危害——用户刚发出的新消息被一条无主中断腰斩，且无法从日志区分（无轮身份可查）。
+- **给每轮起独立子进程（换 session 隔离轮）**：推翻 #28 的常驻进程复用，代价远超收益。
+
+## 决策 2：Interrupt 有界 ack + `ErrInterruptPending` 不杀子进程（行为变更 + 反例）
+
+**行为契约（变更后）**
+
+- `Session.Interrupt(ctx)`：写完 `control_request{interrupt}` 后等 ack，但等的时间**有界**（`interruptAckBound = 500ms`，与 `piStopAbortWriteBound` 同值）。超时返回**独立错误** `ErrInterruptPending`，帧已写、中断在途，CLI 处理到后会自然收尾。取值的唯一未定项是「ack 依赖 readLoop 追平 drain 的派发延迟是否能在 500ms 内到达」，由收尾时的真实 CLI 观察**校准**；若实测不足，作为独立修订走审批，不静默放宽。
+- `claudecode.Runtime.Abort` 对 `ErrInterruptPending`：视作「中断已下发」→ 返回 nil（配合决策 3，向 `chat_svc` 报告被中断轮的类型），**不** `Close(ctx)`、**不** `cache.Remove`。只有写帧失败 / session closed / CLI 明确拒绝等**真错误**才保留 `runtime.go:248-252` 的 Close+evict 兜底（那些情形下子进程确实焊死/已死，杀掉才合理）。
+- 效果闭环（`failAutonomousTurnPersist`）：中断异步发出 → ack 有界等待超时 → `ErrInterruptPending` → 不杀子进程 → watcher 继续第 4 步 drain → readLoop 追上来派发 ack → turn 以 result 收尾。桌面端不挂 goroutine、不杀活子进程、轮照常收尾。
+- 同款无界形态存在于 `StopTask`（`session.go:827` 的 select）——同一修复类，一并纳入本轮（StopBackgroundTask 同样不能因超时杀子进程）。
+
+**反例（rejected）**
+
+- **调用方包 `context.WithTimeout`**：超时是普通 error，`runtime.go:248` 直接 `Close` + `cache.Remove`——杀掉一个活着的子进程，正是本轮 Hard invariant 禁止的。
+- **维持现状（无 deadline）**：`failAutonomousTurnPersist` 的 background ctx 永久挂一个 goroutine 到子进程死；`Stop` 的 `a.ctx` 同理。
+- **Interrupt 完全 fire-and-forget**：写完帧立刻返回，丢失「CLI 拒绝 / 无活跃轮」信号，`reconcileOrphanStop` 依赖的 `ErrNoActiveTurn` 判据塌掉（无法区分「真有一轮被中断」与「没轮可中断」）。
+- **有界 ack + 超时当普通错误但单独豁免 Close**：等价于为超时单开一条不杀路径，但错误类型不区分，其它调用方（看门狗等）会误判为真错误——不如显式 `ErrInterruptPending` 类型语义清晰。
+
+## 决策 3：Abort 上报被中断轮类型，`reconcileOrphanStop` 按类型接管（行为变更 + 反例）
+
+**会话状态归属契约（变更后）**
+
+| 被中断的轮 | 谁 reconcile 会话状态 | 终态 |
+|---|---|---|
+| 用户轮 | `runTurn` / finalize | idle / error / waiting（既有） |
+| 自主续轮 | `driveAutonomousTurn` 收尾 | idle / error（既有） |
+| subagent 活动轮 | **`reconcileOrphanStop`（新增）** | idle |
+| 无轮（`ErrNoActiveTurn`） | `reconcileOrphanStop` 遗孤路径 | idle（既有） |
+
+- `Abort` 返回被中断轮的类型（决策 1 的同一接口变更顺带携带）。`reconcileOrphanStop` 分支：
+  - 中断的是自主轮 → 维持现状：返回 `{Stopped: true}`，状态留给 `driveAutonomousTurn` 收尾（它一定会写 idle/error）。
+  - 中断的是 subagent 活动轮 → **自己**把会话翻 idle 并持久化（复用遗孤路径的翻写逻辑）——用户点了停止、没有用户轮在飞，running/waiting 已无合法依据；subagent 活动轮的 `driveSubagentActivity` 不写状态，缺口由这里补上。
+  - `ErrNoActiveTurn` / 解析不出 runner → 既有遗孤 reconcile 路径不变。
+- 一次点停止即可收干净，不再需要第二次点停止。
+- **作用范围（用户确认）**：本变更仅作用于**带外路径**（`reconcileOrphanStop`）；`Stop` 的**活跃用户轮**路径（用户轮刚结束、abort 落在活动轮上）维持现状，仍走既有 `finalize` 收尾，不新增接管。
+
+**反例（rejected）**
+
+- **让 `driveSubagentActivity` 收尾时无条件 reconcile**：活动轮**正常**发生在 idle 态，翻 idle 是 no-op；但 running/waiting 可能是**合法**状态（`awaitingPlanAction` 在等计划批准、自动接续窗口保持 running），subagent 活动轮收尾时盲目翻 idle 会 clobber 掉合法状态。subagent 活动轮**无法**从自身判断「会话的 running/waiting 是否因我而存在」，所以不能由它收尾。
+- **`reconcileOrphanStop` 中断后无条件立即 reconcile**（反向推翻 #28 的「留给轮收尾」）：与自主轮的收尾 race——自主轮可能翻 `error`（中断 → `StopErr`），被后写的 idle 盖掉；且 CLI 尾帧还在流时就谎报 idle，正是 #28 明确拒绝的形态。按类型分流后，自主轮仍留给它自己收尾，规避了这两个 race。
+- **维持现状**：会话卡 running/waiting、要第二次点停止才 reconcile——本次要修的可见缺陷。
+
+## 会话状态归属与中止的边界
+
+- **用户面向的 Stop 语义不变**：`turnToken=0` = 「停当前活跃轮」，用户点停止时无论当前活跃的是用户轮 / 自主轮 / subagent 活动轮，都中断它（沿用 #28 的 `inTurn || outOfBandActive` 判据）。
+- **内部面向的中断是精确寻址**：`failAutonomousTurnPersist` 携带失败轮的 token，只中断那一轮，绝不波及之后新起的轮。
+- **终态收敛**：所有被中断的轮，其会话终态最终收敛到 idle 或 error（error 仅当轮带 `StopErr`），且每一步翻转都是既有的 last-write-wins 持久化，不引入新的状态值。
+- **失败路径**：`reconcileOrphanStop` 接管翻 idle 的那次写若失败，只记日志、不重试、不阻塞（与遗孤路径现状一致）；`ErrInterruptPending` 路径不改变任何 DB 状态。
+
+## Out of scope
+
+- **带外轮活性检测**（帧流长时间静默的兜底）——与上一轮 `autonomous-turn-resilience.md` 的 Out of scope 一致，判据必须排除「`waiting` 态合法等待用户回答」的情形，设计比本轮微妙，需要单独一轮。
+- **远端 Pi 的 `abortGeneration` 内部 generation gate 重构**——它已有 session 对象身份校验，本次只让它适配新接口（透传 token / 返回轮类型），不重写其陈旧清理逻辑。
+- **`driveSubagentActivity` 的三处 `drainAndDiscard`**（找不到发起消息 / 加载会话失败）——同类静默丢弃但不在中断链上，维持上一轮 Out of scope。
+- **恢复已卡死的历史会话现场**——手工操作，不由代码交付。
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| `claudecode.Runtime.Abort`（fake handle 注入 token + ack 延迟） | 带 token 的 abort 在轮已切换时 no-op、不中断新轮；`ErrInterruptPending` 返回 nil 且不 Close/不 evict；`turnToken=0` 行为不变 | `runtimes/claudecode/runtime_test.go` 既有 `TestRuntime_Abort`（`runtime_test.go:733` 钉死 `inTurn \|\| outOfBandActive`） |
+| `pkg/claudecode.Session.Interrupt`（fake proc 不回 ack） | 有界 ack 超时返回 `ErrInterruptPending`（errors.Is 可判），写帧只发生一次；正常回执路径仍返 nil | `pkg/claudecode/` 既有 session 测试 |
+| `chatSvc.failAutonomousTurnPersist`（repo mock + abortRecordingRunner 带 token） | 异步 abort 携带失败轮的 token；模拟「drain 后新轮已起」时迟到中断 no-op、新轮不受影响 | `autonomous_turn_test.go` 既有 `InterruptDoesNotBlockWatcher` |
+| `chatSvc.Stop` / `reconcileOrphanStop`（mock runner 返回「被中断的是 subagent 活动轮」） | 一次点停止即把 running/waiting reconcile 回 idle 并持久化；自主轮分支仍不落库（维持既有测试）；`ErrNoActiveTurn` 遗孤路径不变 | `chat_test.go:8613` `TestStop_OutOfBandTurnIsInterruptedNotReconciled`（需扩为按类型断言） |
+| `remote` wire + daemon handler | `AbortParams` 携带 token；daemon 侧透传并返回轮类型 | `remote/runtime_test.go`、`daemon/integration_test.go` 既有 abort 用例 |
+| mock 再生成 | `mock_agentruntime.MockAborter` 随接口签名更新 | `make mock` |
+
+单元测试覆盖不到的边界（收尾时源码审查 + 一次真实启动观察承担）：
+
+- 有界 ack 的**真实时长**取决于 CLI 在 readLoop 忙时的派发延迟。取值已定为 500ms，真实 CLI 观察只负责**校准**该值是否够 readLoop 追平后派发 ack；若实测不足，作为独立修订走审批，不静默放宽。
+- 跨轮 race 的**精确交错**难以做成常驻用例，由 token 语义的单元测试 + 代码审查覆盖。
+
+## Links
+
+- 上一轮：`docs/specs/2026-08-07-autonomous-turn-resilience.md`（三条残留风险来自其落库后；决策 8 放宽 Abort 活跃判据、`reconcileOrphanStop` 的「留给轮收尾」是本轮决策 3 的直接上下文）
+- 关键实现点：`internal/pkg/agentruntime/runner.go:552`（Aborter）、`pkg/claudecode/session.go:735/769`（Interrupt 无界 select）、`runtimes/claudecode/runtime.go:236-255`（Abort + Close/evict）、`internal/service/chat_svc/autonomous_turn.go:281`（异步 abort）、`internal/service/chat_svc/chat.go:1791-1845`（reconcileOrphanStop / abortOutOfBandTurn）
+- 既有保护：`internal/service/chat_svc/autonomous_turn_test.go` `TestDriveAutonomousTurn_PersistFailure_InterruptDoesNotBlockWatcher`；`internal/service/chat_svc/chat_test.go:8613` `TestStop_OutOfBandTurnIsInterruptedNotReconciled`
+- 先例：`piStopAbortWriteBound = 500ms`（`internal/service/chat_svc/chat.go:70`）；piagent generation 防陈旧清理（`runtimes/piagent/runtime_test.go:456`）
+
+## Open questions
+
+无。

--- a/internal/daemon/handlers/runtime.go
+++ b/internal/daemon/handlers/runtime.go
@@ -754,6 +754,7 @@ func (h *RuntimeHandlers) forwardAutonomousTurn(em *sessionEmitter, at agentrunt
 	em.emit(wire.NotifyAutonomousTurnStarted, &wire.AutonomousTurnStartedFrame{
 		SessionID: sid,
 		Trigger:   at.Trigger,
+		TurnToken: at.TurnToken,
 	})
 	count := 0
 	for ev := range at.Events {
@@ -942,6 +943,7 @@ func runResultToFrame(sid int64, r *agentruntime.RunResult) wire.RunResultDoneFr
 		UserAnchor:        r.UserAnchor,
 		Model:             r.Model,
 		ContextWindow:     r.ContextWindow,
+		TurnToken:         r.TurnToken,
 	}
 	if r.Usage != nil {
 		f.Usage = &wire.UsageWire{
@@ -1040,24 +1042,24 @@ func (h *RuntimeHandlers) DrainPending(ctx context.Context, p wire.DrainParams) 
 	return wire.DrainResult{Steers: steers}, nil
 }
 
-func (h *RuntimeHandlers) Abort(ctx context.Context, p wire.AbortParams) (wire.OK, error) {
+func (h *RuntimeHandlers) Abort(ctx context.Context, p wire.AbortParams) (wire.AbortResult, error) {
 	// 会话键按对端隔离,而这里要处理的可能是他端(账号)接管后的会话:先解析
 	// 提交方对端(省略 = 调用方自己),再按隔离后的键查本 handler 的内存会话表。
 	peer, err := ResolveSessionPeer(ctx, p.PeerFingerprint, h.deps.ClaimedAccountID)
 	if err != nil {
-		return wire.OK{}, err
+		return wire.AbortResult{}, err
 	}
 	rid := runtimeSessionID(peer, p.SessionID)
 	h.mu.Lock()
 	owner := h.sessions[rid]
 	if owner == nil {
 		h.mu.Unlock()
-		return wire.OK{}, agentruntime.ErrNoActiveTurn
+		return wire.AbortResult{}, agentruntime.ErrNoActiveTurn
 	}
 	if owner.backendType == agent_backend_entity.TypePiAgent && owner.ctx != nil {
 		if owner.terminalClaimed || owner.finalizing || owner.aborting {
 			h.mu.Unlock()
-			return wire.OK{}, h.waitPiFinalization(ctx, owner)
+			return wire.AbortResult{}, h.waitPiFinalization(ctx, owner)
 		}
 		owner.cancelRequested = true
 		owner.aborting = true
@@ -1070,10 +1072,10 @@ func (h *RuntimeHandlers) Abort(ctx context.Context, p wire.AbortParams) (wire.O
 			owner.cancel()
 		}
 		if preparing || starting {
-			return wire.OK{}, h.waitPiFinalization(ctx, owner)
+			return wire.AbortResult{}, h.waitPiFinalization(ctx, owner)
 		}
 		if !accepted {
-			return wire.OK{}, h.finalizePiGeneration(ctx, rid, owner)
+			return wire.AbortResult{}, h.finalizePiGeneration(ctx, rid, owner)
 		}
 
 		// An acknowledged prompt owns one terminal settlement. Runtime Abort is
@@ -1081,37 +1083,38 @@ func (h *RuntimeHandlers) Abort(ctx context.Context, p wire.AbortParams) (wire.O
 		// does, this RPC waits only for the bounded exact-owner finalization.
 		var abortErr error
 		if aborter, ok := h.lookupRuntimeByType(owner.backendType).(agentruntime.Aborter); ok {
-			abortErr = aborter.Abort(ctx, rid)
+			_, abortErr = aborter.Abort(ctx, rid, p.TurnToken)
 			if errors.Is(abortErr, agentruntime.ErrNoActiveTurn) {
 				abortErr = nil
 			}
 		}
 		if abortErr != nil {
 			cleanupErr := h.finalizePiGeneration(ctx, rid, owner)
-			return wire.OK{}, errors.Join(abortErr, cleanupErr)
+			return wire.AbortResult{}, errors.Join(abortErr, cleanupErr)
 		}
 		waitErr := h.waitPiFinalization(ctx, owner)
 		if waitErr == nil {
-			return wire.OK{}, nil
+			return wire.AbortResult{}, nil
 		}
 		h.mu.RLock()
 		terminalOwned := owner.terminalClaimed || owner.finalizing
 		h.mu.RUnlock()
 		if terminalOwned {
-			return wire.OK{}, waitErr
+			return wire.AbortResult{}, waitErr
 		}
 		cleanupErr := h.finalizePiGeneration(ctx, rid, owner)
-		return wire.OK{}, errors.Join(waitErr, cleanupErr)
+		return wire.AbortResult{}, errors.Join(waitErr, cleanupErr)
 	}
 	h.mu.Unlock()
 	a, rid, err := resolveSessionCapability[agentruntime.Aborter](ctx, h, p.SessionID, p.PeerFingerprint)
 	if err != nil {
-		return wire.OK{}, err
+		return wire.AbortResult{}, err
 	}
-	if err := a.Abort(ctx, rid); err != nil {
-		return wire.OK{}, err
+	outcome, err := a.Abort(ctx, rid, p.TurnToken)
+	if err != nil {
+		return wire.AbortResult{}, err
 	}
-	return wire.OK{}, nil
+	return wire.AbortResult{TurnKind: outcome.TurnKind}, nil
 }
 
 func (h *RuntimeHandlers) StopBackgroundTask(ctx context.Context, p wire.StopBackgroundTaskParams) (wire.OK, error) {

--- a/internal/daemon/handlers/runtime_test.go
+++ b/internal/daemon/handlers/runtime_test.go
@@ -57,8 +57,10 @@ type fullRT struct {
 	drainFn   func(int64) []agentruntime.ConsumedSteer
 	drainArgs []int64
 
-	abortErr   error
-	abortCalls []int64
+	abortErr     error
+	abortCalls   []int64
+	abortTokens  []uint64
+	abortOutcome agentruntime.AbortOutcome
 
 	stopBgErr   error
 	stopBgCalls []stopBgCall
@@ -175,11 +177,12 @@ func (r *fullRT) DrainPending(_ context.Context, sid int64) []agentruntime.Consu
 	return nil
 }
 
-func (r *fullRT) Abort(_ context.Context, sid int64, _ uint64) (agentruntime.AbortOutcome, error) {
+func (r *fullRT) Abort(_ context.Context, sid int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.abortCalls = append(r.abortCalls, sid)
-	return agentruntime.AbortOutcome{}, r.abortErr
+	r.abortTokens = append(r.abortTokens, turnToken)
+	return r.abortOutcome, r.abortErr
 }
 
 func (r *fullRT) StopBackgroundTask(_ context.Context, sid int64, taskID string) error {
@@ -1511,6 +1514,22 @@ func TestRuntime_Abort_Success(t *testing.T) {
 	_, err := h.Abort(ctx, wire.AbortParams{SessionID: 3})
 	require.NoError(t, err)
 	assert.Equal(t, []int64{3}, rt.abortCalls)
+}
+
+// TestRuntime_Abort_PassesTokenAndReturnsInterruptedTurnKind 钉死决策 1 的 daemon 侧:
+// RuntimeHandlers.Abort 把 wire.AbortParams.TurnToken 透传给 runtime 的 Abort,并把
+// 被中断轮的类型经 wire.AbortResult.TurnKind 返给对端 —— spec 测试接缝「remote wire
+// + daemon handler:AbortParams 携带 token,daemon 侧透传并返回轮类型」。
+func TestRuntime_Abort_PassesTokenAndReturnsInterruptedTurnKind(t *testing.T) {
+	rt := &fullRT{abortOutcome: agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindSubagentActivity}}
+	ctx, _, h, live := runtimeWithLiveSession(t, rt, 3)
+	defer close(live)
+
+	res, err := h.Abort(ctx, wire.AbortParams{SessionID: 3, TurnToken: 42})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{3}, rt.abortCalls)
+	assert.Equal(t, []uint64{42}, rt.abortTokens, "daemon 侧必须把 turnToken 原样透传给 runtime")
+	assert.Equal(t, agentruntime.TurnKindSubagentActivity, res.TurnKind)
 }
 
 func TestRuntime_Abort_NoSession_ErrNoActiveTurn(t *testing.T) {

--- a/internal/daemon/handlers/runtime_test.go
+++ b/internal/daemon/handlers/runtime_test.go
@@ -175,11 +175,11 @@ func (r *fullRT) DrainPending(_ context.Context, sid int64) []agentruntime.Consu
 	return nil
 }
 
-func (r *fullRT) Abort(_ context.Context, sid int64) error {
+func (r *fullRT) Abort(_ context.Context, sid int64, _ uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.abortCalls = append(r.abortCalls, sid)
-	return r.abortErr
+	return agentruntime.AbortOutcome{}, r.abortErr
 }
 
 func (r *fullRT) StopBackgroundTask(_ context.Context, sid int64, taskID string) error {
@@ -2278,11 +2278,11 @@ func (r *settlingAcceptedPiRT) PrepareRun(context.Context, agentruntime.RunReque
 	return r.prepared, nil
 }
 
-func (r *settlingAcceptedPiRT) Abort(context.Context, int64) error {
+func (r *settlingAcceptedPiRT) Abort(context.Context, int64, uint64) (agentruntime.AbortOutcome, error) {
 	r.prepared.result.UserAnchor = "pi-user-anchor-after-stop"
 	r.prepared.result.StopErr = agentruntime.ErrAborted
 	r.prepared.finish()
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 type settlingAcceptedPiRun struct {
@@ -2318,11 +2318,11 @@ func (r *blockingAbortAcceptedPiRT) PrepareRun(context.Context, agentruntime.Run
 	return r.prepared, nil
 }
 
-func (r *blockingAbortAcceptedPiRT) Abort(context.Context, int64) error {
+func (r *blockingAbortAcceptedPiRT) Abort(context.Context, int64, uint64) (agentruntime.AbortOutcome, error) {
 	r.abortOnce.Do(func() { close(r.abortEntered) })
 	<-r.allowAbort
 	r.prepared.finish()
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 func (p *settlingAcceptedPiRun) Start(context.Context) (<-chan agentruntime.Event, *agentruntime.RunResult, error) {
@@ -2405,16 +2405,16 @@ func (r *gatedPreparedPiRT) PrepareRun(ctx context.Context, req agentruntime.Run
 	return r.scriptedPreparedPiRT.PrepareRun(ctx, req)
 }
 
-func (r *scriptedPreparedPiRT) Abort(context.Context, int64) error {
+func (r *scriptedPreparedPiRT) Abort(context.Context, int64, uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	active := r.active
 	r.mu.Unlock()
 	if active == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
 	}
 	active.result.StopErr = agentruntime.ErrAborted
 	active.finish()
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 type scriptedPreparedPiRun struct {

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -89,11 +89,11 @@ func (f *fakeBackendRunner) Steer(_ context.Context, _ int64, _ string, text str
 	return nil
 }
 
-func (f *fakeBackendRunner) Abort(_ context.Context, sessionID int64) error {
+func (f *fakeBackendRunner) Abort(_ context.Context, sessionID int64, _ uint64) (agentruntime.AbortOutcome, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.aborted = append(f.aborted, sessionID)
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 // startTestDaemon spins a daemon on ephemeral port, returns it + cancel.
@@ -478,7 +478,9 @@ func (p *pacedBackendRunner) Run(_ context.Context, _ agentruntime.RunRequest) (
 }
 
 func (p *pacedBackendRunner) Steer(_ context.Context, _ int64, _ string, _ string) error { return nil }
-func (p *pacedBackendRunner) Abort(_ context.Context, _ int64) error                     { return nil }
+func (p *pacedBackendRunner) Abort(_ context.Context, _ int64, _ uint64) (agentruntime.AbortOutcome, error) {
+	return agentruntime.AbortOutcome{}, nil
+}
 
 // pairedTestRig boots a daemon, pairs a WS client, and constructs a *remote.Runtime
 // proxy on top so subtests can drive backend Events end-to-end through the full

--- a/internal/pkg/agentruntime/mock_agentruntime/mock_runner.go
+++ b/internal/pkg/agentruntime/mock_agentruntime/mock_runner.go
@@ -271,17 +271,18 @@ func (m *MockAborter) EXPECT() *MockAborterMockRecorder {
 }
 
 // Abort mocks base method.
-func (m *MockAborter) Abort(ctx context.Context, sessionID int64) error {
+func (m *MockAborter) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Abort", ctx, sessionID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "Abort", ctx, sessionID, turnToken)
+	ret0, _ := ret[0].(agentruntime.AbortOutcome)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Abort indicates an expected call of Abort.
-func (mr *MockAborterMockRecorder) Abort(ctx, sessionID any) *gomock.Call {
+func (mr *MockAborterMockRecorder) Abort(ctx, sessionID, turnToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockAborter)(nil).Abort), ctx, sessionID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockAborter)(nil).Abort), ctx, sessionID, turnToken)
 }
 
 // MockBackgroundTaskStopper is a mock of BackgroundTaskStopper interface.

--- a/internal/pkg/agentruntime/runner.go
+++ b/internal/pkg/agentruntime/runner.go
@@ -457,6 +457,12 @@ type RunResult struct {
 	Usage             *provider.Usage
 	StopErr           error
 
+	// TurnToken 是这一轮的 per-turn token(本会话内的递增序号,0 表示 runner 未
+	// 生成)。Abort 携带它做精确寻址:非 0 时仅当该轮仍是当前活跃轮才中断,否则
+	// stale no-op(决策 1)。claudecode / codex / builtin / piagent / openclaw
+	// 在每轮入口递增一次;remote 侧由 daemon 生成后经 wire 透传回来。
+	TurnToken uint64
+
 	// UserAnchor 是 provider 端对本轮 user prompt 的稳定标识，用于将来
 	// 「重新生成 assistant N」时反向定位到 user N 之前的会话点。
 	//
@@ -546,12 +552,43 @@ type SteerDrainer interface {
 	DrainPending(ctx context.Context, sessionID int64) []ConsumedSteer
 }
 
+// AbortOutcome 描述一次 Abort 的结果:被中断的那一轮的类型。
+//
+// TurnKind == TurnKindNone 只随 ErrNoActiveTurn / stale no-op 返回(没有实际中断任何轮);
+// 成功中断时带具体类型。
+type AbortOutcome struct {
+	TurnKind TurnKind
+}
+
+// TurnKind 标识被中断的那一轮的类型。
+type TurnKind string
+
+const (
+	// TurnKindNone 没有中断任何轮(无活跃轮 / stale token no-op)。
+	TurnKindNone TurnKind = "none"
+	// TurnKindUser 被中断的是用户轮(Run)。
+	TurnKindUser TurnKind = "userTurn"
+	// TurnKindAutonomous 被中断的是自主续轮(AutonomousTurn)。
+	TurnKindAutonomous TurnKind = "autonomous"
+	// TurnKindSubagentActivity 被中断的是后台 subagent 活动轮(SubagentActivity)。
+	TurnKindSubagentActivity TurnKind = "subagentActivity"
+)
+
 // Aborter is implemented by BackendRunners that support stopping the in-flight
 // turn (user clicks "停止"). chat_svc.Stop calls Abort to unblock the runner's
 // blocking I/O — claudecode writes a control_request{interrupt} frame, codex
 // sends turn/interrupt RPC, builtin cancels turnCtx. Implementations MUST be
 // idempotent and MUST be safe to call concurrently with the runner's own
 // drain goroutine.
+//
+// turnToken 是调用方想中断的那一轮的 per-turn token(随 RunResult /
+// AutonomousTurn / SubagentActivity 暴露):
+//   - 0 = 中断该会话当前活跃的那一轮(等价于旧行为,用户点停止的语义不变);
+//   - 非 0 = 仅当该轮仍是当前活跃轮时才中断,否则视为 stale、返回 (AbortOutcome{}, nil)
+//     no-op,不触碰任何其它轮 —— 迟到的带 token 中断不会杀掉新起的轮。
+//
+// 返回 AbortOutcome 携带被中断轮的类型(TurnKindUser / TurnKindAutonomous /
+// TurnKindSubagentActivity;无轮可中断或 stale no-op 时 TurnKindNone)。
 //
 // Returns ErrNoActiveTurn when there is no in-flight turn for sessionID
 // (already finished, never started, or unknown to this runner). chat_svc
@@ -560,7 +597,7 @@ type SteerDrainer interface {
 // Defined as a separate interface (like SteerCanceler) so a backend can be
 // added without abort support if needed; all three current runners implement it.
 type Aborter interface {
-	Abort(ctx context.Context, sessionID int64) error
+	Abort(ctx context.Context, sessionID int64, turnToken uint64) (AbortOutcome, error)
 }
 
 // BackgroundTaskStopper is implemented by BackendRunners that support stopping a
@@ -622,6 +659,8 @@ type AutonomousTurn struct {
 	Events  <-chan Event
 	Result  *RunResult
 	Trigger string // "background_task"
+	// TurnToken 是本自主轮的 per-turn token,供 Abort 精确寻址(决策 1)。
+	TurnToken uint64
 	// CompletedTask 镜像 claudecode.CompletedBackgroundTask:触发本自主轮的后台命令身份。
 	CompletedTask *CompletedBackgroundTask
 }
@@ -644,6 +683,8 @@ type SubagentActivitySource interface {
 type SubagentActivity struct {
 	ToolUseID string
 	Events    <-chan Event
+	// TurnToken 是本活动轮的 per-turn token,供 Abort 精确寻址(决策 1)。
+	TurnToken uint64
 }
 
 // Errors live in errors.go; registry / RuntimeFor / RegisterRuntime / SwapRuntimeForTest live in registry.go.

--- a/internal/pkg/agentruntime/runtimes/builtin/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/builtin/runtime.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cago-frame/agents/agent"
 	"github.com/cago-frame/agents/app/coding"
@@ -71,6 +72,10 @@ type builtinActive struct {
 	// cancel 取消本轮 turn 的 ctx。Run 用 context.WithCancel 派生 turnCtx 给
 	// runner.Send,cago 的 LLM 调用监听 ctx 退出。Abort 通过它解锁阻塞读。
 	cancel context.CancelFunc
+	// turnToken 本会话当前活跃轮的 per-turn token(决策 1):每轮 Run 入口递增,值随
+	// RunResult 暴露给 chat_svc。Abort(turnToken!=0) 只在该 token 仍是当前活跃轮时
+	// 才中断,否则 stale no-op。builtin 每会话同时至多一轮、只有用户轮。
+	turnToken atomic.Uint64
 }
 
 // Runtime in-process cago runtime 实现。
@@ -122,13 +127,19 @@ func (r *Runtime) Steer(ctx context.Context, sessionID int64, queuedID, text str
 //  2. cancel turnCtx —— cago Runner.Send 监听 ctx,events channel 关闭,drain
 //     goroutine 退出。
 //
+// turnToken 语义(决策 1):0 = 中断当前活跃轮;非 0 = 仅当该轮仍是当前活跃轮才中断,
+// 否则 stale no-op。builtin 只有用户轮,被中断轮类型恒为 userTurn。
+//
 // 幂等;并发安全。
-func (r *Runtime) Abort(_ context.Context, sessionID int64) error {
+func (r *Runtime) Abort(_ context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	a := r.active[sessionID]
 	r.mu.Unlock()
 	if a == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
+	}
+	if turnToken != 0 && a.turnToken.Load() != turnToken {
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 	if a.runner != nil {
 		_ = a.runner.ClearPendingSteers()
@@ -136,7 +147,7 @@ func (r *Runtime) Abort(_ context.Context, sessionID int64) error {
 	if a.cancel != nil {
 		a.cancel()
 	}
-	return nil
+	return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindUser}, nil
 }
 
 // CancelSteer 撤回尚未被消费的 steer 条目。语义同顶层 builtin.go.CancelSteer:
@@ -271,12 +282,14 @@ func (r *Runtime) Run(ctx context.Context, req agentruntime.RunRequest) (<-chan 
 		zap.String("convID", convID),
 		zap.Int("historyLen", len(history)))
 
-	r.register(req.SessionID, &builtinActive{runner: runner, cancel: cancelTurn})
+	ba := &builtinActive{runner: runner, cancel: cancelTurn}
+	r.register(req.SessionID, ba)
 
 	out := make(chan agentruntime.Event, 32)
 	result := &agentruntime.RunResult{
 		ProviderSessionID: convID,
 		Model:             builtinEffectiveModel(req),
+		TurnToken:         ba.turnToken.Add(1),
 	}
 	go func() {
 		defer close(out)

--- a/internal/pkg/agentruntime/runtimes/builtin/runtime_e2e_test.go
+++ b/internal/pkg/agentruntime/runtimes/builtin/runtime_e2e_test.go
@@ -161,7 +161,7 @@ func TestSteer_MapsCagoErrSteerNoActiveTurn(t *testing.T) {
 
 func TestAbort_NoActiveReturnsErr(t *testing.T) {
 	r := New()
-	err := r.Abort(context.Background(), 42)
+	_, err := r.Abort(context.Background(), 42, 0)
 	assert.True(t, errors.Is(err, agentruntime.ErrNoActiveTurn))
 }
 

--- a/internal/pkg/agentruntime/runtimes/claudecode/active.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/active.go
@@ -34,6 +34,15 @@ type claudeActive struct {
 	// **一帧都收不到**。startup 看门狗必须据此暂停计时,否则会把一个健康、正忙的
 	// 子进程当成「起步即卡死」硬杀(sess-1950)。
 	outOfBand atomic.Int32
+	// turnSeq 会话级轮计数器:每次 Run(用户轮)入口 / 自主续轮入口 / 后台 subagent
+	// 活动轮入口递增一次,值随 RunResult / AutonomousTurn / SubagentActivity 暴露给
+	// chat_svc,供 Abort 按 token 精确寻址(决策 1)。
+	turnSeq atomic.Uint64
+	// curTurnToken / curTurnKind 记录「当前活跃轮」的 token 与类型(0=暂无)。每次轮
+	// 入口(nextTurnToken)覆盖为最新一轮;Abort(turnToken!=0)只在该 token 仍是当前
+	// 活跃轮时才中断,否则 stale no-op。curTurnKind 供 Abort 上报被中断轮的类型。
+	curTurnToken atomic.Uint64
+	curTurnKind  atomic.Value // holds agentruntime.TurnKind
 	// launchedEffort 记录 spawn 时下发给 claude CLI 的 --effort <level>。
 	// --effort 是启动期 flag,运行时改不掉;下一轮如果 backend.ReasoningEffort
 	// 变了,acquireSession 会用这个字段比对、强制 evict 重 spawn。
@@ -94,6 +103,23 @@ func (a *claudeActive) leaveOutOfBand() { a.outOfBand.Add(-1) }
 
 // outOfBandActive 报告此刻是否有带外轮在流。
 func (a *claudeActive) outOfBandActive() bool { return a.outOfBand.Load() > 0 }
+
+// nextTurnToken 为新一轮入口分配自增 token 并记录为当前活跃轮,返回新 token。
+// kind 是这一轮的类型(用户轮 / 自主续轮 / 后台 subagent 活动轮)。
+func (a *claudeActive) nextTurnToken(kind agentruntime.TurnKind) uint64 {
+	t := a.turnSeq.Add(1)
+	a.curTurnToken.Store(t)
+	a.curTurnKind.Store(kind)
+	return t
+}
+
+// currentTurnKind 读当前活跃轮的类型;尚无任何轮记录时返回 TurnKindNone。
+func (a *claudeActive) currentTurnKind() agentruntime.TurnKind {
+	if v := a.curTurnKind.Load(); v != nil {
+		return v.(agentruntime.TurnKind)
+	}
+	return agentruntime.TurnKindNone
+}
 
 // attachOut / detachOut 由 drainStream 圈住一轮的事件出口存活期。
 func (a *claudeActive) attachOut(out chan<- agentruntime.Event) {

--- a/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/autoturn.go
@@ -50,7 +50,8 @@ func (r *Runtime) AutonomousTurns(sessionID int64) <-chan agentruntime.Autonomou
 			}
 			// 先把这一轮交给 consumer(它并发 drain evOut),随后 inline 翻译填 evOut。
 			// inline(非 goroutine)保证多个自主轮之间顺序处理、不重叠。
-			out <- agentruntime.AutonomousTurn{Events: evOut, Result: result, Trigger: at.Trigger, CompletedTask: completed}
+			token := a.nextTurnToken(agentruntime.TurnKindAutonomous)
+			out <- agentruntime.AutonomousTurn{Events: evOut, Result: result, Trigger: at.Trigger, CompletedTask: completed, TurnToken: token}
 			stream := &ccChanStream{ch: at.Events, sidFn: func() string { return at.SessionID }}
 			// 自主续轮的子进程早已存活(由首轮 spawn),不存在「起步即卡死」, 不挂看门狗。
 			// 但本轮占着 Session 活跃槽位:期间起的 user turn 收不到任何帧,必须让它的
@@ -101,7 +102,7 @@ func (r *Runtime) SubagentActivity(sessionID int64) <-chan agentruntime.Subagent
 			result := &agentruntime.RunResult{ProviderSessionID: sa.SessionID}
 			// 先把这一轮活动交给 consumer(它并发 drain evOut),随后 inline 翻译填 evOut。
 			// inline(非 goroutine)保证多个活动轮之间顺序处理、不重叠。
-			out <- agentruntime.SubagentActivity{ToolUseID: sa.ToolUseID, Events: evOut}
+			out <- agentruntime.SubagentActivity{ToolUseID: sa.ToolUseID, Events: evOut, TurnToken: a.nextTurnToken(agentruntime.TurnKindSubagentActivity)}
 			stream := &ccChanStream{ch: sa.Events, sidFn: func() string { return sa.SessionID }}
 			// 活动轮的子进程早已存活(由首轮 spawn),不存在「起步即卡死」, 不挂看门狗。
 			// 与自主续轮同理:本轮占着 Session 活跃槽位,期间起的 user turn 收不到帧。

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
@@ -255,6 +255,13 @@ func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) 
 	}
 	if a.handle != nil {
 		if err := a.handle.Interrupt(ctx); err != nil {
+			if errors.Is(err, claudecode.ErrInterruptPending) {
+				// 中断已下发、ack 异步到（CLI 卡在别的处理上，interruptAckBound 内没回执）。
+				// **不** Close、**不** 逐出缓存 —— 帧已写、在途，readLoop 追平后 CLI 会
+				// 发 result 帧让本轮自然收尾。只有真错误（写帧失败 / session closed /
+				// CLI 拒绝）才走下方 Close+evict 兜底。
+				return agentruntime.AbortOutcome{TurnKind: a.currentTurnKind()}, nil
+			}
 			_ = a.handle.Close(ctx)
 			r.cache.Remove(sessionKey(sessionID))
 			return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, err

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
@@ -233,14 +233,22 @@ func (r *Runtime) DrainPending(ctx context.Context, sessionID int64) []agentrunt
 // 活跃轮既包括用户轮(inTurn)也包括带外轮(outOfBandActive:自主续轮 / 后台
 // subagent 活动轮独占帧流期间 inTurn 仍是 false)。两者都不活跃时才是真的
 // 无轮可中断,返回 ErrNoActiveTurn。
-func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
+//
+// turnToken 语义(决策 1):0 = 中断当前活跃轮(等价旧行为);非 0 = 仅当该轮仍是
+// 当前活跃轮时才中断,否则 stale no-op、不触碰其它轮。成功中断时上报被中断轮的
+// 类型(curTurnKind)。
+func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	v, ok := r.cache.Get(sessionKey(sessionID))
 	if !ok {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, agentruntime.ErrNoActiveTurn
 	}
 	a := v.(*claudeActive)
 	if !a.inTurn.Load() && !a.outOfBandActive() {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, agentruntime.ErrNoActiveTurn
+	}
+	if turnToken != 0 && a.curTurnToken.Load() != turnToken {
+		// stale:该轮已不是当前活跃轮,no-op,不触碰任何其它轮。
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 	if r.steer != nil && a.sessionUUID != "" {
 		_ = r.steer.Drain(a.sessionUUID)
@@ -249,9 +257,10 @@ func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
 		if err := a.handle.Interrupt(ctx); err != nil {
 			_ = a.handle.Close(ctx)
 			r.cache.Remove(sessionKey(sessionID))
+			return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, err
 		}
 	}
-	return nil
+	return agentruntime.AbortOutcome{TurnKind: a.currentTurnKind()}, nil
 }
 
 // StopBackgroundTask 实现 BackgroundTaskStopper：停掉某个后台任务/子 agent(按 CLI
@@ -348,9 +357,11 @@ func (r *Runtime) Run(ctx context.Context, req agentruntime.RunRequest) (<-chan 
 	}
 
 	out := make(chan agentruntime.Event, 32)
+	token := a.nextTurnToken(agentruntime.TurnKindUser)
 	result := &agentruntime.RunResult{
 		ProviderSessionID:    a.handle.ID(),
 		LaunchPermissionMode: launchMode,
+		TurnToken:            token,
 	}
 
 	// startup 看门狗:turn 起步后 startupTimeout 内一帧都没有 → 判定子进程卡死(典型:

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -734,19 +734,21 @@ func TestRuntime_StopBackgroundTask(t *testing.T) {
 // 带外轮(自主续轮 / 后台 subagent 活动轮)独占帧流期间 inTurn 仍是 false —— 此前
 // 会被误判为「无活跃轮」拒绝中断,用户按「停止」停不掉正在飞的带外轮。放宽后
 // outOfBandActive 单独也能触发真正的中断;两者都不活跃时契约不变,仍返回
-// ErrNoActiveTurn。
+// ErrNoActiveTurn。turnToken=0 时语义与旧版一致:「中断当前活跃的那一轮」。
 func TestRuntime_Abort(t *testing.T) {
 	Convey("仅带外轮活跃(inTurn=false, outOfBandActive=true) → 执行中断", t, func() {
 		r := New()
 		h := &fakeCCHandle{}
 		a := &claudeActive{handle: h}
 		a.enterOutOfBand()
+		a.nextTurnToken(agentruntime.TurnKindAutonomous)
 		r.cache.Put(sessionKey(501), a)
 
-		err := r.Abort(context.Background(), 501)
+		outcome, err := r.Abort(context.Background(), 501, 0)
 
 		So(err, ShouldBeNil)
 		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindAutonomous)
 	})
 
 	Convey("用户轮与带外轮都不活跃 → 契约不变,返回 ErrNoActiveTurn", t, func() {
@@ -755,10 +757,80 @@ func TestRuntime_Abort(t *testing.T) {
 		a := &claudeActive{handle: h}
 		r.cache.Put(sessionKey(502), a)
 
-		err := r.Abort(context.Background(), 502)
+		outcome, err := r.Abort(context.Background(), 502, 0)
 
 		So(errors.Is(err, agentruntime.ErrNoActiveTurn), ShouldBeTrue)
 		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 0)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindNone)
+	})
+}
+
+// TestRuntime_Abort_TurnToken 钉死决策 1 的 per-turn token 语义:Abort 携带 token
+// (0=当前活跃轮)精确寻址,非 0 时仅当该轮仍是当前活跃轮才中断,否则 stale no-op
+// 不触碰任何其它轮;并上报被中断轮的类型。
+func TestRuntime_Abort_TurnToken(t *testing.T) {
+	Convey("stale token(轮已切换)→ no-op,不中断新轮、不返错", t, func() {
+		r := New()
+		h := &fakeCCHandle{}
+		a := &claudeActive{handle: h}
+		a.enterOutOfBand()
+		r.cache.Put(sessionKey(511), a)
+
+		tokenOld := a.nextTurnToken(agentruntime.TurnKindAutonomous)
+		tokenNew := a.nextTurnToken(agentruntime.TurnKindAutonomous)
+		So(tokenNew, ShouldNotEqual, tokenOld)
+
+		outcome, err := r.Abort(context.Background(), 511, tokenOld)
+
+		So(err, ShouldBeNil)
+		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 0)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindNone)
+	})
+
+	Convey("当前 token → 执行中断并上报被中断轮类型", t, func() {
+		r := New()
+		h := &fakeCCHandle{}
+		a := &claudeActive{handle: h}
+		a.enterOutOfBand()
+		r.cache.Put(sessionKey(512), a)
+
+		token := a.nextTurnToken(agentruntime.TurnKindAutonomous)
+
+		outcome, err := r.Abort(context.Background(), 512, token)
+
+		So(err, ShouldBeNil)
+		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindAutonomous)
+	})
+
+	Convey("turnToken=0 → 中断当前活跃轮(等价旧行为),上报类型", t, func() {
+		r := New()
+		h := &fakeCCHandle{}
+		a := &claudeActive{handle: h}
+		a.enterOutOfBand()
+		a.nextTurnToken(agentruntime.TurnKindSubagentActivity)
+		r.cache.Put(sessionKey(513), a)
+
+		outcome, err := r.Abort(context.Background(), 513, 0)
+
+		So(err, ShouldBeNil)
+		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindSubagentActivity)
+	})
+
+	Convey("用户轮(inTurn=true)活跃时 turnToken=0 → 上报 userTurn", t, func() {
+		r := New()
+		h := &fakeCCHandle{}
+		a := &claudeActive{handle: h}
+		a.inTurn.Store(true)
+		a.nextTurnToken(agentruntime.TurnKindUser)
+		r.cache.Put(sessionKey(514), a)
+
+		outcome, err := r.Abort(context.Background(), 514, 0)
+
+		So(err, ShouldBeNil)
+		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindUser)
 	})
 }
 

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -877,7 +877,11 @@ func TestRuntime_Abort_ErrInterruptPending(t *testing.T) {
 		_, err := r.Abort(context.Background(), 602, 0)
 
 		So(err, ShouldNotBeNil)
-		So(atomic.LoadInt32(&h.closeCalls), ShouldEqual, 1) // 真错误应 Close 子进程
+		// 真错误应 Close 子进程:显式 a.handle.Close 一次,且 cache.Remove 还会异步 close
+		// 被逐出的 handle(CLISessionPool.Remove 里 go closeWithTimeout),故 closeCalls 是
+		// 1 或 2 —— 钉死「至少一次 Close + 缓存被逐出」这条与 ErrInterruptPending(0 次
+		// Close)可区分的判据,不钉死可能被异步 close 竞态的精确次数。
+		So(atomic.LoadInt32(&h.closeCalls), ShouldBeGreaterThanOrEqualTo, 1)
 		_, ok := r.cache.Get(sessionKey(602))
 		So(ok, ShouldBeFalse) // 真错误应逐出缓存
 	})

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -278,13 +278,21 @@ type fakeCCHandle struct {
 	// interruptCalls 原子计数 Interrupt 调用次数,断言 Abort 是否真下发中断
 	// (决策 8:Abort 放宽到带外轮活跃也执行中断)。
 	interruptCalls int32
+	// interruptErr 非 nil 时 Interrupt 返回它(注入 ErrInterruptPending / 写帧失败等
+	// 真错误,断言 Abort 走不杀 / Close+evict 哪条路)。
+	interruptErr error
+	// closeCalls 原子计数 Close 调用次数,断言 ErrInterruptPending 不走 Close+evict 兜底。
+	closeCalls int32
 }
 
-func (f *fakeCCHandle) ID() string                  { return f.id }
-func (f *fakeCCHandle) Close(context.Context) error { return nil }
+func (f *fakeCCHandle) ID() string { return f.id }
+func (f *fakeCCHandle) Close(context.Context) error {
+	atomic.AddInt32(&f.closeCalls, 1)
+	return nil
+}
 func (f *fakeCCHandle) Interrupt(context.Context) error {
 	atomic.AddInt32(&f.interruptCalls, 1)
-	return nil
+	return f.interruptErr
 }
 func (f *fakeCCHandle) Kill(context.Context) error {
 	atomic.AddInt32(&f.killCalls, 1)
@@ -831,6 +839,47 @@ func TestRuntime_Abort_TurnToken(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
 		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindUser)
+	})
+}
+
+// TestRuntime_Abort_ErrInterruptPending 钉死决策 2:Interrupt 有界超时返回的
+// ErrInterruptPending 被 Abort 视为「中断已下发、ack 异步到」→ 返回 nil、不 Close
+// 子进程、不逐出缓存;只有写帧失败 / session closed / CLI 拒绝等**真错误**才保留
+// runtime.go:248-252 的 Close+evict 兜底。
+func TestRuntime_Abort_ErrInterruptPending(t *testing.T) {
+	Convey("Interrupt 返 ErrInterruptPending → 返回 nil、不 Close、不逐出缓存", t, func() {
+		r := New()
+		h := &fakeCCHandle{interruptErr: claudecode.ErrInterruptPending}
+		a := &claudeActive{handle: h}
+		a.enterOutOfBand()
+		a.nextTurnToken(agentruntime.TurnKindAutonomous)
+		r.cache.Put(sessionKey(601), a)
+
+		outcome, err := r.Abort(context.Background(), 601, 0)
+
+		So(err, ShouldBeNil)
+		So(outcome.TurnKind, ShouldEqual, agentruntime.TurnKindAutonomous)
+		So(atomic.LoadInt32(&h.interruptCalls), ShouldEqual, 1)
+		So(atomic.LoadInt32(&h.closeCalls), ShouldEqual, 0) // ErrInterruptPending 不应 Close 子进程
+		v, ok := r.cache.Get(sessionKey(601))
+		So(ok, ShouldBeTrue) // ErrInterruptPending 不应逐出缓存
+		So(v, ShouldEqual, a)
+	})
+
+	Convey("真错误(写帧失败)→ 保留 Close+evict 兜底", t, func() {
+		r := New()
+		h := &fakeCCHandle{interruptErr: errors.New("claudecode: write frame: broken pipe")}
+		a := &claudeActive{handle: h}
+		a.enterOutOfBand()
+		a.nextTurnToken(agentruntime.TurnKindAutonomous)
+		r.cache.Put(sessionKey(602), a)
+
+		_, err := r.Abort(context.Background(), 602, 0)
+
+		So(err, ShouldNotBeNil)
+		So(atomic.LoadInt32(&h.closeCalls), ShouldEqual, 1) // 真错误应 Close 子进程
+		_, ok := r.cache.Get(sessionKey(602))
+		So(ok, ShouldBeFalse) // 真错误应逐出缓存
 	})
 }
 

--- a/internal/pkg/agentruntime/runtimes/codex/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/codex/runtime.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cago-frame/cago/pkg/logger"
 	"go.uber.org/zap"
@@ -50,6 +51,10 @@ type codexActive struct {
 	poolKey     string
 	outMu       sync.Mutex
 	out         chan<- agentruntime.Event
+	// turnToken 本会话当前活跃轮的 per-turn token(决策 1):每轮 Run 入口递增,值随
+	// RunResult 暴露给 chat_svc。Abort(turnToken!=0) 只在该 token 仍是当前活跃轮时
+	// 才中断,否则 stale no-op。codex 只有用户轮,上报类型恒为 userTurn。
+	turnToken atomic.Uint64
 }
 
 type codexAskWaiter struct {
@@ -443,7 +448,7 @@ func (r *Runtime) Run(ctx context.Context, req agentruntime.RunRequest) (<-chan 
 	if modelID == "" {
 		modelID = defaultModelID
 	}
-	result := &agentruntime.RunResult{ProviderSessionID: sess.ID(), Model: modelID}
+	result := &agentruntime.RunResult{ProviderSessionID: sess.ID(), Model: modelID, TurnToken: active.turnToken.Add(1)}
 
 	go func() {
 		defer close(out)
@@ -533,21 +538,29 @@ func (r *Runtime) CloseAllSessions(_ context.Context) {
 }
 
 // Abort 软中断当前 turn。语义同顶层 codex.go.Abort。
-func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
+// turnToken 语义(决策 1):0 = 中断当前活跃轮;非 0 = 仅当该轮仍是当前活跃轮才中断,
+// 否则 stale no-op。codex 每会话同时至多一轮、只有用户轮,故被中断轮类型恒为 userTurn。
+func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	a := r.active[sessionID]
 	r.mu.Unlock()
 	if a == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
+	}
+	if turnToken != 0 && a.turnToken.Load() != turnToken {
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 	a.mu.Lock()
 	a.pending = nil
 	intr := a.interrupter
 	a.mu.Unlock()
 	if intr == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
 	}
-	return intr.Interrupt(ctx)
+	if err := intr.Interrupt(ctx); err != nil {
+		return agentruntime.AbortOutcome{}, err
+	}
+	return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindUser}, nil
 }
 
 // Steer 把 text dispatch 给 active codex.Stream(turn/steer JSON-RPC)。

--- a/internal/pkg/agentruntime/runtimes/codex/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/codex/runtime_test.go
@@ -870,7 +870,7 @@ func TestRun_ControlCallsAreRaceFreeWhileActiveOwnerInitializes(t *testing.T) {
 			case <-stopControls:
 				return
 			default:
-				_ = r.Abort(context.Background(), 707)
+				_, _ = r.Abort(context.Background(), 707, 0)
 			}
 		}
 	}()

--- a/internal/pkg/agentruntime/runtimes/openclaw/active.go
+++ b/internal/pkg/agentruntime/runtimes/openclaw/active.go
@@ -44,6 +44,8 @@ type activeTurn struct {
 	finishOnce sync.Once
 	abortMu    sync.Mutex
 	aborted    bool
+	// turnToken 本轮的身份 token(创建时一次性赋值,发布进 r.active 后只读,Abort 比对用)。
+	turnToken uint64
 
 	approvalMu        sync.Mutex
 	approvalResolveMu sync.Mutex

--- a/internal/pkg/agentruntime/runtimes/openclaw/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/openclaw/runtime.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 
@@ -35,6 +36,11 @@ type Runtime struct {
 
 	mu     sync.RWMutex
 	active map[int64]*activeTurn
+	// turnSeq 会话无关的轮计数器:每轮 Run 入口递增一次,赋给 activeTurn.turnToken,
+	// 值随 RunResult 暴露给 chat_svc。openclaw 每会话同时至多一轮(register 会拒绝
+	// 重入),token 用于区分「调用方想中断的那一轮」与「当前活跃轮」:旧轮已结束、
+	// 新轮已起时带旧 token 的 abort 是 stale no-op(决策 1)。
+	turnSeq atomic.Uint64
 }
 
 var defaultRuntime = New(nil)
@@ -245,7 +251,9 @@ func (r *Runtime) Run(ctx context.Context, req agentruntime.RunRequest) (<-chan 
 		sessionDescribe:      slices.Contains(hello.Features.Methods, sessionDescribeMethod),
 		approvals:            make(map[string]*approvalState),
 		initialApprovals:     initialApprovals,
+		turnToken:            r.turnSeq.Add(1),
 	}
+	result.TurnToken = active.turnToken
 	if !r.register(active) {
 		client.Close()
 		return nil, nil, fmt.Errorf("openclaw runtime: session already has an active turn")
@@ -273,14 +281,20 @@ func (r *Runtime) ResolveExecApproval(ctx context.Context, sessionID int64, appr
 	return active.resolveApproval(ctx, approvalID, decision)
 }
 
-func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
+func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.RLock()
 	active := r.active[sessionID]
 	r.mu.RUnlock()
 	if active == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
 	}
-	return active.abort(ctx)
+	if turnToken != 0 && active.turnToken != turnToken {
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
+	}
+	if err := active.abort(ctx); err != nil {
+		return agentruntime.AbortOutcome{}, err
+	}
+	return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindUser}, nil
 }
 
 func (r *Runtime) register(active *activeTurn) bool {

--- a/internal/pkg/agentruntime/runtimes/openclaw/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/openclaw/runtime_test.go
@@ -721,8 +721,10 @@ func TestRuntimeAbortIsIdempotentAndDistinctFromCompletion(t *testing.T) {
 		Backend: runtimeBackend(), SessionID: 36, UserText: "long task",
 	})
 	require.NoError(t, err)
-	require.NoError(t, runtime.Abort(context.Background(), 36))
-	require.NoError(t, runtime.Abort(context.Background(), 36))
+	_, abortErr := runtime.Abort(context.Background(), 36, 0)
+	require.NoError(t, abortErr)
+	_, abortErr = runtime.Abort(context.Background(), 36, 0)
+	require.NoError(t, abortErr)
 	close(allowTerminal)
 	collected := collectRuntimeEvents(t, events)
 	assert.Equal(t, int32(1), abortCalls.Load())
@@ -730,7 +732,8 @@ func TestRuntimeAbortIsIdempotentAndDistinctFromCompletion(t *testing.T) {
 	require.Len(t, collected, 1)
 	_, ok := collected[0].(agentruntime.Done)
 	assert.True(t, ok)
-	assert.ErrorIs(t, runtime.Abort(context.Background(), 36), agentruntime.ErrNoActiveTurn)
+	_, abortErr = runtime.Abort(context.Background(), 36, 0)
+	assert.ErrorIs(t, abortErr, agentruntime.ErrNoActiveTurn)
 }
 
 func TestRuntimeReconcilesAfterDisconnectWithoutResubmittingUserMessage(t *testing.T) {

--- a/internal/pkg/agentruntime/runtimes/piagent/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/piagent/runtime.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cago-frame/agents/provider"
 	"github.com/cago-frame/cago/pkg/logger"
@@ -31,6 +32,10 @@ type activeSession struct {
 	interrupter    interruptable
 	pending        []agentruntime.ConsumedSteer
 	abortRequested bool
+	// turnToken 本会话当前活跃轮的 per-turn token(决策 1):每轮入口递增,值随
+	// RunResult 暴露给 chat_svc。Abort(turnToken!=0) 只在该 token 仍是当前活跃轮时
+	// 才中断,否则 stale no-op。piagent 只有用户轮,被中断轮类型恒为 userTurn。
+	turnToken atomic.Uint64
 }
 
 type Runtime struct {
@@ -214,7 +219,7 @@ func (p *preparedRun) Start(ctx context.Context) (<-chan agentruntime.Event, *ag
 	if providerSessionID == "" {
 		providerSessionID = strings.TrimSpace(p.sess.ID())
 	}
-	result := &agentruntime.RunResult{ProviderSessionID: providerSessionID, Model: p.modelID}
+	result := &agentruntime.RunResult{ProviderSessionID: providerSessionID, Model: p.modelID, TurnToken: active.turnToken.Add(1)}
 	logFields := make([]zap.Field, 0, 7)
 	logFields = append(logFields,
 		zap.Int64("sessionID", p.req.SessionID),
@@ -261,19 +266,22 @@ func (p *preparedRun) Close(ctx context.Context) error {
 	return closeErr
 }
 
-func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
+func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	a := r.active[sessionID]
 	r.mu.Unlock()
 	if a == nil || a.interrupter == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
+	}
+	if turnToken != 0 && a.turnToken.Load() != turnToken {
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 	a.setAbortRequested(true)
 	if err := a.interrupter.Interrupt(ctx); err != nil {
 		a.setAbortRequested(false)
-		return err
+		return agentruntime.AbortOutcome{}, err
 	}
-	return nil
+	return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindUser}, nil
 }
 
 func (r *Runtime) Steer(ctx context.Context, sessionID int64, queuedID string, text string) error {

--- a/internal/pkg/agentruntime/runtimes/piagent/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/piagent/runtime_test.go
@@ -132,7 +132,8 @@ func TestRun_CanceledAcceptedTurnReturnsSettledUserAnchor(t *testing.T) {
 	<-stream.started
 
 	cancel()
-	require.NoError(t, runtime.Abort(context.Background(), 2))
+	_, abortErr := runtime.Abort(context.Background(), 2, 0)
+	require.NoError(t, abortErr)
 	for range events {
 	}
 
@@ -504,7 +505,8 @@ func TestRun_StaleCleanupCannotUnregisterNewerGeneration(t *testing.T) {
 	for range firstEvents {
 	}
 
-	require.NoError(t, runtime.Abort(context.Background(), req.SessionID),
+	_, abortErr := runtime.Abort(context.Background(), req.SessionID, 0)
+	require.NoError(t, abortErr,
 		"generation A's deferred unregister must not remove generation B")
 	select {
 	case <-secondInterrupted:

--- a/internal/pkg/agentruntime/runtimes/remote/autoturn.go
+++ b/internal/pkg/agentruntime/runtimes/remote/autoturn.go
@@ -47,7 +47,7 @@ type autoTurn struct {
 //
 // a.out 有缓冲且轮次串行(daemon 任一时刻至多一轮、消费方独立 drain),送出几乎不
 // 阻塞;缓冲满时短暂阻塞读循环(既定 back-pressure 契约),不与 a.mu 形成锁环。
-func (a *autoSession) openTurnLocked(trigger string, catchUp bool) *autoTurn {
+func (a *autoSession) openTurnLocked(trigger string, catchUp bool, turnToken uint64) *autoTurn {
 	if a.closed {
 		return nil
 	}
@@ -68,9 +68,10 @@ func (a *autoSession) openTurnLocked(trigger string, catchUp bool) *autoTurn {
 	}
 	a.cur = turn
 	a.out <- agentruntime.AutonomousTurn{
-		Events:  turn.events,
-		Result:  turn.result,
-		Trigger: trigger,
+		Events:    turn.events,
+		Result:    turn.result,
+		Trigger:   trigger,
+		TurnToken: turnToken,
 	}
 	return turn
 }
@@ -128,7 +129,7 @@ func (r *Runtime) handleAutonomousTurnStarted(ctx context.Context, raw json.RawM
 	// send-on-closed-channel panic。对齐 handleAutonomousTurnEvent 的同款纪律。
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.openTurnLocked(frame.Trigger, false)
+	a.openTurnLocked(frame.Trigger, false, frame.TurnToken)
 	return nil, nil
 }
 
@@ -153,7 +154,7 @@ func (r *Runtime) deliverToCatchUpTurn(ctx context.Context, sid int64, ev agentr
 	if a.cur == nil {
 		logger.Ctx(ctx).Info("remote runtime: opening catch-up turn for replayed content",
 			zap.Int64("sid", sid))
-		if a.openTurnLocked(TriggerCatchUp, true) == nil {
+		if a.openTurnLocked(TriggerCatchUp, true, 0) == nil {
 			return false
 		}
 	}
@@ -180,6 +181,7 @@ func (r *Runtime) closeCatchUpTurn(ctx context.Context, frame wire.RunResultDone
 	a.cur.result.UserAnchor = frame.UserAnchor
 	a.cur.result.Model = frame.Model
 	a.cur.result.ContextWindow = frame.ContextWindow
+	a.cur.result.TurnToken = frame.TurnToken
 	if frame.Usage != nil {
 		a.cur.result.Usage = usageFromWire(frame.Usage)
 	}
@@ -241,6 +243,7 @@ func (r *Runtime) handleAutonomousTurnDone(ctx context.Context, raw json.RawMess
 	cur.result.ProviderSessionID = frame.ProviderSessionID
 	cur.result.Model = frame.Model
 	cur.result.ContextWindow = frame.ContextWindow
+	cur.result.TurnToken = frame.TurnToken
 	if frame.Usage != nil {
 		cur.result.Usage = usageFromWire(frame.Usage)
 	}

--- a/internal/pkg/agentruntime/runtimes/remote/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime.go
@@ -65,6 +65,7 @@ type remoteSession struct {
 	registrationOnce  sync.Once
 	abortOnce         sync.Once
 	abortErr          error
+	abortOutcome      agentruntime.AbortOutcome
 }
 
 // Runtime 包装 DaemonClientPort 把 chat session 委托给远端 daemon。生命周期:
@@ -372,33 +373,33 @@ func (r *Runtime) PrepareRun(ctx context.Context, req agentruntime.RunRequest) (
 	sess.registrationOnce.Do(func() { close(sess.registrationDone) })
 	releaseGenerationGate()
 	if registrationErr != nil {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		return nil, wire.FromJSONRPCError(registrationErr)
 	}
 	if registrationAck.SessionID != req.SessionID {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		return nil, fmt.Errorf("remote runtime: Pi registration returned session %d for %d", registrationAck.SessionID, req.SessionID)
 	}
 	if err := generationCtx.Err(); err != nil {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		return nil, err
 	}
 
 	var ack wire.RunAck
 	if err := r.conn().Call(generationCtx, wire.MethodRun, params, &ack); err != nil {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		logger.Ctx(ctx).Warn("remote runtime: Pi preparation RPC failed",
 			zap.Int64("sessionId", req.SessionID),
 			zap.String("errorType", fmt.Sprintf("%T", err)))
 		return nil, wire.FromJSONRPCError(err)
 	}
 	if ack.SessionID != req.SessionID {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		return nil, fmt.Errorf("remote runtime: Pi preparation returned session %d for %d", ack.SessionID, req.SessionID)
 	}
 	providerSessionID := strings.TrimSpace(ack.ProviderSessionID)
 	if providerSessionID == "" {
-		_ = r.abortGeneration(ctx, sess)
+		_, _ = r.abortGeneration(ctx, sess, 0)
 		return nil, errors.New("remote runtime: Pi preparation returned empty provider session id")
 	}
 	sess.mu.Lock()
@@ -456,11 +457,11 @@ func (p *remotePreparedRun) Start(ctx context.Context) (<-chan agentruntime.Even
 	}()
 	var ack wire.RunAck
 	if err := p.runtime.conn().Call(startCtx, wire.MethodRun, p.params, &ack); err != nil {
-		_ = p.runtime.abortGeneration(ctx, p.session)
+		_, _ = p.runtime.abortGeneration(ctx, p.session, 0)
 		return nil, nil, wire.FromJSONRPCError(err)
 	}
 	if ack.SessionID != p.session.id || strings.TrimSpace(ack.ProviderSessionID) != p.ProviderSessionID() {
-		_ = p.runtime.abortGeneration(ctx, p.session)
+		_, _ = p.runtime.abortGeneration(ctx, p.session, 0)
 		return nil, nil, errors.New("remote runtime: Pi start acknowledged a different prepared generation")
 	}
 	p.session.mu.Lock()
@@ -479,7 +480,8 @@ func (p *remotePreparedRun) Close(ctx context.Context) error {
 	p.mu.Lock()
 	p.closed = true
 	p.mu.Unlock()
-	return p.runtime.abortGeneration(ctx, p.session)
+	_, err := p.runtime.abortGeneration(ctx, p.session, 0)
+	return err
 }
 
 func (r *Runtime) runDirect(ctx context.Context, req agentruntime.RunRequest) (<-chan agentruntime.Event, *agentruntime.RunResult, error) {
@@ -856,6 +858,7 @@ func (r *Runtime) handleRunResultDone(ctx context.Context, raw json.RawMessage) 
 	sess.result.UserAnchor = frame.UserAnchor
 	sess.result.Model = frame.Model
 	sess.result.ContextWindow = frame.ContextWindow
+	sess.result.TurnToken = frame.TurnToken
 	if frame.Usage != nil {
 		// provider.Usage 没 JSON tag,wire 端用 UsageWire 中转,这里 1:1 拷回。
 		sess.result.Usage = usageFromWire(frame.Usage)
@@ -922,22 +925,26 @@ func (r *Runtime) DrainPending(ctx context.Context, sessionID int64) []agentrunt
 	return res.Steers
 }
 
-func (r *Runtime) Abort(ctx context.Context, sessionID int64) error {
+func (r *Runtime) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.RLock()
 	sess := r.sessions[sessionID]
 	r.mu.RUnlock()
 	// 本进程在跑 Pi generation:走本地收尾路径(main 的 Pi abort)。
 	if sess != nil && sess.backendType == agent_backend_entity.TypePiAgent {
-		return r.abortGeneration(ctx, sess)
+		return r.abortGeneration(ctx, sess, turnToken)
 	}
 	// 其余会话(含补齐进 tracked / autoSessions 的 R12 远端会话):用 HEAD 的
 	// hasSession 判定 + origin 路由,避免把无本地 Run 的会话拦成 ErrNoActiveTurn。
 	if !r.hasSession(sessionID) {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
 	}
-	return r.callSession(ctx, sessionID, wire.MethodAbort, wire.AbortParams{
-		SessionID: sessionID, PeerFingerprint: r.originFor(sessionID),
-	}, &wire.OK{})
+	var res wire.AbortResult
+	if err := r.callSession(ctx, sessionID, wire.MethodAbort, wire.AbortParams{
+		SessionID: sessionID, PeerFingerprint: r.originFor(sessionID), TurnToken: turnToken,
+	}, &res); err != nil {
+		return agentruntime.AbortOutcome{}, err
+	}
+	return agentruntime.AbortOutcome{TurnKind: res.TurnKind}, nil
 }
 
 func (r *Runtime) StopBackgroundTask(ctx context.Context, sessionID int64, taskID string) error {
@@ -1039,15 +1046,15 @@ func (r *Runtime) goalParams(req agentruntime.GoalRequest) (wire.GoalParams, err
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-func (r *Runtime) abortGeneration(ctx context.Context, sess *remoteSession) error {
+func (r *Runtime) abortGeneration(ctx context.Context, sess *remoteSession, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	if sess == nil {
-		return agentruntime.ErrNoActiveTurn
+		return agentruntime.AbortOutcome{}, agentruntime.ErrNoActiveTurn
 	}
 	r.mu.RLock()
 	current := r.sessions[sess.id] == sess
 	r.mu.RUnlock()
 	if !current {
-		return nil
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 
 	// Cancellation is owner-local and must reach preparation immediately. Only
@@ -1068,7 +1075,7 @@ func (r *Runtime) abortGeneration(ctx context.Context, sess *remoteSession) erro
 	current = r.sessions[sess.id] == sess
 	r.mu.RUnlock()
 	if !current {
-		return nil
+		return agentruntime.AbortOutcome{TurnKind: agentruntime.TurnKindNone}, nil
 	}
 	sess.abortOnce.Do(func() {
 		base := ctx
@@ -1077,14 +1084,16 @@ func (r *Runtime) abortGeneration(ctx context.Context, sess *remoteSession) erro
 		}
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(base), generationControlTimeout)
 		defer cancel()
-		err := r.callSentinel(abortCtx, wire.MethodAbort, wire.AbortParams{SessionID: sess.id}, &wire.OK{})
+		var res wire.AbortResult
+		err := r.callSentinel(abortCtx, wire.MethodAbort, wire.AbortParams{SessionID: sess.id, TurnToken: turnToken}, &res)
 		if errors.Is(err, agentruntime.ErrNoActiveTurn) {
 			err = nil
 		}
 		sess.abortErr = err
+		sess.abortOutcome = agentruntime.AbortOutcome{TurnKind: res.TurnKind}
 		r.finishSession(sess, agentruntime.ErrAborted)
 	})
-	return sess.abortErr
+	return sess.abortOutcome, sess.abortErr
 }
 
 // abortOverflowedGeneration cancels the daemon-side generation after a bounded
@@ -1096,7 +1105,7 @@ func (r *Runtime) abortGeneration(ctx context.Context, sess *remoteSession) erro
 func (r *Runtime) abortOverflowedGeneration(sess *remoteSession) {
 	abortCtx, cancel := context.WithTimeout(context.Background(), generationControlTimeout)
 	defer cancel()
-	err := r.callSentinel(abortCtx, wire.MethodAbort, wire.AbortParams{SessionID: sess.id}, &wire.OK{})
+	err := r.callSentinel(abortCtx, wire.MethodAbort, wire.AbortParams{SessionID: sess.id}, &wire.AbortResult{})
 	if errors.Is(err, agentruntime.ErrNoActiveTurn) {
 		err = nil
 	}

--- a/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
@@ -1298,6 +1298,35 @@ func TestAbort_SuccessAndNoSession(t *testing.T) {
 	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 }
 
+// TestAbort_PassesTurnTokenAndReturnsInterruptedTurnKind 钉死决策 1 的远端链路:
+// remote.Runtime.Abort 把调用方的 turnToken 原样透传到 wire.AbortParams,并把 daemon
+// 返回的 wire.AbortResult.TurnKind 带回给调用方(AbortOutcome.TurnKind)—— spec 测试接缝
+// 「remote wire + daemon handler:AbortParams 携带 token,daemon 侧透传并返回轮类型」。
+func TestAbort_PassesTurnTokenAndReturnsInterruptedTurnKind(t *testing.T) {
+	_, cli, _, rt := setupRemote(t)
+	cli.EXPECT().Call(gomock.Any(), wire.MethodRun, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ any, result any) error {
+			*(result.(*wire.RunAck)) = wire.RunAck{SessionID: 4}
+			return nil
+		})
+	_, _, err := rt.Run(context.Background(), agentruntime.RunRequest{
+		Backend:   &agent_backend_entity.AgentBackend{Type: "claudecode"},
+		SessionID: 4,
+	})
+	require.NoError(t, err)
+
+	// 断言 AbortParams 携带 turnToken=42,并让 daemon 应答一个具体的被中断轮类型。
+	cli.EXPECT().Call(gomock.Any(), wire.MethodAbort,
+		gomock.Eq(wire.AbortParams{SessionID: 4, TurnToken: 42}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ any, result any) error {
+			*(result.(*wire.AbortResult)) = wire.AbortResult{TurnKind: agentruntime.TurnKindAutonomous}
+			return nil
+		})
+	outcome, err := rt.Abort(context.Background(), 4, 42)
+	require.NoError(t, err)
+	assert.Equal(t, agentruntime.TurnKindAutonomous, outcome.TurnKind)
+}
+
 func TestStopBackgroundTask_SuccessAndNoSession(t *testing.T) {
 	_, cli, _, rt := setupRemote(t)
 	cli.EXPECT().Call(gomock.Any(), wire.MethodRun, gomock.Any(), gomock.Any()).

--- a/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
@@ -319,7 +319,8 @@ func TestPrepareRun_SlowConsumerOverflowCancelsExactGenerationAndAllowsRetry(t *
 	require.Error(t, firstResult.StopErr)
 	assert.Equal(t, "remote runtime: event delivery exceeded bounded buffer", firstResult.StopErr.Error())
 	assert.NotContains(t, firstResult.StopErr.Error(), secret)
-	assert.ErrorIs(t, rt.Abort(context.Background(), sessionID), agentruntime.ErrNoActiveTurn)
+	_, err = rt.Abort(context.Background(), sessionID, 0)
+	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 
 	// A stale frame observed after exact-owner finalization is dropped before a
 	// same-SessionID retry is installed.
@@ -383,7 +384,8 @@ func TestPrepareRun_StopDuringRegistrationWaitsForOwnerAckThenAborts(t *testing.
 	abortErrC := make(chan error, 1)
 	go func() {
 		close(abortStarted)
-		abortErrC <- rt.Abort(context.Background(), 72)
+		_, err := rt.Abort(context.Background(), 72, 0)
+		abortErrC <- err
 	}()
 	<-abortStarted
 	select {
@@ -428,9 +430,11 @@ func TestPrepareRun_PendingPiAbortCancelsTheRegisteredGeneration(t *testing.T) {
 	}()
 	<-entered
 
-	require.NoError(t, rt.Abort(context.Background(), 73))
+	_, err := rt.Abort(context.Background(), 73, 0)
+	require.NoError(t, err)
 	require.ErrorIs(t, <-errC, context.Canceled)
-	assert.ErrorIs(t, rt.Abort(context.Background(), 73), agentruntime.ErrNoActiveTurn)
+	_, err = rt.Abort(context.Background(), 73, 0)
+	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 }
 
 func TestPrepareRun_RequestCancellationAbortsPendingDaemonGeneration(t *testing.T) {
@@ -471,7 +475,8 @@ func TestPrepareRun_RequestCancellationAbortsPendingDaemonGeneration(t *testing.
 
 	require.ErrorIs(t, <-errC, context.Canceled)
 	<-abortCalled
-	assert.ErrorIs(t, rt.Abort(context.Background(), 74), agentruntime.ErrNoActiveTurn)
+	_, err := rt.Abort(context.Background(), 74, 0)
+	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 }
 
 func TestPrepareRun_StartCancellationAbortsPromptAcknowledgement(t *testing.T) {
@@ -519,7 +524,8 @@ func TestPrepareRun_StartCancellationAbortsPromptAcknowledgement(t *testing.T) {
 
 	require.ErrorIs(t, <-startErrC, context.Canceled)
 	<-abortCalled
-	assert.ErrorIs(t, rt.Abort(context.Background(), 75), agentruntime.ErrNoActiveTurn)
+	_, err = rt.Abort(context.Background(), 75, 0)
+	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 }
 
 func TestPrepareRun_CurrentPiCompletionIsNotConsumedWhenAbortedOwnerEmitsNoTerminalFrame(t *testing.T) {
@@ -1284,10 +1290,11 @@ func TestAbort_SuccessAndNoSession(t *testing.T) {
 
 	cli.EXPECT().Call(gomock.Any(), wire.MethodAbort, gomock.Any(), gomock.Any()).
 		Return(nil)
-	require.NoError(t, rt.Abort(context.Background(), 4))
+	_, err = rt.Abort(context.Background(), 4, 0)
+	require.NoError(t, err)
 
 	// Unknown session
-	err = rt.Abort(context.Background(), 999)
+	_, err = rt.Abort(context.Background(), 999, 0)
 	assert.ErrorIs(t, err, agentruntime.ErrNoActiveTurn)
 }
 

--- a/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
@@ -1508,7 +1508,7 @@ func TestControlRequests_CarryPeerOrigin(t *testing.T) {
 		{"Steer", func() error { return rt.Steer(context.Background(), peerSid, "q-1", "stop") }, wire.MethodSteer},
 		{"CancelSteer", func() error { _, err := rt.CancelSteer(context.Background(), peerSid, "q-1"); return err }, wire.MethodCancelSteer},
 		{"DrainPending", func() error { rt.DrainPending(context.Background(), peerSid); return nil }, wire.MethodDrainPending},
-		{"Abort", func() error { return rt.Abort(context.Background(), peerSid) }, wire.MethodAbort},
+		{"Abort", func() error { _, err := rt.Abort(context.Background(), peerSid, 0); return err }, wire.MethodAbort},
 		{"StopBackgroundTask", func() error { return rt.StopBackgroundTask(context.Background(), peerSid, "t-1") }, wire.MethodStopBackgroundTask},
 		{"SetPermissionMode", func() error { return rt.SetPermissionMode(context.Background(), peerSid, "plan") }, wire.MethodSetPermissionMode},
 		{"SubmitAnswer", func() error { return rt.SubmitAnswer(context.Background(), peerSid, "r-1", nil, nil, true) }, wire.MethodSubmitAnswer},

--- a/internal/pkg/agentruntime/runtimes/remote/wire/wire.go
+++ b/internal/pkg/agentruntime/runtimes/remote/wire/wire.go
@@ -305,9 +305,16 @@ type DrainResult struct {
 }
 
 // AbortParams 等同 agentruntime.Aborter.Abort 的入参。
+// TurnToken 语义同 agentruntime:0 = 中断当前活跃轮;非 0 = 仅当该轮仍是当前活跃轮才中断。
 type AbortParams struct {
 	SessionID       int64  `json:"sessionId"`
 	PeerFingerprint string `json:"peerFingerprint,omitempty"`
+	TurnToken       uint64 `json:"turnToken,omitempty"`
+}
+
+// AbortResult 是 MethodAbort 的应答,携带被中断轮的类型(agentruntime.AbortOutcome.TurnKind)。
+type AbortResult struct {
+	TurnKind agentruntime.TurnKind `json:"turnKind"`
 }
 
 // StopBackgroundTaskParams 等同 agentruntime.BackgroundTaskStopper.StopBackgroundTask 的入参。
@@ -500,6 +507,7 @@ type RunResultDoneFrame struct {
 	UserAnchor        string     `json:"userAnchor,omitempty"`
 	Model             string     `json:"model,omitempty"`
 	ContextWindow     int        `json:"contextWindow,omitempty"`
+	TurnToken         uint64     `json:"turnToken,omitempty"`
 	StopErrMsg        string     `json:"stopErrMsg,omitempty"`
 	StopErrCode       int        `json:"stopErrCode,omitempty"`
 	Seq               int64      `json:"seq,omitempty"`
@@ -515,6 +523,7 @@ func (f *RunResultDoneFrame) SetSeq(seq int64) { f.Seq = seq }
 type AutonomousTurnStartedFrame struct {
 	SessionID int64  `json:"sessionId"`
 	Trigger   string `json:"trigger,omitempty"`
+	TurnToken uint64 `json:"turnToken,omitempty"`
 	Seq       int64  `json:"seq,omitempty"`
 }
 

--- a/internal/service/chat_svc/autonomous_turn.go
+++ b/internal/service/chat_svc/autonomous_turn.go
@@ -89,7 +89,7 @@ func (s *chatSvc) driveAutonomousTurn(ctx context.Context, sessionID int64, be *
 	}); err != nil {
 		logger.Ctx(ctx).Error("chat_svc: driveAutonomousTurn persist assistant failed",
 			zap.Int64("sessionId", sessionID), zap.Error(err))
-		s.failAutonomousTurnPersist(ctx, sessionID, sess, be, err, at.Events)
+		s.failAutonomousTurnPersist(ctx, sessionID, sess, be, err, at.Events, at.TurnToken)
 		return
 	}
 
@@ -258,6 +258,7 @@ func (s *chatSvc) failAutonomousTurnPersist(
 	be *agent_backend_entity.AgentBackend,
 	persistErr error,
 	events <-chan agentruntime.Event,
+	turnToken uint64,
 ) {
 	// 1. 会话翻 error 并持久化;这次写失败只记日志,不重试。
 	sess.AgentStatus = "error"
@@ -278,7 +279,10 @@ func (s *chatSvc) failAutonomousTurnPersist(
 	// 中断要等的回执反过来依赖抽干)。走与 Stop 遗孤路径同一个 requestRuntimeAbort:
 	// selectRunner / Abort 失败(含子进程已消失)在那里只记日志,不影响前两步已经产
 	// 生的结果,这里的布尔判据也就无人可报,直接丢弃。
-	go func() { _ = s.requestRuntimeAbort(ctx, be, sessionID) }()
+	//
+	// turnToken 携带本轮的身份(决策 1):异步中断到达时若这一轮仍是当前活跃轮就中断,
+	// 否则 stale no-op —— drain 完成后即使新轮已起,迟到的中断也不会杀掉新轮。
+	go func() { _ = s.requestRuntimeAbort(ctx, be, sessionID, turnToken) }()
 
 	// 4. Hard invariant:抽干事件 channel,别让 Session reader 阻塞。
 	drainAndDiscard(events)

--- a/internal/service/chat_svc/autonomous_turn.go
+++ b/internal/service/chat_svc/autonomous_turn.go
@@ -282,7 +282,7 @@ func (s *chatSvc) failAutonomousTurnPersist(
 	//
 	// turnToken 携带本轮的身份(决策 1):异步中断到达时若这一轮仍是当前活跃轮就中断,
 	// 否则 stale no-op —— drain 完成后即使新轮已起,迟到的中断也不会杀掉新轮。
-	go func() { _ = s.requestRuntimeAbort(ctx, be, sessionID, turnToken) }()
+	go func() { _, _ = s.requestRuntimeAbort(ctx, be, sessionID, turnToken) }()
 
 	// 4. Hard invariant:抽干事件 channel,别让 Session reader 阻塞。
 	drainAndDiscard(events)

--- a/internal/service/chat_svc/autonomous_turn_test.go
+++ b/internal/service/chat_svc/autonomous_turn_test.go
@@ -29,10 +29,13 @@ import (
 // abortRecordingRunner 是一个最小的 agentruntime.Runtime + agentruntime.Aborter
 // fake,用来断言 driveAutonomousTurn 落库失败分支(结果 3)确实请求了中断,以及
 // 中断失败(abortErr,含"子进程已消失"场景)不影响其余可观察结果。
+//
+// abortTokens 记录每次 Abort 收到的 turnToken,供断言「异步中断携带失败轮的 token」。
 type abortRecordingRunner struct {
-	mu         sync.Mutex
-	abortCalls []int64
-	abortErr   error
+	mu          sync.Mutex
+	abortCalls  []int64
+	abortTokens []uint64
+	abortErr    error
 }
 
 func (*abortRecordingRunner) Capabilities() capability.Capabilities {
@@ -43,17 +46,24 @@ func (*abortRecordingRunner) Run(context.Context, agentruntime.RunRequest) (<-ch
 	return nil, nil, errors.New("abortRecordingRunner: Run must not be called")
 }
 
-func (r *abortRecordingRunner) Abort(_ context.Context, sessionID int64) error {
+func (r *abortRecordingRunner) Abort(_ context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.abortCalls = append(r.abortCalls, sessionID)
-	return r.abortErr
+	r.abortTokens = append(r.abortTokens, turnToken)
+	return agentruntime.AbortOutcome{}, r.abortErr
 }
 
 func (r *abortRecordingRunner) Calls() []int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]int64(nil), r.abortCalls...)
+}
+
+func (r *abortRecordingRunner) Tokens() []uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]uint64(nil), r.abortTokens...)
 }
 
 // joinAbort 在**父作用域**里等本遍那个异步中断落地,再放叶子断言跑。
@@ -346,7 +356,7 @@ func TestDriveAutonomousTurn_PersistFailure_FlipsErrorEmitsAndInterrupts(t *test
 		evs <- agentruntime.TextDelta{Text: "must not be read by the dispatcher"}
 		evs <- agentruntime.TextDelta{Text: "must not be read by the dispatcher either"}
 		close(evs)
-		at := agentruntime.AutonomousTurn{Events: evs, Trigger: "background_task"}
+		at := agentruntime.AutonomousTurn{Events: evs, Trigger: "background_task", TurnToken: 7}
 
 		chat_svc.DriveAutonomousTurnForTest(ctx, m.svc, 100, be, at)
 		// 中断是异步发出的(见 failAutonomousTurnPersist:同步等回执会与第 4 步的抽干
@@ -378,6 +388,8 @@ func TestDriveAutonomousTurn_PersistFailure_FlipsErrorEmitsAndInterrupts(t *test
 
 		convey.Convey("3. 主动中断 CLI 当前这一轮,使子进程解除等待", func() {
 			assert.Equal(t, []int64{100}, runner.Calls(), "应请求中断这一轮")
+			assert.Equal(t, []uint64{7}, runner.Tokens(),
+				"异步中断必须携带失败轮的 per-turn token,精确寻址(决策 1)")
 		})
 
 		convey.Convey("4. Hard invariant:事件流仍被抽干,发生在前三步之后", func() {
@@ -462,13 +474,13 @@ type abortWaitsForDrainRunner struct {
 	giveUp  <-chan struct{}
 }
 
-func (r *abortWaitsForDrainRunner) Abort(ctx context.Context, sessionID int64) error {
-	err := r.abortRecordingRunner.Abort(ctx, sessionID)
+func (r *abortWaitsForDrainRunner) Abort(ctx context.Context, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, error) {
+	outcome, err := r.abortRecordingRunner.Abort(ctx, sessionID, turnToken)
 	select {
 	case <-r.drained:
 	case <-r.giveUp:
 	}
-	return err
+	return outcome, err
 }
 
 // TestDriveAutonomousTurn_PersistFailure_InterruptDoesNotBlockWatcher 钉死 spec

--- a/internal/service/chat_svc/autonomous_turn_test.go
+++ b/internal/service/chat_svc/autonomous_turn_test.go
@@ -31,11 +31,14 @@ import (
 // 中断失败(abortErr,含"子进程已消失"场景)不影响其余可观察结果。
 //
 // abortTokens 记录每次 Abort 收到的 turnToken,供断言「异步中断携带失败轮的 token」。
+// turnKind 配置 Abort 返回的被中断轮类型(决策 1 的 AbortOutcome),让
+// reconcileOrphanStop 的分流(自主轮 vs subagent 活动轮)可测。
 type abortRecordingRunner struct {
 	mu          sync.Mutex
 	abortCalls  []int64
 	abortTokens []uint64
 	abortErr    error
+	turnKind    agentruntime.TurnKind
 }
 
 func (*abortRecordingRunner) Capabilities() capability.Capabilities {
@@ -51,7 +54,7 @@ func (r *abortRecordingRunner) Abort(_ context.Context, sessionID int64, turnTok
 	defer r.mu.Unlock()
 	r.abortCalls = append(r.abortCalls, sessionID)
 	r.abortTokens = append(r.abortTokens, turnToken)
-	return agentruntime.AbortOutcome{}, r.abortErr
+	return agentruntime.AbortOutcome{TurnKind: r.turnKind}, r.abortErr
 }
 
 func (r *abortRecordingRunner) Calls() []int64 {

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -1773,7 +1773,7 @@ func (s *chatSvc) Stop(ctx context.Context, req *StopRequest) (*StopResponse, er
 			if _, be, _, berr := s.resolveAgentBackend(ctx, sess.AgentID); berr == nil && be != nil {
 				// 中断没下发下去不致命(前面已 cancel turnCtx 兜底),布尔判据这里
 				// 无人可报;失败的留底由 requestRuntimeAbort 自己记。
-				_ = s.requestRuntimeAbort(ctx, be, req.SessionID, 0)
+				_, _ = s.requestRuntimeAbort(ctx, be, req.SessionID, 0)
 			}
 		}
 	}
@@ -1784,10 +1784,13 @@ func (s *chatSvc) Stop(ctx context.Context, req *StopRequest) (*StopResponse, er
 //   - 会话查不到 / 已是终态(idle/error)→ turn 早就收尾,返 ChatStopNoActive(无害的
 //     「太晚了」,前端静默)。
 //   - 会话还停在 running/waiting,先问 runtime 有没有带外轮在飞(自主续轮 / 后台
-//     subagent 活动轮不进 activeCancels,却是此刻真正活跃的那一轮)→ 有就中断它,
-//     状态留给那一轮自己收尾。
-//   - runtime 也说没有活跃轮,才是真「重启遗孤」→ 翻回 idle(等同 abort 收尾)并落库,
-//     让前端那颗按 DB 状态一直亮着的「停止」按钮真能把会话停下来。
+//     subagent 活动轮不进 activeCancels,却是此刻真正活跃的那一轮)→ 有就中断它,再
+//     按被中断轮的类型决定谁 reconcile 会话状态(决策 3):
+//   - 中断的是自主轮 → 状态留给 driveAutonomousTurn 收尾(idle/error),Stop 不落库;
+//   - 中断的是 subagent 活动轮 → driveSubagentActivity 不写会话状态,由这里自己把
+//     running/waiting 翻回 idle 并持久化(复用遗孤路径的翻写逻辑),一次点停止即收干净;
+//   - runtime 报 ErrNoActiveTurn / 解析不出 runner → 才是真「重启遗孤」→ 翻回 idle 并
+//     落库(等同 abort 收尾),让前端那颗按 DB 状态一直亮着的「停止」按钮真能把会话停下来。
 //
 // 不去 emit StreamSessionStatus:遗孤会话没有活跃 stream 订阅(stream 名按
 // sessionID+assistantMsgID 双键),推了也送不到;前端 doStop 成功后会主动 reload
@@ -1800,58 +1803,79 @@ func (s *chatSvc) reconcileOrphanStop(ctx context.Context, sessionID int64) (*St
 	if sess.AgentStatus != "running" && sess.AgentStatus != "waiting" {
 		return nil, i18n.NewError(ctx, code.ChatStopNoActive)
 	}
-	if s.abortOutOfBandTurn(ctx, sess) {
+	outcome, interrupted := s.abortOutOfBandTurn(ctx, sess)
+	if interrupted {
+		// 确有一轮被中断,会话仍在跑。中断的是 subagent 活动轮时,会话的
+		// running/waiting 已无合法依据且那一轮不写状态 —— 由这里接管翻 idle 落库;
+		// 中断的是自主轮时状态留给它自己收尾,不落库。
+		if outcome.TurnKind == agentruntime.TurnKindSubagentActivity {
+			if perr := s.reconcileSessionToIdle(ctx, sess); perr != nil {
+				return nil, perr
+			}
+		}
 		return &StopResponse{Stopped: true}, nil
 	}
-	logger.Ctx(ctx).Info("chat_svc.Stop: reconciling orphan session to idle",
-		zap.Int64("sessionId", sessionID),
-		zap.String("prevStatus", sess.AgentStatus))
-	sess.AgentStatus = "idle"
-	sess.NeedsAttention = false
-	if perr := s.persistSessionStatus(ctx, sess); perr != nil {
+	if perr := s.reconcileSessionToIdle(ctx, sess); perr != nil {
 		return nil, perr
 	}
 	return &StopResponse{Stopped: true}, nil
 }
 
+// reconcileSessionToIdle 把会话 running/waiting 翻回 idle 并清 attention,复用
+// persistSessionStatus(重试一次 + 失败上抛不静默)。遗孤路径与「被中断的是 subagent
+// 活动轮」的接管路径共用这一份翻写逻辑。
+func (s *chatSvc) reconcileSessionToIdle(ctx context.Context, sess *chat_entity.Session) error {
+	logger.Ctx(ctx).Info("chat_svc.Stop: reconciling session to idle",
+		zap.Int64("sessionId", sess.ID),
+		zap.String("prevStatus", sess.AgentStatus))
+	sess.AgentStatus = "idle"
+	sess.NeedsAttention = false
+	return s.persistSessionStatus(ctx, sess)
+}
+
 // abortOutOfBandTurn 在「没有活跃用户轮」的前提下,把中断请求交给 runtime 试一次,
-// 报告是否真有一轮被中断。
+// 报告是否真有一轮被中断,以及被中断的那一轮的类型(AbortOutcome.TurnKind)。
 //
 // 带外轮(自主续轮 / 后台 subagent 活动轮)独占帧流期间不进 activeCancels —— 它就是
 // 该会话此刻活跃的那一轮,而 Abort 的契约正是「中断该会话当前活跃的那一轮」,两者
 // 都不活跃时才返回 ErrNoActiveTurn。因此这里可以直接拿 Abort 的返回值当判据:
-// nil = 确有一轮被中断,会话仍在跑,调用方不能再把它当遗孤 reconcile 成 idle(那会
+// 中断成功 = 确有一轮被中断,会话仍在跑,调用方不能再把它当遗孤 reconcile 成 idle(那会
 // 在 CLI 还在产帧时谎报 idle);ErrNoActiveTurn / 解析不出 runner = 内存里真的什么
-// 都没有,交回遗孤路径。turnToken 固定传 0(中断当前活跃的带外轮,等价旧行为)。
-func (s *chatSvc) abortOutOfBandTurn(ctx context.Context, sess *chat_entity.Session) bool {
+// 都没有,交回遗孤路径。被中断轮的类型由 reconcileOrphanStop 拿来分流:自主轮留给它
+// 自己收尾,subagent 活动轮则由 Stop 接管翻 idle(决策 3)。turnToken 固定传 0(中断
+// 当前活跃的带外轮,等价旧行为)。
+func (s *chatSvc) abortOutOfBandTurn(ctx context.Context, sess *chat_entity.Session) (agentruntime.AbortOutcome, bool) {
 	_, be, _, err := s.resolveAgentBackend(ctx, sess.AgentID)
 	if err != nil || be == nil {
 		logger.Ctx(ctx).Warn("chat_svc.Stop: cannot resolve backend to interrupt out-of-band turn",
 			zap.Int64("sessionId", sess.ID), zap.Error(err))
-		return false
+		return agentruntime.AbortOutcome{}, false
 	}
-	if !s.requestRuntimeAbort(ctx, be, sess.ID, 0) {
-		return false
+	outcome, ok := s.requestRuntimeAbort(ctx, be, sess.ID, 0)
+	if !ok {
+		return agentruntime.AbortOutcome{}, false
 	}
 	logger.Ctx(ctx).Info("chat_svc.Stop: interrupted out-of-band turn",
 		zap.Int64("sessionId", sess.ID),
 		zap.String("backendType", be.Type),
+		zap.String("turnKind", string(outcome.TurnKind)),
 		zap.String("prevStatus", sess.AgentStatus))
-	return true
+	return outcome, true
 }
 
 // requestRuntimeAbort 把「中断该会话当前活跃的那一轮」尽力下发给 runtime,报告是否
-// 真有一轮被中断:Abort 返 nil = 确有一轮被中断;ErrNoActiveTurn / 解析不出 runner /
-// runner 不支持中断 = 内存里没有可中断的轮。任何一步失败都只记日志、不返回错误 ——
-// 三个调用方(Stop 里活跃用户轮的 best-effort 中断、Stop 的遗孤路径
-// abortOutOfBandTurn、自主续轮落库失败处置 failAutonomousTurnPersist)要么只要这一个
-// 布尔判据、要么连它都不要,失败各自另有兜底(已 cancel turnCtx / 交回遗孤 reconcile /
-// 前两步的可观察结果已经产生)。
+// 真有一轮被中断以及被中断轮的类型:Abort 返 nil = 确有一轮被中断(AbortOutcome 携带
+// 轮类型);ErrNoActiveTurn / 解析不出 runner / runner 不支持中断 = 内存里没有可中断
+// 的轮(返回零值 outcome + false)。任何一步失败都只记日志、不返回错误 —— 三个调用方
+// (Stop 里活跃用户轮的 best-effort 中断、Stop 的遗孤路径 abortOutOfBandTurn、自主续轮
+// 落库失败处置 failAutonomousTurnPersist)要么只要这个布尔判据 + 轮类型、要么连它都
+// 不要,失败各自另有兜底(已 cancel turnCtx / 交回遗孤 reconcile / 前两步的可观察结果
+// 已经产生)。
 //
 // **会阻塞**:claudecode 的 Abort 写完 control_request 后要等 CLI 的 control_response,
 // 而那条回执要常驻 readLoop 前进才派发得了。调用方若同时还担着「让帧流继续被消费」的
 // 责任(failAutonomousTurnPersist 的抽干),必须以非阻塞方式调用,否则两者互相等着。
-func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64, turnToken uint64) bool {
+func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64, turnToken uint64) (agentruntime.AbortOutcome, bool) {
 	backendType := ""
 	if be != nil {
 		backendType = be.Type
@@ -1860,20 +1884,21 @@ func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_ent
 	if err != nil {
 		logger.Ctx(ctx).Warn("chat_svc.requestRuntimeAbort: selectRunner failed, cannot interrupt turn",
 			zap.Int64("sessionId", sessionID), zap.String("backendType", backendType), zap.Error(err))
-		return false
+		return agentruntime.AbortOutcome{}, false
 	}
 	aborter, ok := runner.(agentruntime.Aborter)
 	if !ok {
-		return false
+		return agentruntime.AbortOutcome{}, false
 	}
-	if _, aerr := aborter.Abort(ctx, sessionID, turnToken); aerr != nil {
+	outcome, aerr := aborter.Abort(ctx, sessionID, turnToken)
+	if aerr != nil {
 		if !errors.Is(aerr, agentruntime.ErrNoActiveTurn) {
 			logger.Ctx(ctx).Warn("chat_svc.requestRuntimeAbort: runner.Abort failed",
 				zap.Int64("sessionId", sessionID), zap.String("backendType", backendType), zap.Error(aerr))
 		}
-		return false
+		return agentruntime.AbortOutcome{}, false
 	}
-	return true
+	return outcome, true
 }
 
 // StopBackgroundTask 停掉某个后台任务 / 子 agent(run_in_background),而不是中断整个 turn。

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -1755,7 +1755,7 @@ func (s *chatSvc) Stop(ctx context.Context, req *StopRequest) (*StopResponse, er
 	}
 	if gracefulAbort {
 		abortCtx, cancelAbort := context.WithTimeout(ctx, piStopAbortWriteBound)
-		abortErr := gracefulAborter.Abort(abortCtx, req.SessionID)
+		_, abortErr := gracefulAborter.Abort(abortCtx, req.SessionID, 0)
 		cancelAbort()
 		if abortErr != nil && !errors.Is(abortErr, agentruntime.ErrNoActiveTurn) {
 			logger.Ctx(ctx).Warn("chat_svc.Stop: local Pi abort failed",
@@ -1773,7 +1773,7 @@ func (s *chatSvc) Stop(ctx context.Context, req *StopRequest) (*StopResponse, er
 			if _, be, _, berr := s.resolveAgentBackend(ctx, sess.AgentID); berr == nil && be != nil {
 				// 中断没下发下去不致命(前面已 cancel turnCtx 兜底),布尔判据这里
 				// 无人可报;失败的留底由 requestRuntimeAbort 自己记。
-				_ = s.requestRuntimeAbort(ctx, be, req.SessionID)
+				_ = s.requestRuntimeAbort(ctx, be, req.SessionID, 0)
 			}
 		}
 	}
@@ -1822,7 +1822,7 @@ func (s *chatSvc) reconcileOrphanStop(ctx context.Context, sessionID int64) (*St
 // 都不活跃时才返回 ErrNoActiveTurn。因此这里可以直接拿 Abort 的返回值当判据:
 // nil = 确有一轮被中断,会话仍在跑,调用方不能再把它当遗孤 reconcile 成 idle(那会
 // 在 CLI 还在产帧时谎报 idle);ErrNoActiveTurn / 解析不出 runner = 内存里真的什么
-// 都没有,交回遗孤路径。
+// 都没有,交回遗孤路径。turnToken 固定传 0(中断当前活跃的带外轮,等价旧行为)。
 func (s *chatSvc) abortOutOfBandTurn(ctx context.Context, sess *chat_entity.Session) bool {
 	_, be, _, err := s.resolveAgentBackend(ctx, sess.AgentID)
 	if err != nil || be == nil {
@@ -1830,7 +1830,7 @@ func (s *chatSvc) abortOutOfBandTurn(ctx context.Context, sess *chat_entity.Sess
 			zap.Int64("sessionId", sess.ID), zap.Error(err))
 		return false
 	}
-	if !s.requestRuntimeAbort(ctx, be, sess.ID) {
+	if !s.requestRuntimeAbort(ctx, be, sess.ID, 0) {
 		return false
 	}
 	logger.Ctx(ctx).Info("chat_svc.Stop: interrupted out-of-band turn",
@@ -1851,7 +1851,7 @@ func (s *chatSvc) abortOutOfBandTurn(ctx context.Context, sess *chat_entity.Sess
 // **会阻塞**:claudecode 的 Abort 写完 control_request 后要等 CLI 的 control_response,
 // 而那条回执要常驻 readLoop 前进才派发得了。调用方若同时还担着「让帧流继续被消费」的
 // 责任(failAutonomousTurnPersist 的抽干),必须以非阻塞方式调用,否则两者互相等着。
-func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64) bool {
+func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64, turnToken uint64) bool {
 	backendType := ""
 	if be != nil {
 		backendType = be.Type
@@ -1866,7 +1866,7 @@ func (s *chatSvc) requestRuntimeAbort(ctx context.Context, be *agent_backend_ent
 	if !ok {
 		return false
 	}
-	if aerr := aborter.Abort(ctx, sessionID); aerr != nil {
+	if _, aerr := aborter.Abort(ctx, sessionID, turnToken); aerr != nil {
 		if !errors.Is(aerr, agentruntime.ErrNoActiveTurn) {
 			logger.Ctx(ctx).Warn("chat_svc.requestRuntimeAbort: runner.Abort failed",
 				zap.Int64("sessionId", sessionID), zap.String("backendType", backendType), zap.Error(aerr))
@@ -3257,7 +3257,7 @@ func (s *chatSvc) discardPreparedTurn(sessionID int64, prepared *preparedTurnRun
 		cancel()
 	} else if prepared.events != nil {
 		if aborter, ok := prepared.runner.(agentruntime.Aborter); ok {
-			_ = aborter.Abort(context.Background(), sessionID)
+			_, _ = aborter.Abort(context.Background(), sessionID, 0)
 		}
 	}
 	if prepared.events == nil {

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -1365,11 +1365,11 @@ func (r *generationSafePreparedRunner) PrepareRun(context.Context, agentruntime.
 	return &generationSafePreparedRun{runner: r}, nil
 }
 
-func (r *generationSafePreparedRunner) Abort(context.Context, int64) error {
+func (r *generationSafePreparedRunner) Abort(context.Context, int64, uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.abortCalls++
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 func (r *generationSafePreparedRunner) Counts() (prepare, closed, abort int) {
@@ -1483,7 +1483,7 @@ func (r *stopOrderPiRunner) Run(ctx context.Context, req agentruntime.RunRequest
 	return events, result, nil
 }
 
-func (r *stopOrderPiRunner) Abort(context.Context, int64) error {
+func (r *stopOrderPiRunner) Abort(context.Context, int64, uint64) (agentruntime.AbortOutcome, error) {
 	r.mu.Lock()
 	r.abortCalls++
 	runCtx := r.runCtx
@@ -1503,7 +1503,7 @@ func (r *stopOrderPiRunner) Abort(context.Context, int64) error {
 		r.mu.Unlock()
 		r.finishOnce.Do(func() { close(events) })
 	}
-	return nil
+	return agentruntime.AbortOutcome{}, nil
 }
 
 func (r *stopOrderPiRunner) stopObservation() (int, bool) {

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -8632,11 +8632,16 @@ func TestStop_OrphanWaitingSessionReconciledToIdle(t *testing.T) {
 // 不进 activeCancels —— 只放宽 Runtime.Abort 的活跃判据够不着这条通路:Stop 在
 // activeCancels 取不到条目时直接走 reconcileOrphanStop,把一个真在跑的会话谎报成
 // idle 就返回,runner.Abort 一次都没下发,CLI 那一轮照跑。
+//
+// 决策 3(本轮)把它扩为按 Abort 返回的被中断轮类型断言:这里 runner 上报被中断的
+// 是自主轮 → 维持现状,状态留给 driveAutonomousTurn 收尾、Stop 不落库(刻意不
+// EXPECT Session().Update);被中断的是 subagent 活动轮 → 由 reconcileOrphanStop
+// 接管翻 idle 落库,见 TestStop_SubagentActivityTurnIsReconciledToIdle。
 func TestStop_OutOfBandTurnIsInterruptedNotReconciled(t *testing.T) {
-	convey.Convey("Stop 无活跃用户轮但带外轮在飞 → 真下发中断,且不按遗孤 reconcile 成 idle", t, func() {
+	convey.Convey("Stop 无活跃用户轮但自主轮在飞 → 真下发中断,状态留给那一轮收尾,不按遗孤 reconcile 成 idle", t, func() {
 		m := setupChatTest(t)
 
-		runner := &abortRecordingRunner{}
+		runner := &abortRecordingRunner{turnKind: agentruntime.TurnKindAutonomous}
 		restore := agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner)
 		t.Cleanup(restore)
 
@@ -8648,7 +8653,7 @@ func TestStop_OutOfBandTurnIsInterruptedNotReconciled(t *testing.T) {
 			&agent_backend_entity.AgentBackend{
 				ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), Status: consts.ACTIVE,
 			}, nil)
-		// 刻意不 EXPECT Session().Update:带外轮仍在跑,状态归它自己收尾时落,
+		// 刻意不 EXPECT Session().Update:自主轮仍在跑,状态归它自己收尾时落,
 		// Stop 这里翻 idle 就是谎报(gomock 严格,真调了会直接判失败)。
 
 		resp, err := m.svc.Stop(m.ctx, &chat_svc.StopRequest{SessionID: 300})
@@ -8657,6 +8662,44 @@ func TestStop_OutOfBandTurnIsInterruptedNotReconciled(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.True(t, resp.Stopped, "带外轮被中断了就该回报已停止")
 		assert.Equal(t, []int64{300}, runner.Calls(), "必须真的把中断下发到 runtime")
+	})
+}
+
+// TestStop_SubagentActivityTurnIsReconciledToIdle 钉死决策 3 的新增接管:Stop 无活跃
+// 用户轮、runner 上报被中断的是 subagent 活动轮时,会话的 running/waiting 已无合法
+// 依据,且 driveSubagentActivity 不写会话状态 —— 由 reconcileOrphanStop 自己翻 idle
+// 并持久化(复用遗孤路径的翻写逻辑),一次点停止即收干净,无需第二次。
+func TestStop_SubagentActivityTurnIsReconciledToIdle(t *testing.T) {
+	convey.Convey("Stop 无活跃用户轮但 subagent 活动轮在飞 → 中断它并自己把会话 reconcile 回 idle 落库", t, func() {
+		m := setupChatTest(t)
+
+		runner := &abortRecordingRunner{turnKind: agentruntime.TurnKindSubagentActivity}
+		restore := agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner)
+		t.Cleanup(restore)
+
+		m.session.EXPECT().Find(m.ctx, int64(310)).Return(
+			&chat_entity.Session{ID: 310, AgentID: 7, AgentStatus: "running", Status: consts.ACTIVE}, nil)
+		m.agent.EXPECT().Find(m.ctx, int64(7)).Return(
+			&agent_entity.Agent{ID: 7, AgentBackendID: 12, Status: consts.ACTIVE}, nil)
+		m.backend.EXPECT().Find(m.ctx, int64(12)).Return(
+			&agent_backend_entity.AgentBackend{
+				ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), Status: consts.ACTIVE,
+			}, nil)
+		var updated *chat_entity.Session
+		m.session.EXPECT().Update(m.ctx, gomock.Any()).DoAndReturn(
+			func(_ context.Context, s *chat_entity.Session) error {
+				updated = s
+				return nil
+			})
+
+		resp, err := m.svc.Stop(m.ctx, &chat_svc.StopRequest{SessionID: 310})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.True(t, resp.Stopped, "subagent 活动轮被中断了就该回报已停止")
+		assert.Equal(t, []int64{310}, runner.Calls(), "必须真的把中断下发到 runtime")
+		assert.NotNil(t, updated, "subagent 活动轮被中断后要由 Stop 自己落库")
+		assert.Equal(t, "idle", updated.AgentStatus, "会话应被 reconcile 回 idle")
 	})
 }
 

--- a/pkg/claudecode/errors.go
+++ b/pkg/claudecode/errors.go
@@ -16,6 +16,11 @@ var (
 	// ErrAPIError 标记 CLI 合成的 API 错误消息帧（isApiErrorMessage:true）。上层用
 	// errors.Is 把「turn 被 API 错误终止」这一类与普通子进程退出错误区分开。
 	ErrAPIError = errors.New("claudecode: api error")
+	// ErrInterruptPending 标记 control_request（interrupt / stop_task）帧已写入
+	// CLI stdin、但 ack 在 interruptAckBound 内未到达。帧已写、请求在途,CLI 处理到
+	// 后会自然收尾 —— 上层（claudecode Runtime.Abort）把它视为「中断已下发」而不是
+	// 「失败」,不得因此杀子进程 / 逐出缓存。
+	ErrInterruptPending = errors.New("claudecode: interrupt pending, ack not received within bound")
 )
 
 // APIError 承载 CLI isApiErrorMessage 帧的错误文本与顶层 error 分类码。

--- a/pkg/claudecode/session.go
+++ b/pkg/claudecode/session.go
@@ -21,6 +21,12 @@ import (
 // 慢机的余量，错过这个窗口的早退由 Turn / 0-frame fallback 兜底（也走 ExitErr）。
 var claudeStartupCheckTimeout = 200 * time.Millisecond
 
+// interruptAckBound 是 Interrupt / StopTask 等 control_request 写帧后等 ack 的
+// 上界（与 chat_svc 的 piStopAbortWriteBound=500ms 同值）。CLI 不回执（卡在别的
+// 处理上）时超时返回 ErrInterruptPending —— 帧已写、请求在途,不无界挂住调用方
+// 的 goroutine,也不因超时杀子进程。
+const interruptAckBound = 500 * time.Millisecond
+
 // Session 是一个常驻的 claude 子进程。多个 Turn 复用同一个 stdin/stdout，
 // 适合"每个 chat session 一个子进程"的部署形态——避免每轮 spawn 的 cold start，
 // 也让 hooks/--settings 注入只做一次。
@@ -725,9 +731,14 @@ func parseControlResponse(line []byte) (controlResponse, string, bool) {
 
 // Interrupt 写一帧 control_request{subtype:"interrupt"} 让 CLI 软中断当前 turn。
 // CLI 会回一帧 control_response 标 success / error，本方法阻塞等这条回执（或 ctx
-// 取消）。中断成功后 CLI 还会发一个 result 帧（subtype 通常是 "interrupted" /
+// 取消 / 子进程收尾 / interruptAckBound 超时）。中断成功后 CLI 还会发一个 result 帧
+// （subtype 通常是 "interrupted" /
 // "error_during_execution"）让正在 drain 的 Turn 自然返 done —— **子进程保留**，
 // 下一轮可以直接复用同一个 Session。
+//
+// ack 等待有界（interruptAckBound=500ms）：CLI 不回执（卡在别的处理上）时超时返回
+// ErrInterruptPending —— 帧已写、中断在途，CLI 处理到后会自然收尾；调用方应把它视
+// 为「中断已下发」而非失败，不得因此杀子进程。
 //
 // 调用约束：可以和 Turn 并发调用（stdinMu 只在写帧期间持有，turnMu 不参与）。
 // Close 之后调返错。同一个 Session 并发多次 Interrupt 不冲突（各自 request_id）
@@ -771,6 +782,10 @@ func (s *Session) Interrupt(ctx context.Context) error {
 		return ctx.Err()
 	case <-s.readerDone:
 		return s.controlRequestAbortedErr("interrupt")
+	case <-time.After(interruptAckBound):
+		// CLI 不回执：中断帧已写、在途，CLI 处理到后 readLoop 会 dispatch 迟到的
+		// control_response / result 让本轮自然收尾。有界返回独立哨兵，不无界挂死。
+		return ErrInterruptPending
 	case resp := <-ch:
 		if resp.Subtype != "success" {
 			if resp.Error != "" {
@@ -829,6 +844,10 @@ func (s *Session) StopTask(ctx context.Context, taskID string) error {
 		return ctx.Err()
 	case <-s.readerDone:
 		return s.controlRequestAbortedErr("stop_task")
+	case <-time.After(interruptAckBound):
+		// 与 Interrupt 同款有界：stop_task 帧已写、在途，CLI 停掉任务后会另发
+		// task_notification 收尾。超时返回 ErrInterruptPending，不无界挂死。
+		return ErrInterruptPending
 	case resp := <-ch:
 		return stopTaskResponseErr(resp)
 	}

--- a/pkg/claudecode/session_test.go
+++ b/pkg/claudecode/session_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"regexp"
@@ -307,6 +308,81 @@ func TestSession_CloseStopsTurns(t *testing.T) {
 
 	_, err = sess.Turn(ctx, "after-close")
 	assert.Error(t, err)
+}
+
+// fakeInterruptNoAck 模拟 CLI 收到 control_request 但迟迟不回执（卡在别的处理上，
+// 既不回 control_response 也不发 result）。吞掉 stdin 所有行、绝不 ack —— 让
+// Interrupt / StopTask 的 ack 等待落在 interruptAckBound 的有界超时上。
+func fakeInterruptNoAck(gotLines chan<- string) fakeCLIFunc {
+	return func(stdin io.Reader, stdout io.Writer) {
+		sc := bufio.NewScanner(stdin)
+		sc.Buffer(make([]byte, 0, 64<<10), maxFrameBytes)
+		for sc.Scan() {
+			select {
+			case gotLines <- sc.Text():
+			default:
+			}
+		}
+	}
+}
+
+// TestSession_Interrupt_PendingAckIsBounded 钉死决策 2：CLI 不回执时 Interrupt 的
+// ack 等待**有界**（interruptAckBound=500ms），超时返回独立哨兵 ErrInterruptPending
+// （errors.Is 可判），control_request 帧只写一次 —— 而不是无界挂到子进程死。
+func TestSession_Interrupt_PendingAckIsBounded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := make(chan string, 8)
+	c := New(WithBinary("fake"), pipeSpawner(t, fakeInterruptNoAck(got)))
+	sess, err := c.OpenSession(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close(context.Background()) }()
+
+	start := time.Now()
+	err = sess.Interrupt(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInterruptPending), "应返回可 errors.Is 判定的 ErrInterruptPending,got: %v", err)
+	assert.Less(t, elapsed, 1500*time.Millisecond, "Interrupt 应在 interruptAckBound 内返回,got %v", elapsed)
+
+	// 帧只写一次：fake 收到的 control_request 恰好一条 interrupt。
+	var controlRequests []string
+	collectUntil := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(collectUntil) {
+		select {
+		case line := <-got:
+			if strings.Contains(line, `"type":"control_request"`) {
+				controlRequests = append(controlRequests, line)
+			}
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	require.Len(t, controlRequests, 1, "Interrupt 应恰好写一帧 control_request")
+	assert.Contains(t, controlRequests[0], `"subtype":"interrupt"`)
+}
+
+// TestSession_StopTask_PendingAckIsBounded 钉死决策 2 的同款修复：StopTask 的 ack
+// 等待同样有界,CLI 不回执时返回 ErrInterruptPending（不无界挂死）。
+func TestSession_StopTask_PendingAckIsBounded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := make(chan string, 8)
+	c := New(WithBinary("fake"), pipeSpawner(t, fakeInterruptNoAck(got)))
+	sess, err := c.OpenSession(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close(context.Background()) }()
+
+	start := time.Now()
+	err = sess.StopTask(ctx, "b0n82mqaj")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInterruptPending), "StopTask 超时应同样返回 ErrInterruptPending,got: %v", err)
+	assert.Less(t, elapsed, 1500*time.Millisecond, "StopTask 应在 interruptAckBound 内返回,got %v", elapsed)
 }
 
 // TestSession_Interrupt 验证 control_request{interrupt} 路径：


### PR DESCRIPTION
## Turn 中断安全：跨轮 abort race / 无界 interrupt / 带外中断后的会话状态归属

闭合 `docs/specs/2026-08-07-autonomous-turn-resilience.md` 落库后的三条残留风险（spec：`docs/specs/2026-08-07-turn-abort-safety.md`，已随本 PR 提交）。

### 三个问题 → 三个决策

1. **跨轮 abort race（Aborter 无轮身份）** —— `Aborter.Abort` 从 `Abort(ctx, sessionID) error` 迁移为 `Abort(ctx, sessionID, turnToken uint64) (AbortOutcome, error)`：`0` = 当前活跃轮（用户点停止语义不变），非 0 = 仅当该轮仍当前才中断、否则 stale no-op。token 由各 runtime 按轮递增并随 `RunResult` / `AutonomousTurn` / `SubagentActivity` 暴露；`failAutonomousTurnPersist` 在落库失败时捕获失败轮的 token 异步携带（`autonomous_turn.go:92,285`），迟到中断绝不波及之后新起的轮。波及 6 个 runtime + mock + `remote/wire`（`AbortParams.TurnToken` + 新 `AbortResult.TurnKind`）+ daemon handler。
2. **无界 interrupt ctx（`pkg/claudecode/session.go:769` 只等 ctx.Done/readerDone/回执）** —— `Session.Interrupt` / `StopTask` 的 ack 等待加 `interruptAckBound = 500ms` 有界化，超时返回独立哨兵错误 `ErrInterruptPending`；`claudecode.Runtime.Abort` 把它视为「中断已下发、ack 异步到」→ 返回 nil、**不** Close 不 evict（只有真错误保留 `runtime.go:248-252` 的 Close+evict 兜底）。修复前不回应中断的 CLI 会把 goroutine 挂到子进程死；直接加 deadline 会被升级成杀活子进程。
3. **带外中断后会话状态无人 reconcile** —— `Abort` 返回被中断轮类型；`reconcileOrphanStop` 按类型分流：中断的是 subagent 活动轮 → 自己把 running/waiting reconcile 回 idle 并持久化（抽 `reconcileSessionToIdle` 复用遗孤路径）；自主轮仍留给 `driveAutonomousTurn` 收尾；`ErrNoActiveTurn` 遗孤路径不变。一次点停止即收干净。

### 验证

- **V2 holds（真实 CLI 双路径）**：真实 claude 2.1.224 idle ack 320ms（无 turn 探测）+ 真实 turn 流式 busy ack 663µs（消耗型，用户授权），均远低于 500ms；多次有界中断后子进程存活、真实 turn 被中断后正常收尾。`ErrInterruptPending` pending 路径由单元测试钉死（健康真实 CLI 每次亚秒回 ack，无法触发「不回应」）。证据：`e2e/scratch/2026-08-07-turn-abort-safety/report.md`。
- **V1 / V3**：由单元测试 + 两轴 review 覆盖（spec testing decisions 判给单元覆盖；跨轮交错 / 真实 subagent 活动轮编排无法稳定触发）。

### 已知说明（请审）

- V1 的 spec 测试表写的是 chat_svc 层「模拟『drain 后新轮已起』的单一组合测试」，实际实现为**两个独立测试**拼出行为链：`TestDriveAutonomousTurn_PersistFailure_FlipsErrorEmitsAndInterrupts` 断言异步 abort 携带失败轮 `at.TurnToken`（`Tokens()=={7}`）+ `TestRuntime_Abort_TurnToken` stale case 断言轮已切换时 abort(旧 token) 不中断新轮（`interruptCalls==0`）。逻辑闭合、无行为缺口，但组合测试未按字面落地，欢迎 review 补强。
- `StopBackgroundTask` 对 `ErrInterruptPending` 返 `ChatStopInternal`（spec 决策 2 只要求不杀子进程，未规定 UI 形态）——保持现状，code 轴已评估。
- daemon PiAgent abort 分支返回零 `TurnKind`（Pi 只有用户轮，与 `User` 可观察一致）。
- code 轴 3 条 finding 均已评估：F2（remote daemon 不消费 `SubagentActivity`）为既有问题、不在本分支范围；F3 理论性 kind 窗口不可复现（Fix Discipline 记录未补）。

### 提交（7）

`2363ff71` docs spec · `4e2c06ad` ✨ Aborter token+轮类型 · `bb5b1a5c` 🐛 interrupt ack 有界化 · `fda982b4` 🐛 中断 subagent 活动轮 reconcile · `c02c7820`/`3c071fb5` ✅ 测试接缝补强 · `01a10bab` 🐛 rebase 适配 origin 新增测试签名

已在 `origin/main`（含 #27 账号中继 peer 路由）上 rebase 并通过 `make test-backend`（119 ok）。
