### PR TITLE
✨ 会话文件预览：右侧可调宽预览面板（Markdown 三档 + 代码/文本 Monaco 只读 + 图片 + Git/变动直接对比）

### DIFF
--- a/docs/specs/2026-08-07-session-file-preview.md
+++ b/docs/specs/2026-08-07-session-file-preview.md
@@ -4,7 +4,7 @@
 > Owner: chat experience / frontend + workspace backend
 > Last updated: 2026-08-07
 
-**Objective:** 在会话「文件」面板的三个模式（变动 / 目录 / Git）为 markdown、代码 / 文本与图片文件提供**应用内预览**：点击文件行的「预览」按钮，在右侧一个**可拖拽调宽**的预览面板里渲染内容——markdown 有三档视图（渲染 / 文本 / 双栏），代码 / 文本走 **Monaco 只读**并可切「对比」（工作区 vs git HEAD），图片走 `<img>` 渲染；读取是会话级、带 cwd 边界、本机与远端（agentred）行为一致；本会话轮次结束时自动刷新已打开的文件；面板入场是克制的右滑动画（design.md §8）。
+**Objective:** 在会话「文件」面板的三个模式（变动 / 目录 / Git）为 markdown、代码 / 文本与图片文件提供**应用内预览**：点击文件行的「预览」按钮，在右侧一个**可拖拽调宽**的预览面板里渲染内容——markdown 有三档视图（渲染 / 文本 / 双栏），代码 / 文本走 **Monaco 只读**（从 Git / 变动模式打开时直接显示与 git HEAD 的对比），图片走 `<img>` 渲染；读取是会话级、带 cwd 边界、本机与远端（agentred）行为一致；本会话轮次结束时自动刷新已打开的文件；面板入场是克制的右滑动画（design.md §8）。
 
 > 本规格建立在 [`2026-08-07-session-files-three-modes.md`](2026-08-07-session-files-three-modes.md) 之上（其「目录 / Git」两模式与 `workspace_fs_svc` 会话路由是本轮的前置）。该轮已合并进 main（`742cd705` #29），前置满足，本轮可实施。
 
@@ -14,7 +14,7 @@
 2. **路径永不以前端绝对路径入参。** 预览读取一律会话级：前端只传 `sessionID` + 相对会话 cwd 的 `relPath`，后端解析并做 cwd 边界拦截（复用 `ErrPathRefused`）；任何越出 cwd 的解析结果都不返回内容。
 3. **本机 / 远端同一语义。** `deviceID == 0` 本机执行，`deviceID != 0` 经租约走新增 `workspacefs.*` RPC；远端 agentred 不认识方法族时给出可区分的「daemon 过旧」态（复用 `WorkspaceFsDaemonOutdated`）。
 4. **文本与图片有界传输、其余二进制不传内容。** 文本 > 1 MiB、图片 > 10 MiB 判「过大」；文本判二进制（首块含 NUL 且非图片）不返回正文。图片是唯一允许传输的二进制——按扩展名 allowlist 判定、以 base64 + MIME 返回（SVG 亦经 `<img>` 渲染，img 上下文不执行脚本）。
-5. **对比只读、只对比当前文件、以 git HEAD 为基准。** 对比档经只读 git 子进程取 HEAD 版本，不写 git 状态、不改文件；非 git 仓库 / 文件无 HEAD 版本分别给明确态。
+5. **对比只读、只对比当前文件、以 git HEAD 为基准，且只在从 Git / 变动模式打开代码 / 文本时直接展示。** 对比经只读 git 子进程取 HEAD 版本，不写 git 状态、不改文件；非 git 仓库 / 文件无 HEAD 版本分别给明确态。
 6. **新增 UI 文案全部走 i18n**，`zh-CN` 与 `en` 双语言，`src/__tests__/i18n.test.ts` 守卫；不硬编码中文。
 7. **Monaco 本地打包、只读、懒加载**，不引 CDN loader（桌面端离线 + `//go:embed`，`@monaco-editor/react` 的默认 jsdelivr loader 不可用）。
 8. **动画克制且 reduced-motion 安全**：遵循 `docs/design.md` §8/§10——微交互 150ms `ease-out`、面板入场 200ms 纯右滑（无淡入）、用 `tw-animate-css` / Radix `data-state`、不引 Framer Motion，**每个动画都带 `motion-reduce:`（或 `motion-safe:`）修饰**。
@@ -49,7 +49,7 @@
 | 6 | **Markdown 复用 `MarkdownText`**（`markdown-text.tsx`：`remark-gfm` + `rehype-highlight` + URL 白名单 + 代码块），不新起渲染栈 | 渲染能力已存在且经过消息流长期验证。拒绝再引一套 markdown 渲染器——重复且易出现渲染差异 |
 | 7 | **markdown 三档视图：渲染 / 文本 / 双栏**（一条分段控件）；文本档与双栏的源码侧走 Monaco 只读路径；markdown 不提供对比档 | 用户裁决（2026-08-07）：markdown 的文本与渲染**都展示出来**（双栏并排），并保留单档切换；对比只给代码 / 文本。拒绝只做切换（无法并排对照）、拒绝双栏用两个普通 `<pre>`（与代码渲染路径不一致）、拒绝给 markdown 加 git 对比（已有双栏对照，diff 价值低） |
 | 8 | **Monaco 本地打包、只读、动态 import 懒加载，不引 CDN loader** | 桌面端离线 + `//go:embed` 决定；`@monaco-editor/react` 默认从 jsdelivr 拉取 Monaco，不可用。集成细节（裸 `monaco-editor` + Vite `?worker` vs `@monaco-editor/react` + `loader.config` 指向本地实例；diff editor 复用同一 Monaco 实例）由计划阶段 spike 定 |
-| 9 | **对比档（仅代码 / 文本）= Monaco diff editor，左 HEAD 版本 / 右工作区**，只对比当前这一个文件；未跟踪文件左列为空（全部新增）；非 git 仓库 → 明确空态 | 用户裁决（2026-08-07，选项 A）。three-modes 已具备只读 git 能力（`git status` / `git diff`），新增一个只读「按 ref 读文件」（`git show HEAD:<path>`）即可；Monaco diff editor 现成。拒绝会话内快照对比（要每轮存文件快照，重得多）、拒绝两文件对比（需文件选择器 UI，与本轮单文件预览心智不符） |
+| 9 | **代码 / 文本无「对比」档位；从 Git / 变动模式打开代码 / 文本时直接显示对比**（Monaco diff editor，左 HEAD 版本 / 右工作区），目录模式打开只显示内容；未跟踪文件左列为空（全部新增）；非 git 仓库 → 明确空态 | 用户裁决（2026-08-07 二次确认）：去掉对比档，首视图由入口模式决定——目录打开=内容、Git / 变动打开=diff；markdown 从任何模式打开都是内容三档，不做对比。three-modes 已具备只读 git 能力，`git show HEAD:<path>` + Monaco diff editor 现成。拒绝会话内快照对比（要每轮存文件快照，重得多）、拒绝两文件对比（需文件选择器 UI，与本轮单文件预览心智不符）、拒绝在面板内留手动「内容 / 对比」切换（模式已表达意图） |
 | 10 | **图片按扩展名 allowlist 判定并渲染**（png / jpg / jpeg / gif / webp / avif / bmp / ico / svg），SVG 经 `<img>` 渲染 | 图片是本轮唯一的二进制例外。拒绝按 content-type 探测判定（扩展名即可、与前端入口 allowlist 一致）；SVG 若当 HTML / React 渲染会执行脚本，`<img>` 上下文天然不执行，安全 |
 | 11 | **预览随本会话轮次结束自动重读刷新**（`useSessionStatus(sessionId).doneTick` 变化时重取）；打开时总是重新读取 | 用户明确要求「文件变动也要更新」；与目录 / Git 模式的自动重拉同一机制（three-modes 决策 13）。拒绝文件系统 watcher / 轮询——过度，且轮次结束已覆盖绝大多数「agent 改了文件」的场景 |
 | 12 | **选中的预览文件、视图档位按会话存储**；切换会话关闭面板、清空选择、档位回默认；面板可拖拽调宽、独立 persistenceKey、带关闭按钮 | 复用 `ResizableSidebar`（`chat-context-sidebar/index.tsx` 同款，edge="left" 可拖拽 + localStorage 记忆）。拒绝跨会话共享预览位置——换会话后文件上下文已无意义 |
@@ -62,6 +62,7 @@
 - 「变动」模式的路径可能来自工具调用的绝对路径：**只有解析后落在会话 cwd 内的文件行才出现预览按钮**；越出 cwd 的不提供预览。「目录 / Git」模式的路径本就相对 cwd，直接可用。
 - 按钮是行右侧与「用系统应用打开」（`ExternalLink`）**并列**的独立图标按钮（`Eye` 图标，与打开的 external-link 明显区分），带 `aria-label`；点击它打开或切换到右侧预览面板并选中该文件，当前被预览文件的按钮高亮。点击不触发行点击既有行为。
 - 按钮出现条件不依赖「本机 / 远端」：远端会话同样出现（内容经 RPC 读取）。
+- **首视图由入口模式决定**：目录模式打开 → 内容（markdown 三档 / 代码文本文本档 / 图片）；Git / 变动模式打开 → 代码 / 文本直接显示与 HEAD 的对比（diff），markdown / 图片仍显示内容。打开另一模式的行会按新模式重设首视图；面板内无「内容 / 对比」手动切换（决策 9）。
 - 无 cwd（自由会话 / 远端未配路径）时，文件面板本就出对应空态，无文件行可点，故预览按钮随行消失。
 
 ## 视图档位（按文件类型）
@@ -71,14 +72,14 @@
 | 文件类型 | 档位 | 默认 |
 |---|---|---|
 | markdown（`.md` / `.markdown`） | 渲染 · 文本 · 双栏 | 渲染 |
-| 代码 / 文本 | 文本 · 对比 | 文本 |
+| 代码 / 文本 | （无分段控件）目录打开=内容、Git / 变动打开=对比 | 由入口模式决定 |
 | 图片 | （无分段控件，只有图片） | — |
 
 - **渲染**：`MarkdownText`（GFM + 高亮 + URL 白名单），与聊天消息外观一致。
 - **文本**：原始内容，Monaco 只读（markdown 源码无 GFM 渲染；代码 / 文本带语言高亮，未知扩展名纯文本）。
 - **双栏**（仅 markdown）：左文本（Monaco 只读源码）+ 右渲染（GFM），两栏各自独立滚动，中间分隔线。
-- **对比**（仅代码 / 文本）：Monaco diff editor（见下节）。markdown 不提供对比档——它已有「双栏」（源码 + 渲染效果）这种对照，git diff 对 markdown 只是给「文本」档加高亮底色，价值低。
-- 档位是面板状态：切文件保留，关面板 / 切会话回到默认档。
+- **对比**（仅代码 / 文本，且仅当从 Git / 变动模式打开时）：Monaco diff editor（见下节）；目录模式打开不显示。markdown 不提供对比——它已有「双栏」（源码 + 渲染效果）这种对照，git diff 对 markdown 只是给「文本」档加高亮底色，价值低。
+- 档位（markdown 三档）是面板状态：切文件保留，关面板 / 切会话回到默认档；代码 / 文本的首视图由入口模式决定，无档位可切。
 
 ## 内容读取（后端契约）
 
@@ -102,13 +103,13 @@
 - **渲染档**：`MarkdownText`（GFM 表格 / 删除线 / 自动链接、代码块语法高亮、URL 白名单安全）。
 - **文本档**：Monaco 只读（`readOnly`），markdown 源码 / 代码 / 文本，已知语言语法高亮、未知按纯文本。
 - **双栏档**：左 = 文本档（Monaco 只读源码），右 = 渲染档（GFM），两栏独立滚动。
-- **对比档**（仅代码 / 文本）：Monaco **diff editor**（`monaco.editor.createDiffEditor`，只读），左 = HEAD 版本、右 = 工作区，增删行底色区分；未跟踪文件左列为空（全部新增）；只对比当前这一个文件。头部条显示「对比 · HEAD → 工作区」与增删图例。
+- **对比**（仅代码 / 文本，从 Git / 变动模式打开时）：Monaco **diff editor**（`monaco.editor.createDiffEditor`，只读），左 = HEAD 版本、右 = 工作区，增删行底色区分；未跟踪文件左列为空（全部新增）；只对比当前这一个文件。顶部条显示「对比 · HEAD → 工作区」与增删图例。目录模式打开不显示对比。
 - **图片**：`<img src="data:<contentType>;base64,…">` 渲染，棋盘格底衬托透明图（png），居中、等比缩放至面板宽，超长超宽可滚动；SVG 同样经 `<img>`（img 上下文不执行脚本，防 XSS）。
 - 面板正文区域按内容类型与档位渲染，内容更新（切换文件 / 轮次刷新 / 切档位）时重渲染。
 
 ## 刷新（文件变动更新）
 
-- 打开文件、或切换选中文件时，总是重新读取（不读缓存）。
+- 打开文件、或切换选中文件时，总是重新读取（不读缓存）。Git / 变动模式打开的文件重读后重算对比（工作区变化反映到 diff）。
 - **本会话轮次结束**（`doneTick` 自增：done / error / aborted / closed / steer_consumed）时，若面板仍打开且指向某文件，自动重新读取并刷新渲染（刷新后正文淡入 150ms）。刷新时机与目录 / Git 模式一致；流式进行中不逐 chunk 刷新。
 - 轮次结束重读发现文件已被删除 / 不可读 → 面板进入对应错误态，不保留旧内容。
 
@@ -129,14 +130,14 @@
 - **远端离线**（`WorkspaceFsDeviceOffline`）。
 - **远端 agentred 过旧**（`WorkspaceFsDaemonOutdated`）——「请升级 daemon」。
 - **二进制 / 超大**（标志）——「该文件无法预览（二进制 / 过大）」，文本与图片各自的阈值在提示中说明。
-- **对比 · 非 git 仓库**——「没有可对比的 git 基准」空态。
+- **对比 · 非 git 仓库**（从 Git / 变动模式打开代码 / 文本时）——「没有可对比的 git 基准」空态。
 - 错误态提供「重试」动作；加载 / 空态 / 错误文案复用 three-modes 合并后目录与 Git 模式共用的 `panel-feedback.tsx`（`PanelSkeleton` / `PanelNotice` / `errorText`），不另起一套。
 
 ## 状态与布局
 
 - 预览面板是 `chat-panel` 主区 flex 行的**最右一栏**（`[transcript + composer] [ChatContextSidebar] [FilePreviewPanel]`）；仅在选中了可预览文件时渲染，关闭后释放宽度。
 - **可拖拽调宽**（复用 `ResizableSidebar`，`edge="left"` 手柄在左边缘——4px 命中区 + 1px 视觉条），独立 `persistenceKey`，默认宽度约 440px（mockup 已按 markdown 表格 / 代码块 / 图片 / 双栏 / 对比的可读性定），宽度记忆不随会话切换丢失。
-- 面板头部显示：文件类型图标、文件名（含所在目录前缀）、按文件类型的视图分段（markdown 3 档 / 代码文本 2 档 / 图片无）、关闭按钮；`aria-label` 表达面板用途、档位与关闭动作。
+- 面板头部显示：文件类型图标、文件名（含所在目录前缀）、按文件类型的视图分段（markdown 3 档 / 代码文本无分段 / 图片无）、关闭按钮；`aria-label` 表达面板用途、档位与关闭动作。
 - 选中的预览文件与视图档位按会话存储；切换会话时关闭面板、清空选择、档位回默认。
 
 ## 安全、隐私、兼容性与可访问性
@@ -154,7 +155,7 @@
 - **Monaco 编辑 / 保存**：本轮是只读预览，无写回能力。
 - **非图片富媒体预览**：音频、视频、PDF 等。
 - **对比的基线选择**：对比档固定以 HEAD 为基准，不做分支 / 基线选择器（Git 模式已有基线选择，本轮不复用）。
-- **markdown 的 git 对比**：markdown 只有渲染 / 文本 / 双栏三档，不提供对比档（见决策 7）。
+- **markdown 的 git 对比**：markdown 只有渲染 / 文本 / 双栏三档，从任何模式打开都不显示对比（见决策 7 / 9）。
 - **会话内快照对比**（当前 vs 会话开始 / 上一轮）：需要每轮存文件快照，本轮不做。
 - **文件内容实时轮询 / 文件系统 watcher**：仅轮次结束刷新。
 - **allowlist 之外的文件**（音视频、压缩包、PDF、可执行文件等）：不出预览按钮；后续再放宽。
@@ -170,9 +171,9 @@
 | wire 双向翻译 + daemon handler | `workspacefs.readFile` / `workspacefs.gitFileContent` 方法名 / 请求响应类型、sentinel ↔ JSON-RPC 码、未鉴权被拒、端到端真目录一跳 | `internal/pkg/workspacefs/wire/*_test.go`、`internal/daemon/workspacefs/*_test.go`、`internal/daemon/integration_test.go`（three-modes） |
 | `workspace_fs_svc` 路由 | `deviceID=0` 读真 tmpdir（远端 mock 零 EXPECT）、`deviceID≠0` 发对应 RPC、错误映射（越界 / daemon 过旧 / 离线 / notARepo） | `internal/service/workspace_fs_svc/*_test.go`（three-modes，sqlmock + mockgen，不连库） |
 | 前端预览按钮出现条件 | 三模式 markdown / 代码 / 文本 / 图片行出按钮、二进制扩展名不出、cwd 外绝对路径不出、远端行出按钮 | `files-view.test.tsx` / `directory-view` / `git-view` 既有测试扩展 |
-| 面板打开 / 切换 / 关闭 / 档位 | 点按钮打开并选中、点另一行切换内容、关闭释放宽度、切换会话清空、档位按文件类型（markdown 3 档 / 代码 2 档 / 图片无）、切文件保留档位 / 关面板回默认 | 无（新增，`FilePreviewPanel` 组件测试） |
+| 面板打开 / 切换 / 关闭 / 档位 | 点按钮打开并选中、点另一行切换内容、关闭释放宽度、切换会话清空、档位按文件类型（markdown 3 档 / 代码文本无分段 / 图片无）、切文件保留档位 / 关面板回默认、首视图由入口模式决定（目录→内容、Git / 变动→diff） | 无（新增，`FilePreviewPanel` 组件测试） |
 | 渲染分流 | `.md` 走 MarkdownText（GFM 表格可渲染）、文本档显示原始源码、双栏左右并存、代码走 Monaco（只读、有语言）、未知扩展名纯文本、图片 `<img>` 用 data URL + alt | `markdown-text.test.tsx` 既有；Monaco 用 mock（happy-dom 不跑真实 Monaco，计划阶段定 mock 形态） |
-| 对比档（仅代码 / 文本） | 切对比档调 `GitFileContent`、diff 左右（HEAD / 工作区）、未跟踪空左列、notARepo 空态、markdown 行不出现对比档 | Monaco mock + `git_state_test.go` 范式 |
+| 对比（入口模式决定） | 从 Git / 变动模式打开代码 / 文本 → 调 `GitFileContent` 显示 diff（HEAD / 工作区）、未跟踪空左列、notARepo 空态；目录模式打开 → 只显示内容不调 `GitFileContent`；markdown 任何模式都不显示对比 | Monaco mock + `git_state_test.go` 范式 |
 | doneTick 刷新 | 打开时首次读取、`doneTick` 变化重读并替换内容、切会话不串 | 目录模式 `doneTick` 自动重拉的既有测试形态 |
 | 错误态 | binary / tooLarge / 越界 / 离线 / daemon 过旧 / notARepo 各文案与重试 | `workspace_fs_svc` 错误映射测试 + 目录 / Git 模式空态测试 |
 | 动画 reduced-motion | 每个动画带 `motion-reduce:` 修饰（审查 + 运行期观察）；面板入场为纯右滑无淡入 | design.md §10 的既有约定（lint 层面可查 `motion-reduce` 缺失由 review 覆盖） |
@@ -182,4 +183,4 @@
 
 ## Open questions
 
-<!-- 无。设计已获用户确认（2026-08-07）：决策 1=A 右侧面板、决策 2=A 独立预览按钮、决策 3=A 本轮引入 Monaco + 图片 + 对比（代码/文本）、决策 4=A 本机+远端、决策 5=A 建立在 three-modes 合并后、对比基准=A git HEAD、动画=面板入场仅右滑无淡入、markdown=三档（渲染/文本/双栏，无对比）、面板可拖拽调宽。 -->
+<!-- 无。设计已获用户确认（2026-08-07）：决策 1=A 右侧面板、决策 2=A 独立预览按钮、决策 3=A 本轮引入 Monaco + 图片 + 对比（代码/文本）、决策 4=A 本机+远端、决策 5=A 建立在 three-modes 合并后、对比基准=A git HEAD、动画=面板入场仅右滑无淡入、markdown=三档（渲染/文本/双栏，无对比）、面板可拖拽调宽。追加（2026-08-07 二次确认）：去掉对比档——代码/文本首视图由入口模式决定（目录→内容、Git/变动→diff），markdown 任何模式都是内容三档，面板内无手动内容/对比切换。 -->

--- a/docs/specs/2026-08-07-session-file-preview.md
+++ b/docs/specs/2026-08-07-session-file-preview.md
@@ -1,0 +1,185 @@
+# 会话文件预览：右侧预览面板（Markdown + Monaco 只读 + 图片 + Git 对比）
+
+> Status: Draft
+> Owner: chat experience / frontend + workspace backend
+> Last updated: 2026-08-07
+
+**Objective:** 在会话「文件」面板的三个模式（变动 / 目录 / Git）为 markdown、代码 / 文本与图片文件提供**应用内预览**：点击文件行的「预览」按钮，在右侧一个**可拖拽调宽**的预览面板里渲染内容——markdown 有三档视图（渲染 / 文本 / 双栏），代码 / 文本走 **Monaco 只读**并可切「对比」（工作区 vs git HEAD），图片走 `<img>` 渲染；读取是会话级、带 cwd 边界、本机与远端（agentred）行为一致；本会话轮次结束时自动刷新已打开的文件；面板入场是克制的右滑动画（design.md §8）。
+
+> 本规格建立在 [`2026-08-07-session-files-three-modes.md`](2026-08-07-session-files-three-modes.md) 之上（其「目录 / Git」两模式与 `workspace_fs_svc` 会话路由是本轮的前置）。该轮已合并进 main（`742cd705` #29），前置满足，本轮可实施。
+
+**Hard invariants:**
+
+1. **行点击行为零回归：** 「变动」模式行点击跳转对应轮次、「目录」模式目录行点击展开 / 收起、「Git」模式行点击（本地）用系统应用打开——全部保持现状。「预览」是**并列的独立按钮**，点击它不触发行点击、也不被行点击吞掉。
+2. **路径永不以前端绝对路径入参。** 预览读取一律会话级：前端只传 `sessionID` + 相对会话 cwd 的 `relPath`，后端解析并做 cwd 边界拦截（复用 `ErrPathRefused`）；任何越出 cwd 的解析结果都不返回内容。
+3. **本机 / 远端同一语义。** `deviceID == 0` 本机执行，`deviceID != 0` 经租约走新增 `workspacefs.*` RPC；远端 agentred 不认识方法族时给出可区分的「daemon 过旧」态（复用 `WorkspaceFsDaemonOutdated`）。
+4. **文本与图片有界传输、其余二进制不传内容。** 文本 > 1 MiB、图片 > 10 MiB 判「过大」；文本判二进制（首块含 NUL 且非图片）不返回正文。图片是唯一允许传输的二进制——按扩展名 allowlist 判定、以 base64 + MIME 返回（SVG 亦经 `<img>` 渲染，img 上下文不执行脚本）。
+5. **对比只读、只对比当前文件、以 git HEAD 为基准。** 对比档经只读 git 子进程取 HEAD 版本，不写 git 状态、不改文件；非 git 仓库 / 文件无 HEAD 版本分别给明确态。
+6. **新增 UI 文案全部走 i18n**，`zh-CN` 与 `en` 双语言，`src/__tests__/i18n.test.ts` 守卫；不硬编码中文。
+7. **Monaco 本地打包、只读、懒加载**，不引 CDN loader（桌面端离线 + `//go:embed`，`@monaco-editor/react` 的默认 jsdelivr loader 不可用）。
+8. **动画克制且 reduced-motion 安全**：遵循 `docs/design.md` §8/§10——微交互 150ms `ease-out`、面板入场 200ms 纯右滑（无淡入）、用 `tw-animate-css` / Radix `data-state`、不引 Framer Motion，**每个动画都带 `motion-reduce:`（或 `motion-safe:`）修饰**。
+
+## Problem
+
+1. **会话文件面板无法在应用内查看文件内容。** 「变动」模式行只有「跳转轮次」与「用系统应用打开」（`files-view.tsx` 的 `ExternalLink` 按钮）；用户想快速确认 agent 改动 / 引用的 markdown、代码、图片内容，只能跳到外部编辑器，上下文被切断。
+2. **后端缺「读文件内容」能力。** `workspace_fs_svc`（three-modes）只有列目录 / git 变动 / 分支清单，没有 session 级、带 cwd 边界的读内容方法（含按 git ref 读）；本机与远端（agentred）两侧都没有。
+3. **文件内容会随轮次推进而变化。** agent 每一轮可能改写同一文件；预览若不随轮次结束刷新，就会一直显示过期内容。用户明确要求「文件变动了也要更新」。
+4. **markdown 的「看效果」与「看源码」需要并存。** 渲染视图适合确认排版，但核对 agent 改了什么、复制原文时需要原始 markdown 源码；两者应能并排或一键切换。
+5. **用户想知道「这个文件改了什么」。** 单看当前内容回答不了「agent 的改动 vs 提交基线」；需要把工作区文件与 git HEAD 版本并排对比（Monaco diff editor 天然支持）。
+6. **预览需要动画反馈，但必须克制。** 面板开合、文件切换如果没有过渡会显得生硬；过度动画又违背本项目「motion restrained」原则（design.md §8）。用户明确要「面板入场右侧滑入、不需要淡入」。
+
+## Actors and user stories
+
+1. 作为**聊天用户**，我想在应用内预览 agent 提到 / 改动的 markdown 文件（GFM 渲染，且可在渲染 / 文本 / 双栏间切换），不必跳出到系统编辑器。
+2. 作为**聊天用户**，我想只读预览代码 / 文本文件（语法高亮），并对比它与 git HEAD 的差异（工作区未提交改动）。
+3. 作为**聊天用户**，我想直接预览 agent 生成 / 改动的图片（含 SVG），确认产物。
+4. 作为**远端会话用户**，我想在 agentred 远端会话里同样能预览与对比文件，行为与本机一致。
+5. 作为**用户**，我不希望预览显示过期内容：agent 一轮跑完改了文件，预览应自动刷新。
+6. 作为**对动效敏感的用户**，我希望预览面板的动画克制，并在系统开启「减弱动态效果」时停用。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | **右侧独立可调宽预览面板**，位于文件侧栏右侧（最右一栏），打开占位、关闭释放 | 用户裁决（2026-08-07）。拒绝模态弹窗——盖住对话、无法边看对话边切换文件、后续 Monaco 塞进模态很别扭；拒绝侧栏内就地展开——默认 240px 太窄，markdown 表格 / 代码块几乎没法看 |
+| 2 | **「预览」是各文件行并列的独立图标按钮**，不动行点击 | 行点击语义各模式不同且部分是硬不变量（变动=跳转轮次、目录=展开、Git=打开）。拒绝整行点击=预览——会破坏既有行为 |
+| 3 | **本轮同时支持 markdown（GFM）+ 代码 / 文本（Monaco 只读）+ 图片（`<img>`）+ 对比（Monaco diff vs HEAD）** | 用户裁决（2026-08-07）：「本轮就引入 Monaco」「图片也加一下预览」「还可以对比模式」。拒绝「本轮只做 markdown」 |
+| 4 | **内容读取按会话（`sessionID` + relPath）由后端解析 cwd，本机 / 远端路由复用 `workspace_fs_svc` 的 `SessionWorkspaceResolver`** | 沿用 three-modes 决策 2 的安全姿态：前端不持有 cwd 解析规则、路径不可被伪造。拒绝前端传绝对路径——把边界校验复制到前端且路径可注入 |
+| 5 | **二进制 / 超大 / 图片类型用返回的标志与字段表达，不新增错误码** | 与 git changes 的 `ChangeView.Binary` 同构；图片单独用 MIME + base64 承载。拒绝为这些常态另开错误码段（错误码只留给真正不可恢复的异常） |
+| 6 | **Markdown 复用 `MarkdownText`**（`markdown-text.tsx`：`remark-gfm` + `rehype-highlight` + URL 白名单 + 代码块），不新起渲染栈 | 渲染能力已存在且经过消息流长期验证。拒绝再引一套 markdown 渲染器——重复且易出现渲染差异 |
+| 7 | **markdown 三档视图：渲染 / 文本 / 双栏**（一条分段控件）；文本档与双栏的源码侧走 Monaco 只读路径；markdown 不提供对比档 | 用户裁决（2026-08-07）：markdown 的文本与渲染**都展示出来**（双栏并排），并保留单档切换；对比只给代码 / 文本。拒绝只做切换（无法并排对照）、拒绝双栏用两个普通 `<pre>`（与代码渲染路径不一致）、拒绝给 markdown 加 git 对比（已有双栏对照，diff 价值低） |
+| 8 | **Monaco 本地打包、只读、动态 import 懒加载，不引 CDN loader** | 桌面端离线 + `//go:embed` 决定；`@monaco-editor/react` 默认从 jsdelivr 拉取 Monaco，不可用。集成细节（裸 `monaco-editor` + Vite `?worker` vs `@monaco-editor/react` + `loader.config` 指向本地实例；diff editor 复用同一 Monaco 实例）由计划阶段 spike 定 |
+| 9 | **对比档（仅代码 / 文本）= Monaco diff editor，左 HEAD 版本 / 右工作区**，只对比当前这一个文件；未跟踪文件左列为空（全部新增）；非 git 仓库 → 明确空态 | 用户裁决（2026-08-07，选项 A）。three-modes 已具备只读 git 能力（`git status` / `git diff`），新增一个只读「按 ref 读文件」（`git show HEAD:<path>`）即可；Monaco diff editor 现成。拒绝会话内快照对比（要每轮存文件快照，重得多）、拒绝两文件对比（需文件选择器 UI，与本轮单文件预览心智不符） |
+| 10 | **图片按扩展名 allowlist 判定并渲染**（png / jpg / jpeg / gif / webp / avif / bmp / ico / svg），SVG 经 `<img>` 渲染 | 图片是本轮唯一的二进制例外。拒绝按 content-type 探测判定（扩展名即可、与前端入口 allowlist 一致）；SVG 若当 HTML / React 渲染会执行脚本，`<img>` 上下文天然不执行，安全 |
+| 11 | **预览随本会话轮次结束自动重读刷新**（`useSessionStatus(sessionId).doneTick` 变化时重取）；打开时总是重新读取 | 用户明确要求「文件变动也要更新」；与目录 / Git 模式的自动重拉同一机制（three-modes 决策 13）。拒绝文件系统 watcher / 轮询——过度，且轮次结束已覆盖绝大多数「agent 改了文件」的场景 |
+| 12 | **选中的预览文件、视图档位按会话存储**；切换会话关闭面板、清空选择、档位回默认；面板可拖拽调宽、独立 persistenceKey、带关闭按钮 | 复用 `ResizableSidebar`（`chat-context-sidebar/index.tsx` 同款，edge="left" 可拖拽 + localStorage 记忆）。拒绝跨会话共享预览位置——换会话后文件上下文已无意义 |
+| 13 | **错误态复用 `workspace_fs_svc` 既有错误码映射**（`NoCwd` / `PathRefused` / `ReadFailed` / `DeviceOffline` / `DaemonOutdated`，20800 段）+ binary / tooLarge 标志 + 对比的 notARepo / 无 HEAD 空态 | 三模式已把错误翻译铺好，预览面板照搬即可，不重复实现。拒绝为预览另起一套错误翻译 |
+| 14 | **动画遵循 design.md §8**：面板开合 200ms `ease-out` **纯右滑（无淡入）**（`animate-in slide-in-from-right` + `motion-reduce:animate-none`）、正文切换 / 刷新淡入 150ms、按钮 hover 用 `transition-colors`，全部 CSS、不引 Framer Motion | 用户裁决（2026-08-07）：「面板入场右侧划入就行，不需要淡入」；design.md §8 定义 restrained motion 约定。拒绝淡入（用户明确否）、拒绝重动画 / Framer Motion |
+
+## 预览面板与入口
+
+- **「预览」按钮**出现在「变动 / 目录 / Git」三模式的文件行上：markdown 文件（`.md` / `.markdown`，不含 `.mdx`——MDX 含 JSX，GFM 渲染会碎）、**文本 / 代码 allowlist** 内扩展名的文件、**图片扩展名**（见「图片预览」）。其余（音视频、压缩包、PDF、可执行文件等）不出现预览按钮，行保持现状。
+- 「变动」模式的路径可能来自工具调用的绝对路径：**只有解析后落在会话 cwd 内的文件行才出现预览按钮**；越出 cwd 的不提供预览。「目录 / Git」模式的路径本就相对 cwd，直接可用。
+- 按钮是行右侧与「用系统应用打开」（`ExternalLink`）**并列**的独立图标按钮（`Eye` 图标，与打开的 external-link 明显区分），带 `aria-label`；点击它打开或切换到右侧预览面板并选中该文件，当前被预览文件的按钮高亮。点击不触发行点击既有行为。
+- 按钮出现条件不依赖「本机 / 远端」：远端会话同样出现（内容经 RPC 读取）。
+- 无 cwd（自由会话 / 远端未配路径）时，文件面板本就出对应空态，无文件行可点，故预览按钮随行消失。
+
+## 视图档位（按文件类型）
+
+面板头部一条分段控件，档位随文件类型变化：
+
+| 文件类型 | 档位 | 默认 |
+|---|---|---|
+| markdown（`.md` / `.markdown`） | 渲染 · 文本 · 双栏 | 渲染 |
+| 代码 / 文本 | 文本 · 对比 | 文本 |
+| 图片 | （无分段控件，只有图片） | — |
+
+- **渲染**：`MarkdownText`（GFM + 高亮 + URL 白名单），与聊天消息外观一致。
+- **文本**：原始内容，Monaco 只读（markdown 源码无 GFM 渲染；代码 / 文本带语言高亮，未知扩展名纯文本）。
+- **双栏**（仅 markdown）：左文本（Monaco 只读源码）+ 右渲染（GFM），两栏各自独立滚动，中间分隔线。
+- **对比**（仅代码 / 文本）：Monaco diff editor（见下节）。markdown 不提供对比档——它已有「双栏」（源码 + 渲染效果）这种对照，git diff 对 markdown 只是给「文本」档加高亮底色，价值低。
+- 档位是面板状态：切文件保留，关面板 / 切会话回到默认档。
+
+## 内容读取（后端契约）
+
+- 新增会话级方法：
+  - `ReadFile(ctx, sessionID, relPath)` → 工作区文件内容 `{ content, contentType, binary, tooLarge }`。
+  - `GitFileContent(ctx, sessionID, relPath)` → 同一文件在 **HEAD** 的版本（供对比档左列）；文件未跟踪 / 不在 HEAD → 返回空基线的标志，非 git 仓库 → `notARepo`。
+- 两者第一个入参都是 `sessionID`，不是路径（沿用 three-modes 决策 2）；路径只以相对 cwd 的 `relPath` 出现。
+- 后端沿既有 `SessionWorkspaceResolver` 解析 `{deviceID, cwd}`；`cwd` 为空 → `WorkspaceFsNoCwd`；`sessionID <= 0` → `InvalidParameter`。
+- `deviceID == 0`：在本机叶子包解析并读取；`deviceID != 0`：经 `remote_device_svc` 租约调新增 `workspacefs.readFile` / `workspacefs.gitFileContent` RPC（daemon 侧是同一份叶子实现）。
+- **边界**：`relPath` 在 cwd 内解析；越界（`..`、绝对路径、逃逸的符号链接）→ 复用 `ErrPathRefused`（→ `WorkspaceFsPathRefused`）。符号链接跟随解析后再校验仍落在 cwd 内，越界拒绝。git 读取按 cwd 在仓库内的前缀换算路径（three-modes 已处理 cwd 子目录的 git 路径语义）。
+- **文本**（markdown / 代码 / 文本）：返回 UTF-8 正文（`content`）。
+- **图片**：按扩展名 allowlist 判定，返回 base64 编码的 `content` + MIME `contentType`（png→`image/png`、svg→`image/svg+xml` 等）。这是唯一允许传输的二进制。
+- **其余二进制**（含 NUL 且非图片）→ `binary` 标志，不返回正文。
+- **超大**：文本 > 1 MiB、图片 > 10 MiB → `tooLarge` 标志，不返回正文（文本阈值与 git changes 的 `maxUntrackedTextSize` 一致；图片阈值单列，计划阶段可按实际照片大小微调）。
+- **对比**：`GitFileContent` 走只读 git 子进程（`git show HEAD:<path>` 之类）；文件不在 HEAD（未跟踪）→ 空基线（对比档左列为空、全部新增）；非 git 仓库 → `notARepo`；超出 cwd / 仓库边界 → `ErrPathRefused`。
+- **daemon 过旧**：远端返回 `-32601`（方法不存在）→ `WorkspaceFsDaemonOutdated`，与三模式同一个翻译路径。
+- 读取是纯读，不写本地库、不改任何文件、不改 git 状态；正文与对比内容不进日志。
+
+## 渲染与对比
+
+- **渲染档**：`MarkdownText`（GFM 表格 / 删除线 / 自动链接、代码块语法高亮、URL 白名单安全）。
+- **文本档**：Monaco 只读（`readOnly`），markdown 源码 / 代码 / 文本，已知语言语法高亮、未知按纯文本。
+- **双栏档**：左 = 文本档（Monaco 只读源码），右 = 渲染档（GFM），两栏独立滚动。
+- **对比档**（仅代码 / 文本）：Monaco **diff editor**（`monaco.editor.createDiffEditor`，只读），左 = HEAD 版本、右 = 工作区，增删行底色区分；未跟踪文件左列为空（全部新增）；只对比当前这一个文件。头部条显示「对比 · HEAD → 工作区」与增删图例。
+- **图片**：`<img src="data:<contentType>;base64,…">` 渲染，棋盘格底衬托透明图（png），居中、等比缩放至面板宽，超长超宽可滚动；SVG 同样经 `<img>`（img 上下文不执行脚本，防 XSS）。
+- 面板正文区域按内容类型与档位渲染，内容更新（切换文件 / 轮次刷新 / 切档位）时重渲染。
+
+## 刷新（文件变动更新）
+
+- 打开文件、或切换选中文件时，总是重新读取（不读缓存）。
+- **本会话轮次结束**（`doneTick` 自增：done / error / aborted / closed / steer_consumed）时，若面板仍打开且指向某文件，自动重新读取并刷新渲染（刷新后正文淡入 150ms）。刷新时机与目录 / Git 模式一致；流式进行中不逐 chunk 刷新。
+- 轮次结束重读发现文件已被删除 / 不可读 → 面板进入对应错误态，不保留旧内容。
+
+## 动画（design.md §8）
+
+- **面板开合**：打开时从右滑入（**纯 `translateX`，无淡入**，200ms `ease-out`，`animate-in slide-in-from-right`），关闭滑出；`motion-reduce:animate-none`。
+- **正文切换**：切换文件、轮次刷新、切档位后正文淡入（150ms）。
+- **按钮反馈**：预览 / 打开 / 关闭按钮 hover 用 `transition-colors duration-150`（既有点击反馈样式延续）。
+- 全部 CSS 动画（`tw-animate-css` + Radix `data-state`），不引 Framer Motion；**每个动画带 `motion-reduce:` / `motion-safe:` 修饰**（design.md §10 硬约定）。
+
+## 失败与恢复
+
+面板内各错误态（复用既有错误码 → 文案，i18n 双语）：
+
+- **路径越界**（`WorkspaceFsPathRefused`）——「路径超出会话工作目录」。
+- **无工作目录**（`WorkspaceFsNoCwd`）。
+- **读取失败**（`WorkspaceFsReadFailed`）。
+- **远端离线**（`WorkspaceFsDeviceOffline`）。
+- **远端 agentred 过旧**（`WorkspaceFsDaemonOutdated`）——「请升级 daemon」。
+- **二进制 / 超大**（标志）——「该文件无法预览（二进制 / 过大）」，文本与图片各自的阈值在提示中说明。
+- **对比 · 非 git 仓库**——「没有可对比的 git 基准」空态。
+- 错误态提供「重试」动作；加载 / 空态 / 错误文案复用 three-modes 合并后目录与 Git 模式共用的 `panel-feedback.tsx`（`PanelSkeleton` / `PanelNotice` / `errorText`），不另起一套。
+
+## 状态与布局
+
+- 预览面板是 `chat-panel` 主区 flex 行的**最右一栏**（`[transcript + composer] [ChatContextSidebar] [FilePreviewPanel]`）；仅在选中了可预览文件时渲染，关闭后释放宽度。
+- **可拖拽调宽**（复用 `ResizableSidebar`，`edge="left"` 手柄在左边缘——4px 命中区 + 1px 视觉条），独立 `persistenceKey`，默认宽度约 440px（mockup 已按 markdown 表格 / 代码块 / 图片 / 双栏 / 对比的可读性定），宽度记忆不随会话切换丢失。
+- 面板头部显示：文件类型图标、文件名（含所在目录前缀）、按文件类型的视图分段（markdown 3 档 / 代码文本 2 档 / 图片无）、关闭按钮；`aria-label` 表达面板用途、档位与关闭动作。
+- 选中的预览文件与视图档位按会话存储；切换会话时关闭面板、清空选择、档位回默认。
+
+## 安全、隐私、兼容性与可访问性
+
+- **路径入参安全**：前端永不传绝对路径；cwd 边界由后端强制执行（硬不变量 2）。会话 cwd 之外的任何文件都无法经本接口读到。
+- **内容不进日志**：读取的文件正文（含图片 base64）与对比内容遵循既有日志红线，不写入日志。
+- **SVG 防脚本**：SVG 一律经 `<img>` 渲染，不当作 HTML / React 节点注入，脚本不执行。
+- **无写路径**：本接口与对比都只读，无任何写文件 / 改 git 的能力。
+- **兼容性**：旧 agentred（无 `workspacefs.*` 方法族）→ `DaemonOutdated` 明确态，不影响其余功能；本机会话不受影响。
+- **可访问性**：预览 / 关闭 / 档位切换按钮与面板都有文本标签（不靠颜色）；错误态有文字；图片带 `alt`（文件名）；对比档增删有文字标签与图例（不靠颜色单表）；面板内容可随 Tab 聚焦进入；动画有 `motion-reduce:` 兜底。
+- **依赖体积**：Monaco 是重依赖，动态 import + 本地 worker 打包，不进初始包；作为本次新增依赖在 review 时确认其产物体积可接受。
+
+## Out of scope
+
+- **Monaco 编辑 / 保存**：本轮是只读预览，无写回能力。
+- **非图片富媒体预览**：音频、视频、PDF 等。
+- **对比的基线选择**：对比档固定以 HEAD 为基准，不做分支 / 基线选择器（Git 模式已有基线选择，本轮不复用）。
+- **markdown 的 git 对比**：markdown 只有渲染 / 文本 / 双栏三档，不提供对比档（见决策 7）。
+- **会话内快照对比**（当前 vs 会话开始 / 上一轮）：需要每轮存文件快照，本轮不做。
+- **文件内容实时轮询 / 文件系统 watcher**：仅轮次结束刷新。
+- **allowlist 之外的文件**（音视频、压缩包、PDF、可执行文件等）：不出预览按钮；后续再放宽。
+- **其他界面的预览**（项目页、会话外）：仅「文件」面板三模式。
+- **three-modes 合并之前**不实施（本规格的前置）。
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| 叶子包 `ReadFile`（本机侧） | 文本正常读、越界（`..` / 绝对路径 / 逃逸符号链接）拒绝、文本 NUL 判 binary、文本 >1MiB 判 tooLarge 不整读、图片扩展名 → base64 + MIME（含 svg）、图片 >10MiB 判 tooLarge、非文件 / 目录拒绝、cwd 为空 | `internal/pkg/workspacefs/*_test.go`（three-modes 的 git_changes 测试同构：真 tmpdir + 不连库） |
+| 叶子包 `GitFileContent`（本机侧） | HEAD 版本读取、未跟踪 → 空基线、非 git 仓库 → notARepo、cwd 子目录的路径换算、越界拒绝 | 同上 + `git_state_test.go` 的 `runGit` helper（three-modes） |
+| wire 双向翻译 + daemon handler | `workspacefs.readFile` / `workspacefs.gitFileContent` 方法名 / 请求响应类型、sentinel ↔ JSON-RPC 码、未鉴权被拒、端到端真目录一跳 | `internal/pkg/workspacefs/wire/*_test.go`、`internal/daemon/workspacefs/*_test.go`、`internal/daemon/integration_test.go`（three-modes） |
+| `workspace_fs_svc` 路由 | `deviceID=0` 读真 tmpdir（远端 mock 零 EXPECT）、`deviceID≠0` 发对应 RPC、错误映射（越界 / daemon 过旧 / 离线 / notARepo） | `internal/service/workspace_fs_svc/*_test.go`（three-modes，sqlmock + mockgen，不连库） |
+| 前端预览按钮出现条件 | 三模式 markdown / 代码 / 文本 / 图片行出按钮、二进制扩展名不出、cwd 外绝对路径不出、远端行出按钮 | `files-view.test.tsx` / `directory-view` / `git-view` 既有测试扩展 |
+| 面板打开 / 切换 / 关闭 / 档位 | 点按钮打开并选中、点另一行切换内容、关闭释放宽度、切换会话清空、档位按文件类型（markdown 3 档 / 代码 2 档 / 图片无）、切文件保留档位 / 关面板回默认 | 无（新增，`FilePreviewPanel` 组件测试） |
+| 渲染分流 | `.md` 走 MarkdownText（GFM 表格可渲染）、文本档显示原始源码、双栏左右并存、代码走 Monaco（只读、有语言）、未知扩展名纯文本、图片 `<img>` 用 data URL + alt | `markdown-text.test.tsx` 既有；Monaco 用 mock（happy-dom 不跑真实 Monaco，计划阶段定 mock 形态） |
+| 对比档（仅代码 / 文本） | 切对比档调 `GitFileContent`、diff 左右（HEAD / 工作区）、未跟踪空左列、notARepo 空态、markdown 行不出现对比档 | Monaco mock + `git_state_test.go` 范式 |
+| doneTick 刷新 | 打开时首次读取、`doneTick` 变化重读并替换内容、切会话不串 | 目录模式 `doneTick` 自动重拉的既有测试形态 |
+| 错误态 | binary / tooLarge / 越界 / 离线 / daemon 过旧 / notARepo 各文案与重试 | `workspace_fs_svc` 错误映射测试 + 目录 / Git 模式空态测试 |
+| 动画 reduced-motion | 每个动画带 `motion-reduce:` 修饰（审查 + 运行期观察）；面板入场为纯右滑无淡入 | design.md §10 的既有约定（lint 层面可查 `motion-reduce` 缺失由 review 覆盖） |
+| i18n key 覆盖 | 新增 key 双语言 | `src/__tests__/i18n.test.ts` |
+
+不可自动化部分：Monaco 真实语法高亮与 diff editor 的视觉效果、图片渲染的观感、动画节奏、面板拖拽手感、预览面板与三模式并存的整体布局，由运行时手动观察覆盖；`chat-panel` 的三栏接线不做单测（大型集成组件，同三模式既有约定）。
+
+## Open questions
+
+<!-- 无。设计已获用户确认（2026-08-07）：决策 1=A 右侧面板、决策 2=A 独立预览按钮、决策 3=A 本轮引入 Monaco + 图片 + 对比（代码/文本）、决策 4=A 本机+远端、决策 5=A 建立在 three-modes 合并后、对比基准=A git HEAD、动画=面板入场仅右滑无淡入、markdown=三档（渲染/文本/双栏，无对比）、面板可拖拽调宽。 -->

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "cmdk": "^1.1.1",
     "i18next": "^26.3.0",
     "lucide-react": "^0.400.0",
+    "monaco-editor": "^0.56.0",
     "pinyin-pro": "^3.28.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@19.2.6)
+      monaco-editor:
+        specifier: ^0.56.0
+        version: 0.56.0
       pinyin-pro:
         specifier: ^3.28.1
         version: 3.28.1
@@ -1641,6 +1644,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1908,6 +1914,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   electron-to-chromium@1.5.355:
     resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
@@ -2314,6 +2323,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -2450,6 +2464,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4435,6 +4452,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -4717,6 +4737,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.355: {}
 
@@ -5114,6 +5138,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@14.0.0: {}
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5463,6 +5489,11 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  monaco-editor@0.56.0:
+    dependencies:
+      dompurify: 3.4.8
+      marked: 14.0.0
 
   ms@2.1.3: {}
 

--- a/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
+++ b/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
@@ -39,6 +39,7 @@ type FakeMonaco = {
 
 function createFakeMonaco(): FakeMonaco {
   const editor = {
+    setTheme: vi.fn(),
     create: vi.fn(
       (_container: HTMLElement, options: Record<string, unknown>) => {
         const e: FakeEditor = {

--- a/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
+++ b/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
@@ -71,7 +71,10 @@ function createFakeMonaco(): FakeMonaco {
 
 let fakeMonaco: FakeMonaco;
 
-import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
+import {
+  useChatSidebarStore,
+  type PreviewSourceMode,
+} from "@/stores/chat-sidebar-store";
 import { useSessionStatusStore } from "@/stores/session-status-store";
 
 import { FilePreviewPanel } from "../file-preview/file-preview-panel";
@@ -104,8 +107,12 @@ function renderPanel(sessionId = 7) {
   return render(<FilePreviewPanel sessionId={sessionId} />);
 }
 
-function openPreview(path: string, sessionId = 7) {
-  useChatSidebarStore.getState().openPreview(sessionId, path);
+function openPreview(
+  path: string,
+  sessionId = 7,
+  sourceMode: PreviewSourceMode = "directory",
+) {
+  useChatSidebarStore.getState().openPreview(sessionId, path, sourceMode);
 }
 
 describe("FilePreviewPanel", () => {
@@ -117,7 +124,7 @@ describe("FilePreviewPanel", () => {
 
   it("reads the selected file on open and renders the header", async () => {
     readFileMock.mockResolvedValue(textView("# Hi"));
-    openPreview("docs/guide.md");
+    openPreview("docs/guide.md", 7, "directory");
 
     renderPanel();
 
@@ -140,7 +147,7 @@ describe("FilePreviewPanel", () => {
 
   it("renders markdown in render mode by default (GFM MarkdownText)", async () => {
     readFileMock.mockResolvedValue(textView("**bold**"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -152,7 +159,7 @@ describe("FilePreviewPanel", () => {
 
   it("switches markdown to text mode showing raw source via Monaco", async () => {
     readFileMock.mockResolvedValue(textView("# raw"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -171,7 +178,7 @@ describe("FilePreviewPanel", () => {
 
   it("switches markdown to split mode showing source and render side by side", async () => {
     readFileMock.mockResolvedValue(textView("# Title\n\nSome **bold** body."));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -189,77 +196,121 @@ describe("FilePreviewPanel", () => {
     );
   });
 
-  it("shows a code file in text mode by default and only two segments", async () => {
+  it("shows a code file opened from directory mode as content with no segment control", async () => {
     readFileMock.mockResolvedValue(textView("package main"));
-    openPreview("main.go");
+    openPreview("main.go", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
       name: "File preview",
     });
+    // 代码 / 文本没有分段控件（不再有「文本 / 对比」两档）。
     expect(within(panel).queryByRole("button", { name: "Render" })).toBeNull();
-    expect(
-      within(panel).getByRole("button", { name: "Diff" }),
-    ).toBeInTheDocument();
+    expect(within(panel).queryByRole("button", { name: "Text" })).toBeNull();
+    expect(within(panel).queryByRole("button", { name: "Diff" })).toBeNull();
+    // 目录打开 → 只读内容，不调 GitFileContent。
+    expect(gitFileContentMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(fakeMonaco.editor.create).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ language: "go", readOnly: true }),
+      ),
+    );
   });
 
-  it("fetches git HEAD content when switching a code file to diff mode", async () => {
+  it("shows a git-opened code file as a diff with no segment control", async () => {
     readFileMock.mockResolvedValue(textView("package main\n"));
     gitFileContentMock.mockResolvedValue({
       content: "package main\n// old\n",
       notARepo: false,
       hasHead: true,
     });
-    openPreview("main.go");
+    openPreview("main.go", 7, "git");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
       name: "File preview",
     });
-    expect(gitFileContentMock).not.toHaveBeenCalled();
-    await userEvent.click(within(panel).getByRole("button", { name: "Diff" }));
-
+    // 首视图直接是对比：调 GitFileContent、出对比头部条 + 增删图例、建 diff editor。
     await waitFor(() =>
       expect(gitFileContentMock).toHaveBeenCalledWith(7, "main.go"),
     );
-    // 头部条:对比 · HEAD → 工作区 + 增删图例。
     expect(
       within(panel).getByText("Diff · HEAD → working tree"),
     ).toBeInTheDocument();
     expect(within(panel).getByText("Added")).toBeInTheDocument();
     expect(within(panel).getByText("Deleted")).toBeInTheDocument();
-    // Monaco diff editor 被创建(只读, side-by-side)。
     await waitFor(() =>
       expect(fakeMonaco.editor.createDiffEditor).toHaveBeenCalledWith(
         expect.any(HTMLElement),
         expect.objectContaining({ readOnly: true }),
       ),
     );
+    // 代码 / 文本没有分段控件。
+    expect(within(panel).queryByRole("button", { name: "Text" })).toBeNull();
+    expect(within(panel).queryByRole("button", { name: "Diff" })).toBeNull();
   });
 
-  it("renders the no-git-baseline empty state when the directory is not a repo", async () => {
+  it("shows a changes-mode code file as a diff too", async () => {
+    readFileMock.mockResolvedValue(textView("package main\n"));
+    gitFileContentMock.mockResolvedValue({
+      content: "package main\n// old\n",
+      notARepo: false,
+      hasHead: true,
+    });
+    openPreview("main.go", 7, "changes");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await waitFor(() =>
+      expect(gitFileContentMock).toHaveBeenCalledWith(7, "main.go"),
+    );
+    expect(
+      within(panel).getByText("Diff · HEAD → working tree"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the no-git-baseline empty state for a git-opened code file outside a repo", async () => {
     readFileMock.mockResolvedValue(textView("hello"));
     gitFileContentMock.mockResolvedValue({
       content: "",
       notARepo: true,
       hasHead: false,
     });
-    openPreview("a.txt");
+    openPreview("a.txt", 7, "git");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
       name: "File preview",
     });
-    await userEvent.click(within(panel).getByRole("button", { name: "Diff" }));
-
     expect(
       await within(panel).findByText("No git baseline to compare"),
     ).toBeInTheDocument();
   });
 
+  it("shows markdown content segments even when opened from git mode (never a diff)", async () => {
+    readFileMock.mockResolvedValue(textView("# Title"));
+    openPreview("README.md", 7, "git");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    // markdown 三档仍在、默认渲染档；从任何模式都不调 GitFileContent。
+    for (const seg of ["Render", "Text", "Split"]) {
+      expect(
+        within(panel).getByRole("button", { name: seg }),
+      ).toBeInTheDocument();
+    }
+    expect(gitFileContentMock).not.toHaveBeenCalled();
+    await within(panel).findByRole("heading", { level: 1, name: "Title" });
+  });
+
   it("renders an image with a data URL and alt text", async () => {
     readFileMock.mockResolvedValue(imageView("aGVsbG8=", "image/png"));
-    openPreview("assets/logo.png");
+    openPreview("assets/logo.png", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -279,7 +330,7 @@ describe("FilePreviewPanel", () => {
       binary: true,
       tooLarge: false,
     });
-    openPreview("archive.bin");
+    openPreview("archive.bin", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -300,7 +351,7 @@ describe("FilePreviewPanel", () => {
       binary: false,
       tooLarge: true,
     });
-    openPreview("photo.jpg");
+    openPreview("photo.jpg", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -319,7 +370,7 @@ describe("FilePreviewPanel", () => {
       new Error("Path is outside the session working directory"),
     );
     readFileMock.mockResolvedValue(textView("# ok"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -340,7 +391,7 @@ describe("FilePreviewPanel", () => {
 
   it("closes the panel and clears the selection when close is clicked", async () => {
     readFileMock.mockResolvedValue(textView("# hi"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -359,7 +410,7 @@ describe("FilePreviewPanel", () => {
 
   it("keeps a newly opened file when a close is still animating", async () => {
     readFileMock.mockResolvedValue(textView("# a"));
-    openPreview("a.md");
+    openPreview("a.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -369,25 +420,26 @@ describe("FilePreviewPanel", () => {
       within(panel).getByRole("button", { name: "Close preview" }),
     );
     // 200ms 出场动画期间打开另一个文件:旧 timer 不能把新选择清掉。
-    useChatSidebarStore.getState().openPreview(7, "b.md");
+    useChatSidebarStore.getState().openPreview(7, "b.md", "directory");
 
     // 等关闭动画的 timer 跑完,断言 b.md 仍然选中、面板仍然开着。
     await new Promise((resolve) => setTimeout(resolve, 300));
     expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
       path: "b.md",
       segment: null,
+      sourceMode: "directory",
     });
   });
 
-  it("switching files re-reads the new file and switches segment back on close", async () => {
+  it("switching files re-reads the new file and keeps the segment in the same mode", async () => {
     readFileMock.mockResolvedValue(textView("# a"));
-    openPreview("a.md");
+    openPreview("a.md", 7, "directory");
     const { rerender } = renderPanel();
 
     await screen.findByRole("complementary", { name: "File preview" });
-    // 打开第二个文件(面板保持打开,档位保留)。
+    // 打开第二个文件(同模式,面板保持打开,markdown 档位保留)。
     useChatSidebarStore.getState().setPreviewSegment(7, "text");
-    useChatSidebarStore.getState().openPreview(7, "b.md");
+    useChatSidebarStore.getState().openPreview(7, "b.md", "directory");
     rerender(<FilePreviewPanel sessionId={7} />);
 
     await waitFor(() => {
@@ -398,9 +450,42 @@ describe("FilePreviewPanel", () => {
     );
   });
 
+  it("re-sets the first view when the same file is opened from a different mode", async () => {
+    readFileMock.mockResolvedValue(textView("hello"));
+    gitFileContentMock.mockResolvedValue({
+      content: "",
+      notARepo: false,
+      hasHead: true,
+    });
+    openPreview("a.go", 7, "directory");
+    const { rerender } = renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await waitFor(() =>
+      expect(fakeMonaco.editor.create).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ language: "go", readOnly: true }),
+      ),
+    );
+    expect(gitFileContentMock).not.toHaveBeenCalled();
+
+    // 换到 Git 模式重开同一文件 → 首视图变对比。
+    useChatSidebarStore.getState().openPreview(7, "a.go", "git");
+    rerender(<FilePreviewPanel sessionId={7} />);
+
+    await waitFor(() =>
+      expect(gitFileContentMock).toHaveBeenCalledWith(7, "a.go"),
+    );
+    expect(
+      within(panel).getByText("Diff · HEAD → working tree"),
+    ).toBeInTheDocument();
+  });
+
   it("clears the selection when the session switches", async () => {
     readFileMock.mockResolvedValue(textView("# hi"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     const { rerender } = renderPanel(7);
 
     await screen.findByRole("complementary", { name: "File preview" });
@@ -416,7 +501,7 @@ describe("FilePreviewPanel", () => {
 
   it("re-reads the open file when the session turn ends (doneTick)", async () => {
     readFileMock.mockResolvedValue(textView("# v1"));
-    openPreview("README.md");
+    openPreview("README.md", 7, "directory");
     renderPanel();
 
     const panel = await screen.findByRole("complementary", {
@@ -430,5 +515,57 @@ describe("FilePreviewPanel", () => {
 
     await within(panel).findByRole("heading", { level: 1, name: "v2" });
     expect(readFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-reads and re-computes the diff for a git-opened code file on doneTick", async () => {
+    readFileMock.mockResolvedValue(textView("v1\n"));
+    gitFileContentMock.mockResolvedValue({
+      content: "old\n",
+      notARepo: false,
+      hasHead: true,
+    });
+    openPreview("a.go", 7, "git");
+    renderPanel();
+
+    await screen.findByRole("complementary", { name: "File preview" });
+    await waitFor(() =>
+      expect(gitFileContentMock).toHaveBeenCalledWith(7, "a.go"),
+    );
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+    expect(gitFileContentMock).toHaveBeenCalledTimes(1);
+
+    readFileMock.mockResolvedValue(textView("v2\n"));
+    useSessionStatusStore.getState().bumpDone(7, { kind: "done" });
+
+    await waitFor(() => expect(readFileMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(gitFileContentMock).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(fakeMonaco.editor.createDiffEditor).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ readOnly: true }),
+      ),
+    );
+  });
+
+  it("re-reads only content on doneTick for a directory-opened code file", async () => {
+    readFileMock.mockResolvedValue(textView("v1"));
+    openPreview("a.go", 7, "directory");
+    renderPanel();
+
+    await screen.findByRole("complementary", { name: "File preview" });
+    await waitFor(() =>
+      expect(fakeMonaco.editor.create).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ language: "go", readOnly: true }),
+      ),
+    );
+    expect(gitFileContentMock).not.toHaveBeenCalled();
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+
+    readFileMock.mockResolvedValue(textView("v2"));
+    useSessionStatusStore.getState().bumpDone(7, { kind: "done" });
+
+    await waitFor(() => expect(readFileMock).toHaveBeenCalledTimes(2));
+    expect(gitFileContentMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
+++ b/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
@@ -60,7 +60,11 @@ function createFakeMonaco(): FakeMonaco {
         return d;
       },
     ),
-    createModel: vi.fn((value: string, lang: string) => ({ value, lang })),
+    createModel: vi.fn((value: string, lang: string) => ({
+      value,
+      lang,
+      dispose: vi.fn(),
+    })),
   };
   return { editor };
 }
@@ -350,6 +354,28 @@ describe("FilePreviewPanel", () => {
       expect(
         useChatSidebarStore.getState().previewBySession[7],
       ).toBeUndefined();
+    });
+  });
+
+  it("keeps a newly opened file when a close is still animating", async () => {
+    readFileMock.mockResolvedValue(textView("# a"));
+    openPreview("a.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await userEvent.click(
+      within(panel).getByRole("button", { name: "Close preview" }),
+    );
+    // 200ms 出场动画期间打开另一个文件:旧 timer 不能把新选择清掉。
+    useChatSidebarStore.getState().openPreview(7, "b.md");
+
+    // 等关闭动画的 timer 跑完,断言 b.md 仍然选中、面板仍然开着。
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+      path: "b.md",
+      segment: null,
     });
   });
 

--- a/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
+++ b/frontend/src/components/agentre/__tests__/file-preview-panel.test.tsx
@@ -1,0 +1,407 @@
+import "@testing-library/jest-dom/vitest";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const gitFileContentMock = vi.fn();
+vi.mock("@/../wailsjs/go/app/App", () => ({
+  WorkspaceFsReadFile: (sessionId: number, relPath: string) =>
+    readFileMock(sessionId, relPath),
+  WorkspaceFsGitFileContent: (sessionId: number, relPath: string) =>
+    gitFileContentMock(sessionId, relPath),
+}));
+
+// Monaco 接缝:面板内的 CodePreview / DiffPreview / MarkdownSourceView 在 happy-dom
+// 里跑不了真实 Monaco,按 task 5 定好的 seam 把 loadMonaco 换成 fake 命名空间。
+const loaderMocks = vi.hoisted(() => ({ loadMonaco: vi.fn() }));
+vi.mock("@/lib/file-preview/monaco-loader", () => loaderMocks);
+
+type FakeEditor = {
+  options: Record<string, unknown>;
+  setValue: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
+type FakeDiff = {
+  options: Record<string, unknown>;
+  setModel: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+type FakeMonaco = {
+  editor: {
+    create: ReturnType<typeof vi.fn>;
+    createDiffEditor: ReturnType<typeof vi.fn>;
+    createModel: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createFakeMonaco(): FakeMonaco {
+  const editor = {
+    create: vi.fn(
+      (_container: HTMLElement, options: Record<string, unknown>) => {
+        const e: FakeEditor = {
+          options,
+          setValue: vi.fn(),
+          dispose: vi.fn(),
+        };
+        return e;
+      },
+    ),
+    createDiffEditor: vi.fn(
+      (_container: HTMLElement, options: Record<string, unknown>) => {
+        const d: FakeDiff = {
+          options,
+          setModel: vi.fn(),
+          dispose: vi.fn(),
+        };
+        return d;
+      },
+    ),
+    createModel: vi.fn((value: string, lang: string) => ({ value, lang })),
+  };
+  return { editor };
+}
+
+let fakeMonaco: FakeMonaco;
+
+import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
+import { useSessionStatusStore } from "@/stores/session-status-store";
+
+import { FilePreviewPanel } from "../file-preview/file-preview-panel";
+
+function textView(content: string) {
+  return { content, contentType: "", binary: false, tooLarge: false };
+}
+function imageView(content: string, contentType: string) {
+  return { content, contentType, binary: false, tooLarge: false };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useChatSidebarStore.setState({
+    open: true,
+    activeTab: "files",
+    filesMode: "changes",
+    showIgnored: false,
+    previewBySession: {},
+  });
+  useSessionStatusStore.getState().__reset();
+  readFileMock.mockReset();
+  gitFileContentMock.mockReset();
+  loaderMocks.loadMonaco.mockReset();
+  fakeMonaco = createFakeMonaco();
+  loaderMocks.loadMonaco.mockResolvedValue(fakeMonaco as never);
+});
+
+function renderPanel(sessionId = 7) {
+  return render(<FilePreviewPanel sessionId={sessionId} />);
+}
+
+function openPreview(path: string, sessionId = 7) {
+  useChatSidebarStore.getState().openPreview(sessionId, path);
+}
+
+describe("FilePreviewPanel", () => {
+  it("renders nothing when no file is selected", () => {
+    const { container } = renderPanel();
+    expect(container).toBeEmptyDOMElement();
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the selected file on open and renders the header", async () => {
+    readFileMock.mockResolvedValue(textView("# Hi"));
+    openPreview("docs/guide.md");
+
+    renderPanel();
+
+    await screen.findByRole("complementary", { name: "File preview" });
+    expect(readFileMock).toHaveBeenCalledWith(7, "docs/guide.md");
+
+    // header: 文件名(含目录前缀) + markdown 三档分段 + 关闭按钮。
+    const panel = screen.getByRole("complementary", { name: "File preview" });
+    expect(within(panel).getByText("guide.md")).toBeInTheDocument();
+    expect(within(panel).getByText("docs/")).toBeInTheDocument();
+    for (const seg of ["Render", "Text", "Split"]) {
+      expect(
+        within(panel).getByRole("button", { name: seg }),
+      ).toBeInTheDocument();
+    }
+    expect(
+      within(panel).getByRole("button", { name: "Close preview" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders markdown in render mode by default (GFM MarkdownText)", async () => {
+    readFileMock.mockResolvedValue(textView("**bold**"));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    // MarkdownText 渲染出 <strong>。
+    await within(panel).findByText("bold");
+  });
+
+  it("switches markdown to text mode showing raw source via Monaco", async () => {
+    readFileMock.mockResolvedValue(textView("# raw"));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await userEvent.click(within(panel).getByRole("button", { name: "Text" }));
+
+    // MarkdownSourceView → CodePreview 以 markdown 语言建只读编辑器。
+    await waitFor(() =>
+      expect(fakeMonaco.editor.create).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ language: "markdown", readOnly: true }),
+      ),
+    );
+  });
+
+  it("switches markdown to split mode showing source and render side by side", async () => {
+    readFileMock.mockResolvedValue(textView("# Title\n\nSome **bold** body."));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await userEvent.click(within(panel).getByRole("button", { name: "Split" }));
+
+    // 渲染侧出现 GFM 的 <strong>;源码侧 Monaco 编辑器建了 markdown 语言。
+    await within(panel).findByText("bold");
+    await waitFor(() =>
+      expect(fakeMonaco.editor.create).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ language: "markdown", readOnly: true }),
+      ),
+    );
+  });
+
+  it("shows a code file in text mode by default and only two segments", async () => {
+    readFileMock.mockResolvedValue(textView("package main"));
+    openPreview("main.go");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    expect(within(panel).queryByRole("button", { name: "Render" })).toBeNull();
+    expect(
+      within(panel).getByRole("button", { name: "Diff" }),
+    ).toBeInTheDocument();
+  });
+
+  it("fetches git HEAD content when switching a code file to diff mode", async () => {
+    readFileMock.mockResolvedValue(textView("package main\n"));
+    gitFileContentMock.mockResolvedValue({
+      content: "package main\n// old\n",
+      notARepo: false,
+      hasHead: true,
+    });
+    openPreview("main.go");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    expect(gitFileContentMock).not.toHaveBeenCalled();
+    await userEvent.click(within(panel).getByRole("button", { name: "Diff" }));
+
+    await waitFor(() =>
+      expect(gitFileContentMock).toHaveBeenCalledWith(7, "main.go"),
+    );
+    // 头部条:对比 · HEAD → 工作区 + 增删图例。
+    expect(
+      within(panel).getByText("Diff · HEAD → working tree"),
+    ).toBeInTheDocument();
+    expect(within(panel).getByText("Added")).toBeInTheDocument();
+    expect(within(panel).getByText("Deleted")).toBeInTheDocument();
+    // Monaco diff editor 被创建(只读, side-by-side)。
+    await waitFor(() =>
+      expect(fakeMonaco.editor.createDiffEditor).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ readOnly: true }),
+      ),
+    );
+  });
+
+  it("renders the no-git-baseline empty state when the directory is not a repo", async () => {
+    readFileMock.mockResolvedValue(textView("hello"));
+    gitFileContentMock.mockResolvedValue({
+      content: "",
+      notARepo: true,
+      hasHead: false,
+    });
+    openPreview("a.txt");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await userEvent.click(within(panel).getByRole("button", { name: "Diff" }));
+
+    expect(
+      await within(panel).findByText("No git baseline to compare"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an image with a data URL and alt text", async () => {
+    readFileMock.mockResolvedValue(imageView("aGVsbG8=", "image/png"));
+    openPreview("assets/logo.png");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    const img = await within(panel).findByAltText("logo.png");
+    expect(img).toHaveAttribute("src", "data:image/png;base64,aGVsbG8=");
+    // 图片没有视图分段。
+    expect(within(panel).queryByRole("button", { name: "Render" })).toBeNull();
+    expect(within(panel).queryByRole("button", { name: "Text" })).toBeNull();
+  });
+
+  it("shows the binary state and a retry for a binary file", async () => {
+    readFileMock.mockResolvedValue({
+      content: "",
+      contentType: "",
+      binary: true,
+      tooLarge: false,
+    });
+    openPreview("archive.bin");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    expect(
+      await within(panel).findByText(/Binary file, cannot preview/),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByRole("button", { name: /Retry/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the too-large state with the image threshold hint for images", async () => {
+    readFileMock.mockResolvedValue({
+      content: "",
+      contentType: "",
+      binary: false,
+      tooLarge: true,
+    });
+    openPreview("photo.jpg");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    expect(
+      await within(panel).findByText(/File too large to preview/),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByText(/Image larger than 10 MiB/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the read error text with a retry that re-reads", async () => {
+    readFileMock.mockRejectedValueOnce(
+      new Error("Path is outside the session working directory"),
+    );
+    readFileMock.mockResolvedValue(textView("# ok"));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    expect(
+      await within(panel).findByText(
+        "Path is outside the session working directory",
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(panel).getByRole("button", { name: /Retry/i }),
+    );
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+    await within(panel).findByRole("heading", { level: 1, name: "ok" });
+  });
+
+  it("closes the panel and clears the selection when close is clicked", async () => {
+    readFileMock.mockResolvedValue(textView("# hi"));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await userEvent.click(
+      within(panel).getByRole("button", { name: "Close preview" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        useChatSidebarStore.getState().previewBySession[7],
+      ).toBeUndefined();
+    });
+  });
+
+  it("switching files re-reads the new file and switches segment back on close", async () => {
+    readFileMock.mockResolvedValue(textView("# a"));
+    openPreview("a.md");
+    const { rerender } = renderPanel();
+
+    await screen.findByRole("complementary", { name: "File preview" });
+    // 打开第二个文件(面板保持打开,档位保留)。
+    useChatSidebarStore.getState().setPreviewSegment(7, "text");
+    useChatSidebarStore.getState().openPreview(7, "b.md");
+    rerender(<FilePreviewPanel sessionId={7} />);
+
+    await waitFor(() => {
+      expect(readFileMock).toHaveBeenLastCalledWith(7, "b.md");
+    });
+    expect(useChatSidebarStore.getState().previewBySession[7].segment).toBe(
+      "text",
+    );
+  });
+
+  it("clears the selection when the session switches", async () => {
+    readFileMock.mockResolvedValue(textView("# hi"));
+    openPreview("README.md");
+    const { rerender } = renderPanel(7);
+
+    await screen.findByRole("complementary", { name: "File preview" });
+
+    rerender(<FilePreviewPanel sessionId={8} />);
+
+    await waitFor(() => {
+      expect(
+        useChatSidebarStore.getState().previewBySession[7],
+      ).toBeUndefined();
+    });
+  });
+
+  it("re-reads the open file when the session turn ends (doneTick)", async () => {
+    readFileMock.mockResolvedValue(textView("# v1"));
+    openPreview("README.md");
+    renderPanel();
+
+    const panel = await screen.findByRole("complementary", {
+      name: "File preview",
+    });
+    await within(panel).findByRole("heading", { level: 1, name: "v1" });
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+
+    readFileMock.mockResolvedValue(textView("# v2"));
+    useSessionStatusStore.getState().bumpDone(7, { kind: "done" });
+
+    await within(panel).findByRole("heading", { level: 1, name: "v2" });
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel-git.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel-git.test.tsx
@@ -122,6 +122,7 @@ beforeEach(() => {
     filesMode: "git",
     showIgnored: false,
     gitBaselineBySession: {},
+    previewBySession: {},
   });
   useSessionStatusStore.getState().__reset();
   openPathMock.mockReset();
@@ -264,6 +265,50 @@ describe("FilesPanel git mode · 未提交档", () => {
     renderPanel({ remote: true });
     await screen.findByText("a.go");
     expect(screen.queryByRole("button", { name: /a\.go/ })).toBeNull();
+  });
+
+  it("shows a preview button beside the row and opens the selection by path", async () => {
+    gitChangesMock.mockResolvedValue(
+      changesView([
+        { path: "internal/a.go", status: "modified" },
+        { path: "asset.zip", status: "added" },
+      ]),
+    );
+    renderPanel({});
+    await screen.findByText("a.go");
+
+    await userEvent.click(
+      within(gitRow("internal/a.go")).getByRole("button", {
+        name: /preview/i,
+      }),
+    );
+    expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+      path: "internal/a.go",
+      segment: null,
+    });
+    // 行点击仍是打开,预览按钮点击不打开文件。
+    expect(openPathMock).not.toHaveBeenCalled();
+    // 不可预览文件行不出预览按钮。
+    expect(
+      within(gitRow("asset.zip")).queryByRole("button", {
+        name: /preview/i,
+      }),
+    ).toBeNull();
+  });
+
+  it("still shows a preview button for a remote git session", async () => {
+    gitChangesMock.mockResolvedValue(
+      changesView([{ path: "internal/a.go", status: "modified" }]),
+    );
+    renderPanel({ remote: true });
+    await screen.findByText("a.go");
+
+    // 远端整行不可点(无 open 按钮),但预览按钮仍在。
+    const rowEl = gitRow("internal/a.go");
+    expect(within(rowEl).queryByRole("button", { name: /a\.go/ })).toBeNull();
+    expect(
+      within(rowEl).getByRole("button", { name: /preview/i }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel-git.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel-git.test.tsx
@@ -285,6 +285,7 @@ describe("FilesPanel git mode · 未提交档", () => {
     expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
       path: "internal/a.go",
       segment: null,
+      sourceMode: "git",
     });
     // 行点击仍是打开,预览按钮点击不打开文件。
     expect(openPathMock).not.toHaveBeenCalled();

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel.test.tsx
@@ -472,6 +472,7 @@ describe("FilesPanel directory mode", () => {
     expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
       path: "internal/chat.go",
       segment: null,
+      sourceMode: "directory",
     });
     expect(openPathMock).not.toHaveBeenCalled();
 
@@ -481,6 +482,7 @@ describe("FilesPanel directory mode", () => {
     expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
       path: "logo.png",
       segment: null,
+      sourceMode: "directory",
     });
   });
 

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-panel.test.tsx
@@ -89,6 +89,7 @@ beforeEach(() => {
     activeTab: "files",
     filesMode: "changes",
     showIgnored: false,
+    previewBySession: {},
   });
   useSessionStatusStore.getState().__reset();
   openPathMock.mockReset();
@@ -442,5 +443,55 @@ describe("FilesPanel directory mode", () => {
 
     await screen.findByText("main.go");
     expect(screen.queryByRole("button", { name: /open file/i })).toBeNull();
+  });
+
+  it("shows a preview button on previewable file rows and opens the selection by relPath", async () => {
+    listDirMock.mockImplementation((_id: number, relPath: string) =>
+      Promise.resolve(
+        relPath === ""
+          ? listing([entry("internal", true), entry("logo.png")])
+          : listing([entry("chat.go"), entry("doc.pdf")]),
+      ),
+    );
+    renderPanel({});
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /expand internal/i }),
+    );
+    // 目录行与不可预览文件行没有预览按钮;代码与图片行有。
+    expect(
+      within(row("internal")).queryByRole("button", { name: /preview/i }),
+    ).toBeNull();
+    expect(
+      within(row("doc.pdf")).queryByRole("button", { name: /preview/i }),
+    ).toBeNull();
+
+    await userEvent.click(
+      within(row("chat.go")).getByRole("button", { name: /preview/i }),
+    );
+    expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+      path: "internal/chat.go",
+      segment: null,
+    });
+    expect(openPathMock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(row("logo.png")).getByRole("button", { name: /preview/i }),
+    );
+    expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+      path: "logo.png",
+      segment: null,
+    });
+  });
+
+  it("still shows preview buttons for a remote directory session", async () => {
+    listDirMock.mockResolvedValue(listing([entry("main.go"), entry("a.zip")]));
+    renderPanel({ remote: true });
+
+    await screen.findByText("main.go");
+    expect(screen.queryByRole("button", { name: /open file/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /preview/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -14,6 +14,8 @@ vi.mock("@/../wailsjs/go/app/App", () => ({
   OpenPath: (p: string) => openPathMock(p),
 }));
 
+import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
+
 import { FilesView } from "../views/files-view";
 
 import type { FileEntry } from "../derive";
@@ -45,12 +47,15 @@ beforeEach(() => {
   openPathMock.mockReset();
   openPathMock.mockResolvedValue(undefined);
   sonnerMocks.toast.error.mockReset();
+  localStorage.clear();
+  useChatSidebarStore.setState({ previewBySession: {} });
 });
 
 describe("FilesView", () => {
   it("renders the directory tree with folder rows and file basenames", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -77,6 +82,7 @@ describe("FilesView", () => {
   it("reserves a chevron-width slot on file rows so dir/file icon and name columns align", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -108,6 +114,7 @@ describe("FilesView", () => {
     ];
     render(
       <FilesView
+        sessionId={1}
         files={windowsFiles}
         cwd="C:\\proj"
         remote={false}
@@ -127,6 +134,7 @@ describe("FilesView", () => {
   it("left-aligns folder names with explicit text-left (matches the file-row pattern)", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -144,6 +152,7 @@ describe("FilesView", () => {
   it("collapses and expands a folder on row click, aria-expanded reflects state", async () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -172,6 +181,7 @@ describe("FilesView", () => {
   it("keeps a collapsed folder closed when an equivalent files array rerenders", async () => {
     const { rerender } = render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -182,6 +192,7 @@ describe("FilesView", () => {
 
     rerender(
       <FilesView
+        sessionId={1}
         files={[...files]}
         cwd={CWD}
         remote={false}
@@ -197,6 +208,7 @@ describe("FilesView", () => {
   it("resets a collapsed folder when the ordered file paths change", async () => {
     const { rerender } = render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -207,6 +219,7 @@ describe("FilesView", () => {
 
     rerender(
       <FilesView
+        sessionId={1}
         files={[...files].reverse()}
         cwd={CWD}
         remote={false}
@@ -223,6 +236,7 @@ describe("FilesView", () => {
     const onJump = vi.fn();
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -236,6 +250,7 @@ describe("FilesView", () => {
   it("renders +N in text-status-running and −N in text-destructive badges", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -254,6 +269,7 @@ describe("FilesView", () => {
   it("omits diff badge when plus and minus are both 0", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -268,6 +284,7 @@ describe("FilesView", () => {
     const onJump = vi.fn();
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -296,6 +313,7 @@ describe("FilesView", () => {
     ];
     render(
       <FilesView
+        sessionId={1}
         files={absoluteFiles}
         cwd={CWD}
         remote={false}
@@ -318,6 +336,7 @@ describe("FilesView", () => {
   it("hides open buttons when remote is true", () => {
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={true}
@@ -331,7 +350,13 @@ describe("FilesView", () => {
 
   it("hides open buttons when cwd is empty", () => {
     render(
-      <FilesView files={files} cwd="" remote={false} onJumpToTurn={() => {}} />,
+      <FilesView
+        sessionId={1}
+        files={files}
+        cwd=""
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
     );
     expect(
       screen.queryByRole("button", { name: /Open file/i }),
@@ -342,6 +367,7 @@ describe("FilesView", () => {
     openPathMock.mockRejectedValue(new Error("boom"));
     render(
       <FilesView
+        sessionId={1}
         files={files}
         cwd={CWD}
         remote={false}
@@ -362,10 +388,157 @@ describe("FilesView", () => {
 
   it("shows empty state when files is empty", () => {
     render(
-      <FilesView files={[]} cwd={CWD} remote={false} onJumpToTurn={() => {}} />,
+      <FilesView
+        sessionId={1}
+        files={[]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
     );
     expect(
       screen.getByText(/No files have been changed in this session/),
     ).toBeInTheDocument();
+  });
+});
+
+describe("FilesView preview button", () => {
+  const previewBtn = (rowName: RegExp) => {
+    const row = screen.getByRole("button", { name: rowName });
+    return within(row.parentElement!).queryByRole("button", {
+      name: /preview/i,
+    });
+  };
+
+  it("renders a preview button for markdown / code / image files", () => {
+    render(
+      <FilesView
+        sessionId={1}
+        files={[
+          ...files,
+          { path: "assets/logo.png", plus: 0, minus: 0, lastTurn: 1 },
+        ]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(previewBtn(/chat\.go/)).not.toBeNull();
+    expect(previewBtn(/README\.md/)).not.toBeNull();
+    expect(previewBtn(/logo\.png/)).not.toBeNull();
+  });
+
+  it("does not render a preview button for non-previewable file types", () => {
+    render(
+      <FilesView
+        sessionId={1}
+        files={[
+          { path: "archive.zip", plus: 0, minus: 0, lastTurn: 1 },
+          { path: "doc.pdf", plus: 0, minus: 0, lastTurn: 1 },
+        ]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /preview/i })).toBeNull();
+  });
+
+  it("opens the panel with the relative path and does not jump on click", async () => {
+    const onJump = vi.fn();
+    render(
+      <FilesView
+        sessionId={1}
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={onJump}
+      />,
+    );
+    await userEvent.click(previewBtn(/README\.md/)!);
+
+    expect(useChatSidebarStore.getState().previewBySession[1]).toEqual({
+      path: "README.md",
+      segment: null,
+    });
+    expect(onJump).not.toHaveBeenCalled();
+  });
+
+  it("strips the cwd prefix for an absolute path inside the cwd", async () => {
+    render(
+      <FilesView
+        sessionId={1}
+        files={[
+          {
+            path: "/Users/me/proj/internal/service/chat_svc/chat.go",
+            plus: 0,
+            minus: 0,
+            lastTurn: 1,
+          },
+        ]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    const row = screen.getByRole("button", { name: /chat\.go/ });
+    await userEvent.click(
+      within(row.parentElement!).getByRole("button", { name: /preview/i }),
+    );
+
+    expect(useChatSidebarStore.getState().previewBySession[1]).toEqual({
+      path: "internal/service/chat_svc/chat.go",
+      segment: null,
+    });
+  });
+
+  it("hides the preview button for an absolute path outside the cwd", () => {
+    render(
+      <FilesView
+        sessionId={1}
+        files={[
+          {
+            path: "/Users/other/proj/secret.go",
+            plus: 0,
+            minus: 0,
+            lastTurn: 1,
+          },
+        ]}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /preview/i })).toBeNull();
+  });
+
+  it("still shows the preview button for remote sessions (unlike open)", () => {
+    render(
+      <FilesView
+        sessionId={1}
+        files={files}
+        cwd={CWD}
+        remote={true}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /open file/i })).toBeNull();
+    // 三行都是可预览文件 → 三个预览按钮(远端也出,内容经 RPC 读取)。
+    expect(screen.getAllByRole("button", { name: /preview/i }).length).toBe(3);
+  });
+
+  it("highlights the currently previewed file's button", () => {
+    useChatSidebarStore.getState().openPreview(1, "README.md");
+    render(
+      <FilesView
+        sessionId={1}
+        files={files}
+        cwd={CWD}
+        remote={false}
+        onJumpToTurn={() => {}}
+      />,
+    );
+    expect(previewBtn(/README\.md/)!.className).toContain("text-primary");
+    expect(previewBtn(/chat\.go/)!.className).not.toContain("text-primary");
   });
 });

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/files-view.test.tsx
@@ -460,6 +460,7 @@ describe("FilesView preview button", () => {
     expect(useChatSidebarStore.getState().previewBySession[1]).toEqual({
       path: "README.md",
       segment: null,
+      sourceMode: "changes",
     });
     expect(onJump).not.toHaveBeenCalled();
   });
@@ -489,6 +490,7 @@ describe("FilesView preview button", () => {
     expect(useChatSidebarStore.getState().previewBySession[1]).toEqual({
       path: "internal/service/chat_svc/chat.go",
       segment: null,
+      sourceMode: "changes",
     });
   });
 
@@ -528,7 +530,7 @@ describe("FilesView preview button", () => {
   });
 
   it("highlights the currently previewed file's button", () => {
-    useChatSidebarStore.getState().openPreview(1, "README.md");
+    useChatSidebarStore.getState().openPreview(1, "README.md", "changes");
     render(
       <FilesView
         sessionId={1}

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/previewable.test.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/previewable.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { previewKind, resolvePreviewRelPath } from "../previewable";
+
+describe("previewKind", () => {
+  it("classifies markdown files (.md / .markdown) as markdown, not .mdx", () => {
+    expect(previewKind("README.md")).toBe("markdown");
+    expect(previewKind("docs/guide.markdown")).toBe("markdown");
+    // MDX 含 JSX,GFM 渲染会碎——明确不入档(spec 决策 3)。
+    expect(previewKind("docs/page.mdx")).toBeNull();
+  });
+
+  it("classifies code / text extensions as code", () => {
+    for (const p of [
+      "main.go",
+      "src/app.ts",
+      "index.js",
+      "page.tsx",
+      "package.json",
+      "Dockerfile.yaml",
+      "style.css",
+      "notes.txt",
+      "debug.log",
+      "a.py",
+      "b.sh",
+      "c.sql",
+    ]) {
+      expect(previewKind(p)).toBe("code");
+    }
+  });
+
+  it("classifies image extensions as image", () => {
+    for (const p of [
+      "logo.png",
+      "photo.jpg",
+      "a.jpeg",
+      "anim.gif",
+      "pic.webp",
+      "x.avif",
+      "i.bmp",
+      "favicon.ico",
+      "diagram.svg",
+    ]) {
+      expect(previewKind(p)).toBe("image");
+    }
+  });
+
+  it("is case-insensitive for extensions", () => {
+    expect(previewKind("README.MD")).toBe("markdown");
+    expect(previewKind("logo.PNG")).toBe("image");
+    expect(previewKind("main.GO")).toBe("code");
+  });
+
+  it("returns null for non-previewable file types", () => {
+    for (const p of [
+      "archive.zip",
+      "doc.pdf",
+      "movie.mp4",
+      "audio.mp3",
+      "app.exe",
+      "font.woff2",
+      "secret.bin",
+      "Dockerfile",
+      "LICENSE",
+      ".gitignore",
+    ]) {
+      expect(previewKind(p)).toBeNull();
+    }
+  });
+});
+
+describe("resolvePreviewRelPath", () => {
+  const CWD = "/Users/me/proj";
+
+  it("passes relative paths through as-is", () => {
+    expect(resolvePreviewRelPath("README.md", CWD)).toBe("README.md");
+    expect(resolvePreviewRelPath("internal/a.go", CWD)).toBe("internal/a.go");
+  });
+
+  it("strips the cwd prefix from an absolute path inside the cwd", () => {
+    expect(resolvePreviewRelPath("/Users/me/proj/README.md", CWD)).toBe(
+      "README.md",
+    );
+    expect(
+      resolvePreviewRelPath("/Users/me/proj/internal/service/a.go", CWD),
+    ).toBe("internal/service/a.go");
+  });
+
+  it("rejects an absolute path outside the cwd", () => {
+    expect(resolvePreviewRelPath("/Users/other/secret.md", CWD)).toBeNull();
+    expect(resolvePreviewRelPath("/tmp/x.go", CWD)).toBeNull();
+  });
+
+  it("rejects absolute paths when there is no cwd", () => {
+    expect(resolvePreviewRelPath("/Users/me/proj/README.md", "")).toBeNull();
+  });
+
+  it("rejects non-previewable files regardless of path shape", () => {
+    expect(resolvePreviewRelPath("archive.zip", CWD)).toBeNull();
+    expect(resolvePreviewRelPath("/Users/me/proj/archive.zip", CWD)).toBeNull();
+  });
+
+  it("handles Windows absolute paths inside the cwd", () => {
+    expect(resolvePreviewRelPath("C:\\proj\\README.md", "C:\\proj")).toBe(
+      "README.md",
+    );
+    expect(resolvePreviewRelPath("C:\\proj\\a.go", "C:\\proj")).toBe("a.go");
+    expect(resolvePreviewRelPath("C:\\other\\a.go", "C:\\proj")).toBeNull();
+  });
+});

--- a/frontend/src/components/agentre/chat-context-sidebar/__tests__/previewable.test.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/__tests__/previewable.test.ts
@@ -95,6 +95,13 @@ describe("resolvePreviewRelPath", () => {
     expect(resolvePreviewRelPath("/Users/me/proj/README.md", "")).toBeNull();
   });
 
+  it("rejects relative paths too when there is no cwd", () => {
+    // 「变动」模式的行可能来自消息派生,即使会话没有 cwd 也会渲染;没有 cwd 后端
+    // 必回 WorkspaceFsNoCwd,预览按钮随行消失(spec「无 cwd ... 预览按钮随行消失」)。
+    expect(resolvePreviewRelPath("README.md", "")).toBeNull();
+    expect(resolvePreviewRelPath("internal/a.go", "")).toBeNull();
+  });
+
   it("rejects non-previewable files regardless of path shape", () => {
     expect(resolvePreviewRelPath("archive.zip", CWD)).toBeNull();
     expect(resolvePreviewRelPath("/Users/me/proj/archive.zip", CWD)).toBeNull();

--- a/frontend/src/components/agentre/chat-context-sidebar/previewable.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/previewable.ts
@@ -1,0 +1,134 @@
+/**
+ * 会话文件预览的可预览性判定与「路径 → 会话级 relPath」换算（spec「预览面板与入口」）。
+ *
+ * 「变动」模式的行路径可能来自工具调用的绝对路径：只有解析后落在会话 cwd 内的
+ * 文件才出预览按钮（越出 cwd 的一律不出）；相对路径原样当 relPath。「目录 / Git」
+ * 模式的路径本就相对 cwd，直接可用。任何不在扩展名 allowlist 内的文件不出预览按钮。
+ */ export type PreviewKind = "markdown" | "code" | "image";
+
+/** markdown 档只收 .md / .markdown；.mdx 含 JSX、GFM 渲染会碎，明确不入档。 */
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"]);
+
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".avif",
+  ".bmp",
+  ".ico",
+  ".svg",
+]);
+
+// 代码 / 文本 allowlist —— 与 lib/file-preview/monaco-language 的语言表对齐
+// （能高亮就给预览按钮），另加常见纯文本格式；markdown / 图片 / .mdx 不在这里。
+const CODE_TEXT_EXTENSIONS = new Set([
+  // web 前端 / 标记
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".json",
+  ".jsonc",
+  ".html",
+  ".htm",
+  ".xml",
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  // 文本格式 / 配置
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".txt",
+  ".log",
+  ".csv",
+  // shell / 脚本
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".py",
+  ".pyw",
+  ".rb",
+  ".php",
+  ".lua",
+  ".r",
+  ".pl",
+  ".ps1",
+  ".psd1",
+  ".psm1",
+  ".bat",
+  ".cmd",
+  // 系统 / 编译型
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".cxx",
+  ".hpp",
+  ".hh",
+  ".cs",
+  ".java",
+  ".go",
+  ".rs",
+  ".swift",
+  ".kt",
+  ".kts",
+  ".dart",
+  ".scala",
+  ".sc",
+  ".clj",
+  ".cljs",
+  ".cljc",
+  ".groovy",
+  ".gradle",
+  ".sql",
+]);
+
+function extensionOf(path: string): string {
+  const base = path.split("/").pop() ?? "";
+  const slash = base.lastIndexOf("\\");
+  const name = slash >= 0 ? base.slice(slash + 1) : base;
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return name.slice(dot).toLowerCase();
+}
+
+/** 按扩展名判定文件的可预览类型；不在 allowlist 内返回 null。 */
+export function previewKind(path: string): PreviewKind | null {
+  const ext = extensionOf(path);
+  if (MARKDOWN_EXTENSIONS.has(ext)) return "markdown";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (CODE_TEXT_EXTENSIONS.has(ext)) return "code";
+  return null;
+}
+
+const ABS_POSIX = /^\//;
+const ABS_WINDOWS = /^[A-Za-z]:[\\/]/;
+
+/**
+ * 把文件面板一条路径解析成可交给后端 ReadFile/GitFileContent 的会话级 relPath。
+ * 返回 null 表示该文件不出预览按钮（扩展名不在 allowlist，或绝对路径越出 cwd）。
+ * 相对路径（目录 / Git 模式）原样通过。
+ */
+export function resolvePreviewRelPath(
+  path: string,
+  cwd: string,
+): string | null {
+  if (previewKind(path) === null) return null;
+  if (!ABS_POSIX.test(path) && !ABS_WINDOWS.test(path)) return path;
+  if (cwd === "") return null;
+  const sep = cwd.includes("\\") ? "\\" : "/";
+  const prefix = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd : `${cwd}${sep}`;
+  if (path === cwd || !path.startsWith(prefix)) return null;
+  return path.slice(prefix.length);
+}

--- a/frontend/src/components/agentre/chat-context-sidebar/previewable.ts
+++ b/frontend/src/components/agentre/chat-context-sidebar/previewable.ts
@@ -117,16 +117,19 @@ const ABS_WINDOWS = /^[A-Za-z]:[\\/]/;
 
 /**
  * 把文件面板一条路径解析成可交给后端 ReadFile/GitFileContent 的会话级 relPath。
- * 返回 null 表示该文件不出预览按钮（扩展名不在 allowlist，或绝对路径越出 cwd）。
- * 相对路径（目录 / Git 模式）原样通过。
+ * 返回 null 表示该文件不出预览按钮（扩展名不在 allowlist，绝对路径越出 cwd，或
+ * 会话根本没有 cwd）。相对路径（目录 / Git 模式）原样通过。
  */
 export function resolvePreviewRelPath(
   path: string,
   cwd: string,
 ): string | null {
   if (previewKind(path) === null) return null;
-  if (!ABS_POSIX.test(path) && !ABS_WINDOWS.test(path)) return path;
+  // 无 cwd(自由会话 / 远端未配路径)时后端必然回 WorkspaceFsNoCwd,预览按钮
+  // 随行消失(spec「预览面板与入口」)——目录 / Git 模式本就不渲染行,这里覆盖
+  // 「变动」模式里消息派生出的相对路径行。
   if (cwd === "") return null;
+  if (!ABS_POSIX.test(path) && !ABS_WINDOWS.test(path)) return path;
   const sep = cwd.includes("\\") ? "\\" : "/";
   const prefix = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd : `${cwd}${sep}`;
   if (path === cwd || !path.startsWith(prefix)) return null;

--- a/frontend/src/components/agentre/chat-context-sidebar/views/directory-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/directory-view.tsx
@@ -191,7 +191,7 @@ export function DirectoryView({ sessionId, cwd, remote, showIgnored }: Props) {
             type="button"
             aria-label={t("chatContext.filePreview.open")}
             title={t("chatContext.filePreview.open")}
-            onClick={() => openPreview(sessionId, previewRelPath)}
+            onClick={() => openPreview(sessionId, previewRelPath, "directory")}
             className={cn(
               "ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground",
               previewPath === previewRelPath && "text-primary",

--- a/frontend/src/components/agentre/chat-context-sidebar/views/directory-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/directory-view.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
+  Eye,
   FileCode,
   Folder,
 } from "lucide-react";
@@ -12,9 +13,12 @@ import { WorkspaceFsListDir } from "@/../wailsjs/go/app/App";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
 import { useSessionStatus } from "@/stores/session-status-store";
 
 import type { workspace_fs_svc } from "@/../wailsjs/go/models";
+
+import { resolvePreviewRelPath } from "../previewable";
 
 import { errorText, PanelNotice, PanelSkeleton } from "./panel-feedback";
 import { indentStyle } from "./tree-indent";
@@ -132,6 +136,11 @@ export function DirectoryView({ sessionId, cwd, remote, showIgnored }: Props) {
 
   const canOpen = cwd !== "" && !remote;
   const openFile = useOpenFile(cwd);
+  // 当前被预览文件的 relPath(按会话);与某文件行预览按钮同路径时高亮它。
+  const previewPath = useChatSidebarStore(
+    (s) => s.previewBySession[sessionId]?.path,
+  );
+  const openPreview = useChatSidebarStore((s) => s.openPreview);
 
   if (cwd === "") {
     return <PanelNotice text={t("chatContext.directory.noCwd")} />;
@@ -158,36 +167,53 @@ export function DirectoryView({ sessionId, cwd, remote, showIgnored }: Props) {
     );
   }
 
-  const renderFile = (entry: Entry, relPath: string, depth: number) => (
-    <div
-      key={relPath}
-      data-testid="directory-row"
-      data-name={entry.name}
-      data-git-ignored={entry.gitIgnored ? "true" : undefined}
-      className={cn("flex items-center", entry.gitIgnored && "opacity-50")}
-      style={indentStyle(depth)}
-    >
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 py-1.5 pr-2.5 text-xs text-muted-foreground">
-        {/* 与目录 chevron 等宽的槽位，让同级目录名 / 文件名对齐。 */}
-        <span className="size-3.5 shrink-0" aria-hidden="true" />
-        <FileCode className="size-3.5 shrink-0" aria-hidden="true" />
-        <span className="min-w-0 flex-1 truncate font-mono" title={relPath}>
-          {entry.name}
-        </span>
+  const renderFile = (entry: Entry, relPath: string, depth: number) => {
+    const previewRelPath = resolvePreviewRelPath(relPath, cwd);
+    return (
+      <div
+        key={relPath}
+        data-testid="directory-row"
+        data-name={entry.name}
+        data-git-ignored={entry.gitIgnored ? "true" : undefined}
+        className={cn("flex items-center", entry.gitIgnored && "opacity-50")}
+        style={indentStyle(depth)}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 py-1.5 pr-2.5 text-xs text-muted-foreground">
+          {/* 与目录 chevron 等宽的槽位，让同级目录名 / 文件名对齐。 */}
+          <span className="size-3.5 shrink-0" aria-hidden="true" />
+          <FileCode className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate font-mono" title={relPath}>
+            {entry.name}
+          </span>
+        </div>
+        {previewRelPath !== null ? (
+          <button
+            type="button"
+            aria-label={t("chatContext.filePreview.open")}
+            title={t("chatContext.filePreview.open")}
+            onClick={() => openPreview(sessionId, previewRelPath)}
+            className={cn(
+              "ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground",
+              previewPath === previewRelPath && "text-primary",
+            )}
+          >
+            <Eye className="size-3" aria-hidden="true" />
+          </button>
+        ) : null}
+        {canOpen ? (
+          <button
+            type="button"
+            aria-label={t("chatContext.files.openFile")}
+            title={t("chatContext.files.openFile")}
+            onClick={() => openFile(relPath)}
+            className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ExternalLink className="size-3" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
-      {canOpen ? (
-        <button
-          type="button"
-          aria-label={t("chatContext.files.openFile")}
-          title={t("chatContext.files.openFile")}
-          onClick={() => openFile(relPath)}
-          className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ExternalLink className="size-3" aria-hidden="true" />
-        </button>
-      ) : null}
-    </div>
-  );
+    );
+  };
 
   const renderDir = (entry: Entry, relPath: string, depth: number) => {
     const isOpen = expanded.has(relPath);

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-panel.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-panel.tsx
@@ -91,6 +91,7 @@ export function FilesPanel({
       <div className="min-h-0 flex-1 overflow-auto">
         {mode === "changes" ? (
           <FilesView
+            sessionId={sessionId}
             files={files}
             cwd={cwd}
             remote={remote}
@@ -107,6 +108,7 @@ export function FilesPanel({
         ) : null}
         {mode === "git" ? (
           <GitView
+            sessionId={sessionId}
             cwd={cwd}
             remote={remote}
             scope={git.scope}

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -161,7 +161,7 @@ export function FilesView({
             type="button"
             aria-label={t("chatContext.filePreview.open")}
             title={t("chatContext.filePreview.open")}
-            onClick={() => openPreview(sessionId, previewRelPath)}
+            onClick={() => openPreview(sessionId, previewRelPath, "changes")}
             className={cn(
               "ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground",
               previewPath === previewRelPath && "text-primary",

--- a/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/files-view.tsx
@@ -2,18 +2,24 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
+  Eye,
   FileCode,
   Folder,
 } from "lucide-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 
+import { cn } from "@/lib/utils";
+import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
+
 import { deriveFileTree, type FileEntry, type FileTreeNode } from "../derive";
+import { resolvePreviewRelPath } from "../previewable";
 
 import { indentStyle } from "./tree-indent";
 import { useOpenFile } from "./use-open-file";
 
 type Props = {
+  sessionId: number;
   files: FileEntry[];
   cwd: string;
   remote: boolean;
@@ -38,10 +44,22 @@ function basename(path: string): string {
   return parts[parts.length - 1] ?? path;
 }
 
-export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
+export function FilesView({
+  sessionId,
+  files,
+  cwd,
+  remote,
+  onJumpToTurn,
+}: Props) {
   const { t } = useTranslation();
   const tree = React.useMemo(() => deriveFileTree(files), [files]);
   const filePathsKey = files.map((file) => file.path).join("\u0000");
+
+  // 当前被预览文件的 relPath(按会话);与某行的预览按钮同路径时高亮它。
+  const previewPath = useChatSidebarStore(
+    (s) => s.previewBySession[sessionId]?.path,
+  );
+  const openPreview = useChatSidebarStore((s) => s.openPreview);
 
   // 展开状态仅存组件内、不持久化；文件集合变化时重置为全部展开。
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
@@ -113,42 +131,59 @@ export function FilesView({ files, cwd, remote, onJumpToTurn }: Props) {
     );
   };
 
-  const renderFile = (entry: FileEntry, depth: number) => (
-    <div
-      key={entry.path}
-      className="flex items-center"
-      style={indentStyle(depth)}
-    >
-      <button
-        type="button"
-        onClick={() => onJumpToTurn(entry.lastTurn)}
-        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
-        title={entry.path}
+  const renderFile = (entry: FileEntry, depth: number) => {
+    const previewRelPath = resolvePreviewRelPath(entry.path, cwd);
+    return (
+      <div
+        key={entry.path}
+        className="flex items-center"
+        style={indentStyle(depth)}
       >
-        {/* 预留与目录 chevron 等宽的槽位，让同级目录名/文件名、图标列对齐 */}
-        <span className="size-3.5 shrink-0" aria-hidden="true" />
-        <FileCode
-          className="size-3.5 shrink-0 text-muted-foreground"
-          aria-hidden="true"
-        />
-        <span className="min-w-0 flex-1 truncate font-mono">
-          {basename(entry.path)}
-        </span>
-        <DiffBadge plus={entry.plus} minus={entry.minus} />
-      </button>
-      {canOpen ? (
         <button
           type="button"
-          aria-label={t("chatContext.files.openFile")}
-          title={t("chatContext.files.openFile")}
-          onClick={() => openFile(entry.path)}
-          className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+          onClick={() => onJumpToTurn(entry.lastTurn)}
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 pr-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50"
+          title={entry.path}
         >
-          <ExternalLink className="size-3" aria-hidden="true" />
+          {/* 预留与目录 chevron 等宽的槽位，让同级目录名/文件名、图标列对齐 */}
+          <span className="size-3.5 shrink-0" aria-hidden="true" />
+          <FileCode
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate font-mono">
+            {basename(entry.path)}
+          </span>
+          <DiffBadge plus={entry.plus} minus={entry.minus} />
         </button>
-      ) : null}
-    </div>
-  );
+        {previewRelPath !== null ? (
+          <button
+            type="button"
+            aria-label={t("chatContext.filePreview.open")}
+            title={t("chatContext.filePreview.open")}
+            onClick={() => openPreview(sessionId, previewRelPath)}
+            className={cn(
+              "ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground",
+              previewPath === previewRelPath && "text-primary",
+            )}
+          >
+            <Eye className="size-3" aria-hidden="true" />
+          </button>
+        ) : null}
+        {canOpen ? (
+          <button
+            type="button"
+            aria-label={t("chatContext.files.openFile")}
+            title={t("chatContext.files.openFile")}
+            onClick={() => openFile(entry.path)}
+            className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ExternalLink className="size-3" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <div className="flex flex-col gap-0.5 px-2 py-2.5">

--- a/frontend/src/components/agentre/chat-context-sidebar/views/git-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/git-view.tsx
@@ -148,7 +148,7 @@ export function GitView({
             previewActive={previewPath === previewRelPath}
             onPreview={
               previewRelPath !== null
-                ? () => openPreview(sessionId, previewRelPath)
+                ? () => openPreview(sessionId, previewRelPath, "git")
                 : null
             }
           />

--- a/frontend/src/components/agentre/chat-context-sidebar/views/git-view.tsx
+++ b/frontend/src/components/agentre/chat-context-sidebar/views/git-view.tsx
@@ -1,18 +1,23 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 
+import { Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useChatSidebarStore } from "@/stores/chat-sidebar-store";
 
 import type { TFunction } from "i18next";
 
 import { deriveGitRows, type GitRow } from "../git-rows";
+import { resolvePreviewRelPath } from "../previewable";
 
 import { PanelNotice, PanelSkeleton } from "./panel-feedback";
 import type { GitChangesState, GitScope } from "./use-git-changes";
 import { useOpenFile } from "./use-open-file";
 
 type Props = {
+  /** 会话 id：预览选中按会话存储。 */
+  sessionId: number;
   /** 会话工作目录；空串表示这个会话没有工作目录，直接出空态。 */
   cwd: string;
   remote: boolean;
@@ -57,6 +62,7 @@ function statusLabel(t: TFunction, status: string): string {
  * 行点击与「变动」模式一致：本地会话用系统默认应用打开，远端会话不提供打开。
  */
 export function GitView({
+  sessionId,
   cwd,
   remote,
   scope,
@@ -67,6 +73,11 @@ export function GitView({
   const { t } = useTranslation();
   const openFile = useOpenFile(cwd);
   const canOpen = cwd !== "" && !remote;
+  // 当前被预览文件的 relPath(按会话);与某行预览按钮同路径时高亮它。
+  const previewPath = useChatSidebarStore(
+    (s) => s.previewBySession[sessionId]?.path,
+  );
+  const openPreview = useChatSidebarStore((s) => s.openPreview);
 
   const changes = state.status === "loaded" ? state.view.changes : null;
   const rows = React.useMemo(() => deriveGitRows(changes), [changes]);
@@ -127,13 +138,22 @@ export function GitView({
 
   return (
     <div className="flex flex-col gap-0.5 px-2 py-2.5">
-      {rows.map((row) => (
-        <Row
-          key={row.path}
-          row={row}
-          onOpen={canOpen ? () => openFile(row.path) : null}
-        />
-      ))}
+      {rows.map((row) => {
+        const previewRelPath = resolvePreviewRelPath(row.path, cwd);
+        return (
+          <Row
+            key={row.path}
+            row={row}
+            onOpen={canOpen ? () => openFile(row.path) : null}
+            previewActive={previewPath === previewRelPath}
+            onPreview={
+              previewRelPath !== null
+                ? () => openPreview(sessionId, previewRelPath)
+                : null
+            }
+          />
+        );
+      })}
       {state.view.truncated ? (
         <div className="py-1.5 pr-2.5 pl-2 text-[11px] text-muted-foreground">
           {t("chatContext.git.truncated", { limit: rows.length })}
@@ -143,7 +163,17 @@ export function GitView({
   );
 }
 
-function Row({ row, onOpen }: { row: GitRow; onOpen: (() => void) | null }) {
+function Row({
+  row,
+  onOpen,
+  previewActive,
+  onPreview,
+}: {
+  row: GitRow;
+  onOpen: (() => void) | null;
+  previewActive: boolean;
+  onPreview: (() => void) | null;
+}) {
   const { t } = useTranslation();
   const meta = STATUS_META[row.status] ?? STATUS_META.modified;
   const body = (
@@ -175,29 +205,41 @@ function Row({ row, onOpen }: { row: GitRow; onOpen: (() => void) | null }) {
     </>
   );
   const className =
-    "flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2.5 pl-2 text-left text-xs text-muted-foreground";
-  const shared = {
-    "data-testid": "git-row",
-    "data-path": row.path,
-    "data-status": row.status,
-    title: row.oldPath ? `${row.oldPath} → ${row.path}` : row.path,
-  };
-  if (!onOpen) {
-    return (
-      <div {...shared} className={className}>
-        {body}
-      </div>
-    );
-  }
+    "flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 pr-2.5 pl-2 text-left text-xs text-muted-foreground";
   return (
-    <button
-      type="button"
-      {...shared}
-      onClick={onOpen}
-      className={cn(className, "transition-colors hover:bg-muted/50")}
+    <div
+      data-testid="git-row"
+      data-path={row.path}
+      data-status={row.status}
+      title={row.oldPath ? `${row.oldPath} → ${row.path}` : row.path}
+      className="flex items-center"
     >
-      {body}
-    </button>
+      {onOpen ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          className={cn(className, "transition-colors hover:bg-muted/50")}
+        >
+          {body}
+        </button>
+      ) : (
+        <div className={className}>{body}</div>
+      )}
+      {onPreview ? (
+        <button
+          type="button"
+          aria-label={t("chatContext.filePreview.open")}
+          title={t("chatContext.filePreview.open")}
+          onClick={onPreview}
+          className={cn(
+            "ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground",
+            previewActive && "text-primary",
+          )}
+        >
+          <Eye className="size-3" aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -82,6 +82,7 @@ import {
 } from "./chat";
 import type { LocalCommandHistoryScope } from "./chat-input";
 import { ChatContextSidebar } from "./chat-context-sidebar";
+import { FilePreviewPanel } from "./file-preview/file-preview-panel";
 import {
   clearCatchUp,
   registerTranscriptRowCounter,
@@ -2875,6 +2876,9 @@ function ChatPanel({
                 }}
               />
             ) : null}
+            {/* 最右一栏:文件预览面板。仅在选中了可预览文件时渲染(内部自行返回
+                null),打开占位、关闭释放宽度;宽高记忆独立 persistenceKey。 */}
+            <FilePreviewPanel sessionId={session?.id ?? 0} />
           </div>
         </main>
       )}

--- a/frontend/src/components/agentre/file-preview/__tests__/code-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/code-view.test.tsx
@@ -1,0 +1,112 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MonacoNS } from "@/lib/file-preview/monaco-loader";
+
+import { CodePreview } from "../code-view";
+
+// 真实 Monaco 在 happy-dom 里不可运行（worker / canvas）。测试走两条 mock 接缝：
+// 1) monaco prop 注入 fake 命名空间（本文件的默认路径）；
+// 2) vi.mock monaco-loader 返回 fake loadMonaco（下面 loadMonaco seam 测试）。
+// fake monaco 只实现组件用到的 editor API 面，断言组件把正确的选项转发给 Monaco。
+// vi.mock 必须位于模块顶层（vitest 未来会禁止嵌套）。
+const loaderMocks = vi.hoisted(() => ({ loadMonaco: vi.fn() }));
+vi.mock("@/lib/file-preview/monaco-loader", () => loaderMocks);
+
+type FakeEditor = {
+  options: Record<string, unknown>;
+  setValue: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+function createFakeMonaco() {
+  const editors: FakeEditor[] = [];
+  const editor = {
+    create: vi.fn(
+      (
+        _container: HTMLElement,
+        options: Record<string, unknown>,
+      ): FakeEditor => {
+        const e: FakeEditor = {
+          options,
+          setValue: vi.fn(),
+          dispose: vi.fn(),
+        };
+        editors.push(e);
+        return e;
+      },
+    ),
+  };
+  const monaco = { editor } as unknown as MonacoNS;
+  return { monaco, editor, editors };
+}
+
+describe("CodePreview", () => {
+  it("creates a readOnly monaco editor with the language inferred from path", () => {
+    const { monaco, editor } = createFakeMonaco();
+
+    render(<CodePreview value="const a = 1;" path="a.ts" monaco={monaco} />);
+
+    expect(editor.create).toHaveBeenCalledTimes(1);
+    const [container, options] = editor.create.mock.calls[0];
+    expect(container).toBeInstanceOf(HTMLElement);
+    expect(options).toMatchObject({
+      readOnly: true,
+      language: "typescript",
+      value: "const a = 1;",
+    });
+  });
+
+  it("defaults to plaintext for unknown extensions and honors an explicit language", () => {
+    const { monaco, editor } = createFakeMonaco();
+
+    const { rerender } = render(
+      <CodePreview value="x" path="a.weird" monaco={monaco} />,
+    );
+    expect(editor.create.mock.calls[0][1].language).toBe("plaintext");
+
+    rerender(
+      <CodePreview value="x" path="a.ts" language="json" monaco={monaco} />,
+    );
+    expect(editor.create).toHaveBeenCalledTimes(2);
+    expect(editor.create.mock.calls[1][1].language).toBe("json");
+  });
+
+  it("updates value on the same editor instance instead of recreating it", () => {
+    const { monaco, editor, editors } = createFakeMonaco();
+
+    const { rerender } = render(
+      <CodePreview value="v1" path="notes.txt" monaco={monaco} />,
+    );
+    rerender(<CodePreview value="v2" path="notes.txt" monaco={monaco} />);
+
+    expect(editor.create).toHaveBeenCalledTimes(1);
+    expect(editors[0].setValue).toHaveBeenCalledWith("v2");
+  });
+
+  it("disposes the editor on unmount", () => {
+    const { monaco, editors } = createFakeMonaco();
+
+    const { unmount } = render(
+      <CodePreview value="x" path="a.go" monaco={monaco} />,
+    );
+    unmount();
+
+    expect(editors[0].dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CodePreview loadMonaco seam", () => {
+  // 不传 monaco prop 时组件应经 monaco-loader 动态加载 —— 这是 task 6 测试
+  // vi.mock("@/lib/file-preview/monaco-loader") 时的接缝路径。
+
+  it("loads monaco through the loader when no monaco prop is injected", async () => {
+    const { monaco, editor } = createFakeMonaco();
+    loaderMocks.loadMonaco.mockResolvedValue(monaco);
+
+    render(<CodePreview value="x" path="a.go" />);
+
+    expect(loaderMocks.loadMonaco).toHaveBeenCalled();
+    await waitFor(() => expect(editor.create).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/components/agentre/file-preview/__tests__/code-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/code-view.test.tsx
@@ -22,6 +22,7 @@ type FakeEditor = {
 function createFakeMonaco() {
   const editors: FakeEditor[] = [];
   const editor = {
+    setTheme: vi.fn(),
     create: vi.fn(
       (
         _container: HTMLElement,
@@ -108,5 +109,25 @@ describe("CodePreview loadMonaco seam", () => {
 
     expect(loaderMocks.loadMonaco).toHaveBeenCalled();
     await waitFor(() => expect(editor.create).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("CodePreview theme following", () => {
+  it("sets the monaco theme on mount and re-themes when the app flips .dark", async () => {
+    document.documentElement.classList.remove("dark");
+    const { monaco, editor } = createFakeMonaco();
+
+    render(<CodePreview value="x" path="a.go" monaco={monaco} />);
+    await waitFor(() => expect(editor.create).toHaveBeenCalledTimes(1));
+    // 挂载时按当前主题涂一次（light）。
+    expect(editor.setTheme).toHaveBeenCalledWith("vs");
+
+    document.documentElement.classList.add("dark");
+    await waitFor(() =>
+      expect(editor.setTheme).toHaveBeenCalledWith("vs-dark"),
+    );
+
+    document.documentElement.classList.remove("dark");
+    await waitFor(() => expect(editor.setTheme).toHaveBeenLastCalledWith("vs"));
   });
 });

--- a/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
@@ -1,0 +1,111 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MonacoNS } from "@/lib/file-preview/monaco-loader";
+
+import { DiffPreview } from "../diff-view";
+
+type FakeModel = {
+  value: string;
+  language: string;
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+type FakeDiffEditor = {
+  options: Record<string, unknown>;
+  setModel: ReturnType<typeof vi.fn>;
+  getModel: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+function createFakeMonaco() {
+  const models: FakeModel[] = [];
+  const diffs: FakeDiffEditor[] = [];
+  const editor = {
+    createDiffEditor: vi.fn(
+      (
+        _container: HTMLElement,
+        options: Record<string, unknown>,
+      ): FakeDiffEditor => {
+        const d: FakeDiffEditor = {
+          options,
+          setModel: vi.fn(),
+          getModel: vi.fn(() => null),
+          dispose: vi.fn(),
+        };
+        diffs.push(d);
+        return d;
+      },
+    ),
+    createModel: vi.fn((value: string, language: string): FakeModel => {
+      const m: FakeModel = { value, language, dispose: vi.fn() };
+      models.push(m);
+      return m;
+    }),
+  };
+  const monaco = { editor } as unknown as MonacoNS;
+  return { monaco, editor, models, diffs };
+}
+
+describe("DiffPreview", () => {
+  it("creates a readOnly diff editor with original/modified models", () => {
+    const { monaco, editor, models, diffs } = createFakeMonaco();
+
+    render(
+      <DiffPreview
+        original={"line1\nline2"}
+        modified={"line1\nline3"}
+        path="a.ts"
+        monaco={monaco}
+      />,
+    );
+
+    expect(editor.createDiffEditor).toHaveBeenCalledTimes(1);
+    const [container, options] = editor.createDiffEditor.mock.calls[0];
+    expect(container).toBeInstanceOf(HTMLElement);
+    expect(options).toMatchObject({
+      readOnly: true,
+      renderSideBySide: true,
+    });
+
+    expect(editor.createModel).toHaveBeenCalledTimes(2);
+    expect(models[0]).toMatchObject({
+      value: "line1\nline2",
+      language: "typescript",
+    });
+    expect(models[1]).toMatchObject({
+      value: "line1\nline3",
+      language: "typescript",
+    });
+
+    expect(diffs[0].setModel).toHaveBeenCalledWith({
+      original: models[0],
+      modified: models[1],
+    });
+  });
+
+  it("rebuilds the diff when content changes and disposes the previous editor", () => {
+    const { monaco, editor, diffs } = createFakeMonaco();
+
+    const { rerender } = render(
+      <DiffPreview original="a" modified="b" path="x.txt" monaco={monaco} />,
+    );
+    rerender(
+      <DiffPreview original="a2" modified="b2" path="x.txt" monaco={monaco} />,
+    );
+
+    expect(editor.createDiffEditor).toHaveBeenCalledTimes(2);
+    expect(diffs[0].dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the diff editor on unmount", () => {
+    const { monaco, diffs } = createFakeMonaco();
+
+    const { unmount } = render(
+      <DiffPreview original="a" modified="b" path="x.go" monaco={monaco} />,
+    );
+    unmount();
+
+    expect(diffs[0].dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
@@ -22,6 +22,7 @@ function createFakeMonaco() {
   const models: FakeModel[] = [];
   const diffs: FakeDiffEditor[] = [];
   const editor = {
+    setTheme: vi.fn(),
     createDiffEditor: vi.fn(
       (
         _container: HTMLElement,

--- a/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/diff-view.test.tsx
@@ -109,4 +109,36 @@ describe("DiffPreview", () => {
 
     expect(diffs[0].dispose).toHaveBeenCalledTimes(1);
   });
+
+  // Monaco 里 createModel 建的模型登记在全局模型表里,编辑器 dispose 不会释放它们;
+  // 不显式 dispose 就每次重建都泄漏 2 个 TextModel(轮次结束重读 / 切文件都会重建)。
+  it("disposes the created models on unmount (no model-registry leak)", () => {
+    const { monaco, models } = createFakeMonaco();
+
+    const { unmount } = render(
+      <DiffPreview original="a" modified="b" path="x.go" monaco={monaco} />,
+    );
+    expect(models).toHaveLength(2);
+    unmount();
+
+    expect(models[0].dispose).toHaveBeenCalledTimes(1);
+    expect(models[1].dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the previous run's models when content changes", () => {
+    const { monaco, models } = createFakeMonaco();
+
+    const { rerender } = render(
+      <DiffPreview original="a" modified="b" path="x.go" monaco={monaco} />,
+    );
+    rerender(
+      <DiffPreview original="a2" modified="b2" path="x.go" monaco={monaco} />,
+    );
+
+    expect(models).toHaveLength(4);
+    expect(models[0].dispose).toHaveBeenCalledTimes(1);
+    expect(models[1].dispose).toHaveBeenCalledTimes(1);
+    expect(models[2].dispose).not.toHaveBeenCalled();
+    expect(models[3].dispose).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/agentre/file-preview/__tests__/markdown-source-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/markdown-source-view.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MonacoNS } from "@/lib/file-preview/monaco-loader";
+
+import { MarkdownSourceView } from "../markdown-source-view";
+
+function createFakeMonaco() {
+  const editor = {
+    create: vi.fn(
+      (_container: HTMLElement, options: Record<string, unknown>) => ({
+        options,
+        setValue: vi.fn(),
+        dispose: vi.fn(),
+      }),
+    ),
+  };
+  const monaco = { editor } as unknown as MonacoNS;
+  return { monaco, editor };
+}
+
+describe("MarkdownSourceView", () => {
+  it("renders raw markdown source through monaco with the markdown language", () => {
+    const { monaco, editor } = createFakeMonaco();
+
+    render(<MarkdownSourceView value={"# Title\n\nbody"} monaco={monaco} />);
+
+    expect(editor.create).toHaveBeenCalledTimes(1);
+    const [, options] = editor.create.mock.calls[0];
+    expect(options).toMatchObject({
+      readOnly: true,
+      language: "markdown",
+      value: "# Title\n\nbody",
+    });
+  });
+});

--- a/frontend/src/components/agentre/file-preview/__tests__/markdown-source-view.test.tsx
+++ b/frontend/src/components/agentre/file-preview/__tests__/markdown-source-view.test.tsx
@@ -7,6 +7,7 @@ import { MarkdownSourceView } from "../markdown-source-view";
 
 function createFakeMonaco() {
   const editor = {
+    setTheme: vi.fn(),
     create: vi.fn(
       (_container: HTMLElement, options: Record<string, unknown>) => ({
         options,

--- a/frontend/src/components/agentre/file-preview/code-view.tsx
+++ b/frontend/src/components/agentre/file-preview/code-view.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+import { monacoLanguageForPath } from "@/lib/file-preview/monaco-language";
+import type {
+  MonacoCodeEditor,
+  MonacoNS,
+} from "@/lib/file-preview/monaco-loader";
+
+import { resolveMonacoTheme, useMonaco } from "./use-monaco";
+
+export type CodePreviewProps = {
+  /** 文件正文（UTF-8）。内容变化时原地更新模型，不重建编辑器（保留滚动位置）。 */
+  value: string;
+  /** 文件路径：用于按扩展名推断语言（未知 → plaintext）。 */
+  path?: string;
+  /** 显式 Monaco 语言 id，优先于 path 推断。 */
+  language?: string;
+  /** 注入 seam：happy-dom 单测传入 fake monaco（见 monaco-loader 注释）。 */
+  monaco?: MonacoNS | null;
+  /** Monaco 无障碍标签（读屏）。 */
+  ariaLabel?: string;
+  className?: string;
+};
+
+// 只读代码 / 文本渲染器（Monaco）。语言按扩展名推断，未知扩展名纯文本。
+export function CodePreview({
+  value,
+  path,
+  language,
+  monaco,
+  ariaLabel,
+  className,
+}: CodePreviewProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const editorRef = React.useRef<MonacoCodeEditor | null>(null);
+  const ns = useMonaco(monaco);
+  const lang = language ?? (path ? monacoLanguageForPath(path) : "plaintext");
+
+  // 编辑器只建一次：ns / 语言 / 无障碍标签变化才重建；value 刷新走下方
+  // [value] effect 原地 setValue，避免轮次结束重读时重建编辑器丢滚动位置。
+  React.useEffect(() => {
+    if (!ns || !containerRef.current) return;
+    const editor = ns.editor.create(containerRef.current, {
+      value,
+      language: lang,
+      readOnly: true,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      fontSize: 13,
+      tabSize: 2,
+      ariaLabel,
+      theme: resolveMonacoTheme(),
+    });
+    editorRef.current = editor;
+    return () => {
+      editor.dispose();
+      editorRef.current = null;
+    };
+    // value 故意不进 deps：见上方注释，由 [value] effect 维护。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ns, lang, ariaLabel]);
+
+  React.useEffect(() => {
+    editorRef.current?.setValue(value);
+  }, [value]);
+
+  return <div ref={containerRef} className={className} />;
+}

--- a/frontend/src/components/agentre/file-preview/code-view.tsx
+++ b/frontend/src/components/agentre/file-preview/code-view.tsx
@@ -6,7 +6,11 @@ import type {
   MonacoNS,
 } from "@/lib/file-preview/monaco-loader";
 
-import { resolveMonacoTheme, useMonaco } from "./use-monaco";
+import {
+  resolveMonacoTheme,
+  useMonaco,
+  useMonacoThemeSync,
+} from "./use-monaco";
 
 export type CodePreviewProps = {
   /** 文件正文（UTF-8）。内容变化时原地更新模型，不重建编辑器（保留滚动位置）。 */
@@ -35,6 +39,7 @@ export function CodePreview({
   const editorRef = React.useRef<MonacoCodeEditor | null>(null);
   const ns = useMonaco(monaco);
   const lang = language ?? (path ? monacoLanguageForPath(path) : "plaintext");
+  useMonacoThemeSync(ns);
 
   // 编辑器只建一次：ns / 语言 / 无障碍标签变化才重建；value 刷新走下方
   // [value] effect 原地 setValue，避免轮次结束重读时重建编辑器丢滚动位置。

--- a/frontend/src/components/agentre/file-preview/diff-view.tsx
+++ b/frontend/src/components/agentre/file-preview/diff-view.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+
+import { monacoLanguageForPath } from "@/lib/file-preview/monaco-language";
+import type { MonacoNS } from "@/lib/file-preview/monaco-loader";
+
+import { resolveMonacoTheme, useMonaco } from "./use-monaco";
+
+export type DiffPreviewProps = {
+  /** 左列 = HEAD 版本（未跟踪文件传空串 → 全部新增）。 */
+  original: string;
+  /** 右列 = 工作区版本。 */
+  modified: string;
+  /** 文件路径：用于按扩展名推断语言（未知 → plaintext）。 */
+  path?: string;
+  /** 显式 Monaco 语言 id，优先于 path 推断。 */
+  language?: string;
+  /** 注入 seam：happy-dom 单测传入 fake monaco（见 monaco-loader 注释）。 */
+  monaco?: MonacoNS | null;
+  /** Monaco 无障碍标签（读屏）。 */
+  ariaLabel?: string;
+  className?: string;
+};
+
+// 只读 diff 渲染器（Monaco diff editor）：左 = HEAD 版本、右 = 工作区。
+// 与 CodePreview 复用同一份动态加载的 Monaco 命名空间单例（见 monaco-loader）。
+// 内容（original/modified）变化时重建 diff editor —— 预览刷新频率低（轮次结束 /
+// 切文件），重建可接受，且 setModel 模型所有权交由 diff editor 在 dispose 时释放。
+export function DiffPreview({
+  original,
+  modified,
+  path,
+  language,
+  monaco,
+  ariaLabel,
+  className,
+}: DiffPreviewProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const ns = useMonaco(monaco);
+  const lang = language ?? (path ? monacoLanguageForPath(path) : "plaintext");
+
+  React.useEffect(() => {
+    if (!ns || !containerRef.current) return;
+    const diff = ns.editor.createDiffEditor(containerRef.current, {
+      readOnly: true,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      fontSize: 13,
+      renderSideBySide: true,
+      ariaLabel,
+      theme: resolveMonacoTheme(),
+    });
+    diff.setModel({
+      original: ns.editor.createModel(original, lang),
+      modified: ns.editor.createModel(modified, lang),
+    });
+    return () => {
+      // dispose 时一并释放它持有的 original/modified 模型，无手动泄漏。
+      diff.dispose();
+    };
+  }, [ns, lang, original, modified, ariaLabel]);
+
+  return <div ref={containerRef} className={className} />;
+}

--- a/frontend/src/components/agentre/file-preview/diff-view.tsx
+++ b/frontend/src/components/agentre/file-preview/diff-view.tsx
@@ -55,13 +55,16 @@ export function DiffPreview({
       ariaLabel,
       theme: resolveMonacoTheme(),
     });
-    diff.setModel({
-      original: ns.editor.createModel(original, lang),
-      modified: ns.editor.createModel(modified, lang),
-    });
+    const originalModel = ns.editor.createModel(original, lang);
+    const modifiedModel = ns.editor.createModel(modified, lang);
+    diff.setModel({ original: originalModel, modified: modifiedModel });
     return () => {
-      // dispose 时一并释放它持有的 original/modified 模型，无手动泄漏。
       diff.dispose();
+      // Monaco 里 createModel 建的模型登记在全局模型表,编辑器 dispose 不会释放
+      // 它们;不显式 dispose 每次重建就泄漏 2 个 TextModel(轮次结束重读 / 切文件
+      // 都会重建)。先 diff.dispose() 解除编辑器引用,再释放模型。
+      originalModel.dispose();
+      modifiedModel.dispose();
     };
   }, [ns, lang, original, modified, ariaLabel]);
 

--- a/frontend/src/components/agentre/file-preview/diff-view.tsx
+++ b/frontend/src/components/agentre/file-preview/diff-view.tsx
@@ -3,7 +3,11 @@ import * as React from "react";
 import { monacoLanguageForPath } from "@/lib/file-preview/monaco-language";
 import type { MonacoNS } from "@/lib/file-preview/monaco-loader";
 
-import { resolveMonacoTheme, useMonaco } from "./use-monaco";
+import {
+  resolveMonacoTheme,
+  useMonaco,
+  useMonacoThemeSync,
+} from "./use-monaco";
 
 export type DiffPreviewProps = {
   /** 左列 = HEAD 版本（未跟踪文件传空串 → 全部新增）。 */
@@ -37,6 +41,7 @@ export function DiffPreview({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const ns = useMonaco(monaco);
   const lang = language ?? (path ? monacoLanguageForPath(path) : "plaintext");
+  useMonacoThemeSync(ns);
 
   React.useEffect(() => {
     if (!ns || !containerRef.current) return;

--- a/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
+++ b/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
@@ -70,15 +70,19 @@ const KIND_ICON: Record<PreviewKind, LucideIcon> = {
 /**
  * FilePreviewPanel 是会话「文件」面板的最右一栏预览面板（spec「状态与布局」）：
  * 仅在选中了可预览文件时渲染，可拖拽调宽（ResizableSidebar edge="left"，独立
- * persistenceKey），按文件类型分档（markdown 渲染/文本/双栏、代码文本/对比、
- * 图片无档）。读取走 WorkspaceFsReadFile / WorkspaceFsGitFileContent（会话级
- * relPath，本机 / 远端同一绑定）；本会话轮次结束（doneTick）自动重读刷新。
+ * persistenceKey）。markdown 三档（渲染/文本/双栏）；代码/文本无分段控件，首视图
+ * 由入口模式决定（目录→内容、Git/变动→与 HEAD 对比，spec 决策 9）；图片无档。
+ * 读取走 WorkspaceFsReadFile / WorkspaceFsGitFileContent（会话级 relPath，本机 /
+ * 远端同一绑定）；本会话轮次结束（doneTick）按 sourceMode 自动重读刷新。
  */
 export function FilePreviewPanel({ sessionId }: Props) {
   const { t } = useTranslation();
   const path = useChatSidebarStore((s) => s.previewBySession[sessionId]?.path);
   const storedSegment = useChatSidebarStore(
     (s) => s.previewBySession[sessionId]?.segment ?? null,
+  );
+  const sourceMode = useChatSidebarStore(
+    (s) => s.previewBySession[sessionId]?.sourceMode,
   );
   const setPreviewSegment = useChatSidebarStore((s) => s.setPreviewSegment);
   const clearPreview = useChatSidebarStore((s) => s.clearPreview);
@@ -119,18 +123,20 @@ export function FilePreviewPanel({ sessionId }: Props) {
     }, 200);
   }, [closing, clearPreview, sessionId]);
 
-  // 档位是面板状态:切文件保留,关面板 / 切会话回默认。这里把存储的档位按文件
-  // 类型钳到合法集合(markdown render/text/split,代码 text/diff,图片无)。
+  // 档位是面板状态:切文件保留,关面板 / 切会话回默认。markdown 的档位才是存储的
+  // segment(render/text/split);代码 / 文本没有分段控件,首视图由入口模式决定
+  // (showDiff)。这里把存储的档位按文件类型钳到合法集合。
   const kind: PreviewKind | null = path ? previewKind(path) : null;
   const effectiveSegment = React.useMemo(() => {
-    if (kind === "image") return null;
-    if (kind === "markdown") {
-      return storedSegment === "text" || storedSegment === "split"
-        ? storedSegment
-        : "render";
-    }
-    return storedSegment === "diff" ? "diff" : "text";
+    if (kind === "image" || kind === "code") return null;
+    return storedSegment === "text" || storedSegment === "split"
+      ? storedSegment
+      : "render";
   }, [kind, storedSegment]);
+  // 代码 / 文本从 Git / 变动模式打开 → 直接展示与 git HEAD 的对比；目录模式打开
+  // → 只读内容。markdown / 图片从任何模式都不对比（spec 决策 9）。
+  const showDiff =
+    kind === "code" && sourceMode != null && sourceMode !== "directory";
 
   // doneTick 每次本会话轮次结束自增一次;轮次结束是「文件可能变了」的唯一强信号,
   // 面板开着时据此重读(不读缓存,spec 决策 11)。
@@ -169,7 +175,7 @@ export function FilePreviewPanel({ sessionId }: Props) {
   }, [sessionId, path, doneTick, reloadKey]);
 
   React.useEffect(() => {
-    if (effectiveSegment !== "diff" || !path) {
+    if (!showDiff || !path) {
       setGitState({ status: "idle" });
       return;
     }
@@ -187,43 +193,36 @@ export function FilePreviewPanel({ sessionId }: Props) {
         setGitState({ status: "error", message: errorText(err) });
       },
     );
-  }, [sessionId, path, effectiveSegment, doneTick, reloadKey]);
+  }, [sessionId, path, showDiff, doneTick, reloadKey]);
 
   if (!path) return null;
 
   const dir = dirname(path);
   const Icon = KIND_ICON[kind ?? "code"];
+  // 只有 markdown 有分段控件（渲染/文本/双栏）；代码 / 文本与图片都没有（首视图
+  // 由入口模式决定，spec 决策 9）。
   const segments =
-    kind === "markdown"
-      ? (["render", "text", "split"] as const)
-      : kind === "code"
-        ? (["text", "diff"] as const)
-        : [];
-  const segmentLabel = (seg: FilePreviewSegment): string => {
-    switch (seg) {
-      case "render":
-        return t("chatContext.filePreview.segmentRender");
-      case "text":
-        return t("chatContext.filePreview.segmentText");
-      case "split":
-        return t("chatContext.filePreview.segmentSplit");
-      default:
-        return t("chatContext.filePreview.segmentDiff");
-    }
+    kind === "markdown" ? (["render", "text", "split"] as const) : [];
+  const SEGMENT_LABEL_KEY: Record<FilePreviewSegment, string> = {
+    render: "chatContext.filePreview.segmentRender",
+    text: "chatContext.filePreview.segmentText",
+    split: "chatContext.filePreview.segmentSplit",
   };
+  const segmentLabel = (seg: FilePreviewSegment): string =>
+    t(SEGMENT_LABEL_KEY[seg]);
 
   const readSettled = readPath === path;
   const gitSettled = gitPath === path;
   const isLoading =
     readState.status === "loading" ||
     !readSettled ||
-    (effectiveSegment === "diff" &&
+    (showDiff &&
       (gitState.status === "idle" ||
         gitState.status === "loading" ||
         !gitSettled));
 
   // 正文容器按内容变化重挂载 → 150ms 淡入(motion-reduce 停用);骨架屏不参与。
-  const contentKey = `${path}|${effectiveSegment}|${readState.status}|${gitState.status}`;
+  const contentKey = `${path}|${effectiveSegment}|${showDiff}|${readState.status}|${gitState.status}`;
 
   return (
     <ResizableSidebar
@@ -305,6 +304,7 @@ export function FilePreviewPanel({ sessionId }: Props) {
             <PanelBody
               kind={kind}
               segment={effectiveSegment}
+              showDiff={showDiff}
               readState={readState}
               gitState={gitState}
               path={path}
@@ -320,6 +320,7 @@ export function FilePreviewPanel({ sessionId }: Props) {
 function PanelBody({
   kind,
   segment,
+  showDiff,
   readState,
   gitState,
   path,
@@ -327,6 +328,7 @@ function PanelBody({
 }: {
   kind: PreviewKind | null;
   segment: FilePreviewSegment | null;
+  showDiff: boolean;
   readState: ReadState;
   gitState: GitState;
   path: string;
@@ -408,7 +410,8 @@ function PanelBody({
     );
   }
 
-  if (segment === "diff") {
+  if (showDiff) {
+    // 代码 / 文本从 Git / 变动模式打开:左 HEAD 版本 / 右工作区,增删行底色区分。
     if (gitState.status === "error") {
       return (
         <PreviewMessage

--- a/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
+++ b/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
@@ -1,0 +1,506 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  FileCode,
+  FileImage,
+  FileText,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import {
+  WorkspaceFsGitFileContent,
+  WorkspaceFsReadFile,
+} from "@/../wailsjs/go/app/App";
+import type { workspace_fs_svc } from "@/../wailsjs/go/models";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  useChatSidebarStore,
+  type FilePreviewSegment,
+} from "@/stores/chat-sidebar-store";
+import { useSessionStatus } from "@/stores/session-status-store";
+
+import type { PreviewKind } from "../chat-context-sidebar/previewable";
+import { previewKind } from "../chat-context-sidebar/previewable";
+import {
+  errorText,
+  PanelNotice,
+  PanelSkeleton,
+} from "../chat-context-sidebar/views/panel-feedback";
+import { MarkdownText } from "../markdown-text";
+import { ResizableSidebar } from "../resizable-sidebar";
+
+import { CodePreview } from "./code-view";
+import { DiffPreview } from "./diff-view";
+import { MarkdownSourceView } from "./markdown-source-view";
+
+type ReadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "loaded"; view: workspace_fs_svc.ReadFileView };
+
+type GitState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "loaded"; view: workspace_fs_svc.GitFileContentView };
+
+type Props = {
+  sessionId: number;
+};
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] ?? path;
+}
+
+function dirname(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i > 0 ? path.slice(0, i + 1) : "";
+}
+
+const KIND_ICON: Record<PreviewKind, LucideIcon> = {
+  markdown: FileText,
+  code: FileCode,
+  image: FileImage,
+};
+
+/**
+ * FilePreviewPanel 是会话「文件」面板的最右一栏预览面板（spec「状态与布局」）：
+ * 仅在选中了可预览文件时渲染，可拖拽调宽（ResizableSidebar edge="left"，独立
+ * persistenceKey），按文件类型分档（markdown 渲染/文本/双栏、代码文本/对比、
+ * 图片无档）。读取走 WorkspaceFsReadFile / WorkspaceFsGitFileContent（会话级
+ * relPath，本机 / 远端同一绑定）；本会话轮次结束（doneTick）自动重读刷新。
+ */
+export function FilePreviewPanel({ sessionId }: Props) {
+  const { t } = useTranslation();
+  const path = useChatSidebarStore((s) => s.previewBySession[sessionId]?.path);
+  const storedSegment = useChatSidebarStore(
+    (s) => s.previewBySession[sessionId]?.segment ?? null,
+  );
+  const setPreviewSegment = useChatSidebarStore((s) => s.setPreviewSegment);
+  const clearPreview = useChatSidebarStore((s) => s.clearPreview);
+
+  // 切换会话：关闭面板、清空上一个会话的选中、档位回默认（spec 决策 12）。
+  const prevSessionRef = React.useRef(sessionId);
+  React.useEffect(() => {
+    const prev = prevSessionRef.current;
+    if (prev !== sessionId) {
+      clearPreview(prev);
+      prevSessionRef.current = sessionId;
+    }
+  }, [sessionId, clearPreview]);
+
+  // 关闭按钮的滑出动画：先本地置 closing 播放 200ms 出场，再清空选中卸载面板。
+  const [closing, setClosing] = React.useState(false);
+  const closeTimerRef = React.useRef<number | null>(null);
+  React.useEffect(
+    () => () => {
+      if (closeTimerRef.current != null)
+        window.clearTimeout(closeTimerRef.current);
+    },
+    [],
+  );
+  const handleClose = React.useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    closeTimerRef.current = window.setTimeout(() => {
+      clearPreview(sessionId);
+      setClosing(false);
+    }, 200);
+  }, [closing, clearPreview, sessionId]);
+
+  // 档位是面板状态:切文件保留,关面板 / 切会话回默认。这里把存储的档位按文件
+  // 类型钳到合法集合(markdown render/text/split,代码 text/diff,图片无)。
+  const kind: PreviewKind | null = path ? previewKind(path) : null;
+  const effectiveSegment = React.useMemo(() => {
+    if (kind === "image") return null;
+    if (kind === "markdown") {
+      return storedSegment === "text" || storedSegment === "split"
+        ? storedSegment
+        : "render";
+    }
+    return storedSegment === "diff" ? "diff" : "text";
+  }, [kind, storedSegment]);
+
+  // doneTick 每次本会话轮次结束自增一次;轮次结束是「文件可能变了」的唯一强信号,
+  // 面板开着时据此重读(不读缓存,spec 决策 11)。
+  const doneTick = useSessionStatus(sessionId)?.doneTick ?? 0;
+
+  const [readState, setReadState] = React.useState<ReadState>({
+    status: "loading",
+  });
+  const [gitState, setGitState] = React.useState<GitState>({ status: "idle" });
+  const [reloadKey, setReloadKey] = React.useState(0);
+  const readGenRef = React.useRef(0);
+  const gitGenRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (!path) return;
+    readGenRef.current += 1;
+    const gen = readGenRef.current;
+    setReadState({ status: "loading" });
+    WorkspaceFsReadFile(sessionId, path).then(
+      (view) => {
+        if (readGenRef.current !== gen) return;
+        setReadState({ status: "loaded", view });
+      },
+      (err: unknown) => {
+        if (readGenRef.current !== gen) return;
+        setReadState({ status: "error", message: errorText(err) });
+      },
+    );
+  }, [sessionId, path, doneTick, reloadKey]);
+
+  React.useEffect(() => {
+    if (effectiveSegment !== "diff" || !path) {
+      setGitState({ status: "idle" });
+      return;
+    }
+    gitGenRef.current += 1;
+    const gen = gitGenRef.current;
+    setGitState({ status: "loading" });
+    WorkspaceFsGitFileContent(sessionId, path).then(
+      (view) => {
+        if (gitGenRef.current !== gen) return;
+        setGitState({ status: "loaded", view });
+      },
+      (err: unknown) => {
+        if (gitGenRef.current !== gen) return;
+        setGitState({ status: "error", message: errorText(err) });
+      },
+    );
+  }, [sessionId, path, effectiveSegment, doneTick, reloadKey]);
+
+  if (!path) return null;
+
+  const dir = dirname(path);
+  const Icon = KIND_ICON[kind ?? "code"];
+  const segments =
+    kind === "markdown"
+      ? (["render", "text", "split"] as const)
+      : kind === "code"
+        ? (["text", "diff"] as const)
+        : [];
+  const segmentLabel = (seg: FilePreviewSegment): string => {
+    switch (seg) {
+      case "render":
+        return t("chatContext.filePreview.segmentRender");
+      case "text":
+        return t("chatContext.filePreview.segmentText");
+      case "split":
+        return t("chatContext.filePreview.segmentSplit");
+      default:
+        return t("chatContext.filePreview.segmentDiff");
+    }
+  };
+
+  const isLoading =
+    readState.status === "loading" ||
+    (effectiveSegment === "diff" &&
+      (gitState.status === "idle" || gitState.status === "loading"));
+
+  // 正文容器按内容变化重挂载 → 150ms 淡入(motion-reduce 停用);骨架屏不参与。
+  const contentKey = `${path}|${effectiveSegment}|${readState.status}|${gitState.status}`;
+
+  return (
+    <ResizableSidebar
+      persistenceKey="file-preview"
+      ariaLabel={t("chatContext.filePreview.panelAria")}
+      edge="left"
+      defaultWidth={440}
+      className={cn(
+        "overflow-hidden",
+        closing
+          ? "animate-out slide-out-to-right-6 duration-200 ease-out motion-reduce:animate-none"
+          : "animate-in slide-in-from-right-6 duration-200 ease-out motion-reduce:animate-none",
+      )}
+    >
+      <header
+        className="flex h-10 shrink-0 items-center gap-1.5 border-b border-border pl-3 pr-2"
+        data-testid="file-preview-header"
+      >
+        <Icon
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span
+          className="shrink truncate font-mono text-xs font-semibold"
+          title={path}
+        >
+          {basename(path)}
+        </span>
+        {dir !== "" ? (
+          <span
+            className="min-w-0 flex-1 truncate font-mono text-[10px] text-muted-foreground"
+            title={dir}
+          >
+            {dir}
+          </span>
+        ) : null}
+        {segments.length > 1 && effectiveSegment !== null ? (
+          <div
+            role="group"
+            aria-label={t("chatContext.filePreview.segmentGroup")}
+            className="flex shrink-0 items-center rounded-md border border-border p-0.5"
+          >
+            {segments.map((seg) => (
+              <button
+                key={seg}
+                type="button"
+                aria-pressed={effectiveSegment === seg}
+                onClick={() => setPreviewSegment(sessionId, seg)}
+                className={cn(
+                  "rounded px-1.5 py-0.5 text-[10px] transition-colors duration-150",
+                  effectiveSegment === seg
+                    ? "bg-accent font-semibold text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {segmentLabel(seg)}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <button
+          type="button"
+          aria-label={t("chatContext.filePreview.close")}
+          title={t("chatContext.filePreview.close")}
+          onClick={handleClose}
+          className="ml-0.5 shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="size-4" aria-hidden="true" />
+        </button>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {isLoading ? (
+          <PanelSkeleton label={t("chatContext.filePreview.loading")} />
+        ) : (
+          <div
+            key={contentKey}
+            className="flex min-h-0 flex-1 flex-col animate-in fade-in duration-150 motion-reduce:animate-none"
+          >
+            <PanelBody
+              kind={kind}
+              segment={effectiveSegment}
+              readState={readState}
+              gitState={gitState}
+              path={path}
+              onRetry={() => setReloadKey((k) => k + 1)}
+            />
+          </div>
+        )}
+      </div>
+    </ResizableSidebar>
+  );
+}
+
+function PanelBody({
+  kind,
+  segment,
+  readState,
+  gitState,
+  path,
+  onRetry,
+}: {
+  kind: PreviewKind | null;
+  segment: FilePreviewSegment | null;
+  readState: ReadState;
+  gitState: GitState;
+  path: string;
+  onRetry: () => void;
+}) {
+  const { t } = useTranslation();
+
+  if (readState.status === "error") {
+    return (
+      <PreviewMessage
+        text={readState.message || t("chatContext.filePreview.readFailed")}
+        onRetry={onRetry}
+      />
+    );
+  }
+  if (readState.status === "loading") return null;
+
+  const view = readState.view;
+  if (view.binary) {
+    return (
+      <PreviewMessage
+        text={t("chatContext.filePreview.binary")}
+        hint={t("chatContext.filePreview.binaryHint")}
+        onRetry={onRetry}
+      />
+    );
+  }
+  if (view.tooLarge) {
+    return (
+      <PreviewMessage
+        text={t("chatContext.filePreview.tooLarge")}
+        hint={
+          kind === "image"
+            ? t("chatContext.filePreview.tooLargeImageHint")
+            : t("chatContext.filePreview.tooLargeTextHint")
+        }
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  if (kind === "image") {
+    return (
+      <div
+        className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4"
+        style={{
+          // 棋盘格底:衬托透明图(png)。
+          backgroundImage:
+            "repeating-conic-gradient(var(--muted) 0% 25%, transparent 0% 50%)",
+          backgroundSize: "16px 16px",
+        }}
+      >
+        <img
+          src={`data:${view.contentType};base64,${view.content}`}
+          alt={basename(path)}
+          className="max-h-full max-w-full rounded-md object-contain shadow-sm"
+        />
+      </div>
+    );
+  }
+
+  if (kind === "markdown" && segment === "split") {
+    return (
+      <div className="flex min-h-0 flex-1">
+        <div className="min-w-0 flex-1 overflow-auto border-r border-border">
+          <MarkdownSourceView
+            value={view.content}
+            path={path}
+            ariaLabel={t("chatContext.filePreview.sourceAria", {
+              name: basename(path),
+            })}
+            className="h-full"
+          />
+        </div>
+        <div className="min-w-0 flex-1 overflow-auto px-4 py-3">
+          <MarkdownText text={view.content} />
+        </div>
+      </div>
+    );
+  }
+
+  if (segment === "diff") {
+    if (gitState.status === "error") {
+      return (
+        <PreviewMessage
+          text={gitState.message || t("chatContext.filePreview.readFailed")}
+          onRetry={onRetry}
+        />
+      );
+    }
+    if (gitState.status !== "loaded") return null;
+    if (gitState.view.notARepo) {
+      return (
+        <PreviewMessage
+          text={t("chatContext.filePreview.noGitBaseline")}
+          hint={t("chatContext.filePreview.noGitBaselineHint")}
+          onRetry={onRetry}
+        />
+      );
+    }
+    return (
+      <>
+        <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border bg-muted px-3 text-[10px] text-muted-foreground">
+          <span className="font-mono">
+            {t("chatContext.filePreview.diffHeader")}
+          </span>
+          <span className="ml-auto inline-flex items-center gap-3">
+            <span className="inline-flex items-center gap-1">
+              <span
+                aria-hidden="true"
+                className="size-2 rounded-[2px] bg-status-running/30"
+              />
+              {t("chatContext.filePreview.diffLegendAdded")}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <span
+                aria-hidden="true"
+                className="size-2 rounded-[2px] bg-destructive/30"
+              />
+              {t("chatContext.filePreview.diffLegendDeleted")}
+            </span>
+          </span>
+        </div>
+        <DiffPreview
+          original={gitState.view.content}
+          modified={view.content}
+          path={path}
+          ariaLabel={t("chatContext.filePreview.diffAria", {
+            name: basename(path),
+          })}
+          className="min-h-0 flex-1"
+        />
+      </>
+    );
+  }
+
+  if (kind === "markdown" && segment === "render") {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+        <MarkdownText text={view.content} />
+      </div>
+    );
+  }
+
+  if (kind === "markdown") {
+    // markdown 文本档:原始源码,Monaco 只读(markdown 语言)。
+    return (
+      <MarkdownSourceView
+        value={view.content}
+        path={path}
+        ariaLabel={t("chatContext.filePreview.sourceAria", {
+          name: basename(path),
+        })}
+        className="min-h-0 flex-1"
+      />
+    );
+  }
+
+  // 代码 / 文本 文本档:Monaco 只读,按扩展名语言高亮。
+  return (
+    <CodePreview
+      value={view.content}
+      path={path}
+      ariaLabel={t("chatContext.filePreview.codeAria", {
+        name: basename(path),
+      })}
+      className="min-h-0 flex-1"
+    />
+  );
+}
+
+/** 面板内错误 / 说明态:复用 panel-feedback 的 PanelNotice + 一个重试按钮。 */
+function PreviewMessage({
+  text,
+  hint,
+  onRetry,
+}: {
+  text: string;
+  hint?: string;
+  onRetry: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center px-4 pb-4">
+      <PanelNotice text={text} hint={hint} />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 text-[11px]"
+        onClick={onRetry}
+      >
+        {t("chatContext.filePreview.retry")}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
+++ b/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
@@ -105,9 +105,16 @@ export function FilePreviewPanel({ sessionId }: Props) {
   );
   const handleClose = React.useCallback(() => {
     if (closing) return;
+    // 记下关闭那一刻的选中,出场动画(200ms)期间用户可能已打开另一个文件
+    // (openPreview):只有选中仍是关闭那一刻的文件才真正清空,否则旧 timer 会把
+    // 用户的新选择一起清掉(面板白关、新文件白选)。
+    const selectedPath =
+      useChatSidebarStore.getState().previewBySession[sessionId]?.path;
     setClosing(true);
     closeTimerRef.current = window.setTimeout(() => {
-      clearPreview(sessionId);
+      const current =
+        useChatSidebarStore.getState().previewBySession[sessionId]?.path;
+      if (current === selectedPath) clearPreview(sessionId);
       setClosing(false);
     }, 200);
   }, [closing, clearPreview, sessionId]);

--- a/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
+++ b/frontend/src/components/agentre/file-preview/file-preview-panel.tsx
@@ -136,11 +136,18 @@ export function FilePreviewPanel({ sessionId }: Props) {
   const [reloadKey, setReloadKey] = React.useState(0);
   const readGenRef = React.useRef(0);
   const gitGenRef = React.useRef(0);
+  // readPath/gitPath 记录当前 readState/gitState 对应的是哪个文件的结果。切换文件
+  // 后、effect 把状态重置成 loading 之前的那一帧,readState/gitState 还是旧文件
+  // 的内容——若不加这道「结果必须匹配当前 path」的闸门,那一帧会把旧文件正文渲染
+  // 在新文件名之下(一帧错内容,spec 决策 12 的切文件场景)。
+  const [readPath, setReadPath] = React.useState<string | null>(null);
+  const [gitPath, setGitPath] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     if (!path) return;
     readGenRef.current += 1;
     const gen = readGenRef.current;
+    setReadPath(path);
     setReadState({ status: "loading" });
     WorkspaceFsReadFile(sessionId, path).then(
       (view) => {
@@ -161,6 +168,7 @@ export function FilePreviewPanel({ sessionId }: Props) {
     }
     gitGenRef.current += 1;
     const gen = gitGenRef.current;
+    setGitPath(path);
     setGitState({ status: "loading" });
     WorkspaceFsGitFileContent(sessionId, path).then(
       (view) => {
@@ -197,10 +205,15 @@ export function FilePreviewPanel({ sessionId }: Props) {
     }
   };
 
+  const readSettled = readPath === path;
+  const gitSettled = gitPath === path;
   const isLoading =
     readState.status === "loading" ||
+    !readSettled ||
     (effectiveSegment === "diff" &&
-      (gitState.status === "idle" || gitState.status === "loading"));
+      (gitState.status === "idle" ||
+        gitState.status === "loading" ||
+        !gitSettled));
 
   // 正文容器按内容变化重挂载 → 150ms 淡入(motion-reduce 停用);骨架屏不参与。
   const contentKey = `${path}|${effectiveSegment}|${readState.status}|${gitState.status}`;

--- a/frontend/src/components/agentre/file-preview/markdown-source-view.tsx
+++ b/frontend/src/components/agentre/file-preview/markdown-source-view.tsx
@@ -1,0 +1,8 @@
+import { CodePreview, type CodePreviewProps } from "./code-view";
+
+// markdown 源码只读档：走与代码/文本完全相同的 Monaco 路径（spec 决策 7），
+// 显式锁 markdown 语言做源码语法着色；绝不 GFM 渲染 —— 渲染档由 MarkdownText
+// 承担，这里只负责「看原始 markdown 源码」。
+export function MarkdownSourceView(props: Omit<CodePreviewProps, "language">) {
+  return <CodePreview {...props} language="markdown" />;
+}

--- a/frontend/src/components/agentre/file-preview/use-monaco.ts
+++ b/frontend/src/components/agentre/file-preview/use-monaco.ts
@@ -35,3 +35,23 @@ export function resolveMonacoTheme(): "vs-dark" | "vs" {
     ? "vs-dark"
     : "vs";
 }
+
+// 让已创建的 Monaco 编辑器跟随应用明暗切换（terminal-panel 同款 MutationObserver
+// 先例）：编辑器建好后主题是全局的，app 在 documentElement 上翻转 .dark 时调
+// ns.editor.setTheme 重涂；不重建编辑器，保留滚动位置。单测 fake monaco 需带
+// editor.setTheme（见各组件测试的 fake 定义）。
+export function useMonacoThemeSync(ns: MonacoNS | null): void {
+  React.useEffect(() => {
+    if (!ns || typeof document === "undefined") return;
+    const apply = () => ns.editor.setTheme(resolveMonacoTheme());
+    // 挂载时先按当前主题涂一次（与 terminal 同一理由：App 的 layout effect 可能
+    // 晚于本组件首次 mount，observer 看不到那次 class 翻转）。
+    apply();
+    const observer = new MutationObserver(apply);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, [ns]);
+}

--- a/frontend/src/components/agentre/file-preview/use-monaco.ts
+++ b/frontend/src/components/agentre/file-preview/use-monaco.ts
@@ -1,0 +1,37 @@
+import * as React from "react";
+
+import { loadMonaco, type MonacoNS } from "@/lib/file-preview/monaco-loader";
+
+// 解析 Monaco 命名空间：注入（单测 / 特殊宿主）优先，否则异步经 loadMonaco()
+// 动态加载。加载失败时静默返回 null，容器保持空白，由调用方的错误态兜底。
+export function useMonaco(injected?: MonacoNS | null): MonacoNS | null {
+  const [ns, setNs] = React.useState<MonacoNS | null>(injected ?? null);
+
+  React.useEffect(() => {
+    if (injected) {
+      setNs(injected);
+      return;
+    }
+    let cancelled = false;
+    loadMonaco()
+      .then((m) => {
+        if (!cancelled) setNs(m);
+      })
+      .catch(() => {
+        /* 加载失败：保持 null，容器留空。 */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [injected]);
+
+  return ns;
+}
+
+// Monaco 主题跟随应用 .dark class（与 xterm 的 terminal-theme 同一判定）。
+export function resolveMonacoTheme(): "vs-dark" | "vs" {
+  return typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+    ? "vs-dark"
+    : "vs";
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -659,6 +659,32 @@
         "untracked": "Untracked"
       }
     },
+    "filePreview": {
+      "panelAria": "File preview",
+      "open": "Preview",
+      "close": "Close preview",
+      "loading": "Reading file…",
+      "readFailed": "Failed to read file",
+      "retry": "Retry",
+      "binary": "Binary file, cannot preview",
+      "binaryHint": "This file type cannot be previewed",
+      "tooLarge": "File too large to preview",
+      "tooLargeTextHint": "Text larger than 1 MiB",
+      "tooLargeImageHint": "Image larger than 10 MiB",
+      "noGitBaseline": "No git baseline to compare",
+      "noGitBaselineHint": "This directory is not a git repository",
+      "segmentGroup": "View mode",
+      "segmentRender": "Render",
+      "segmentText": "Text",
+      "segmentSplit": "Split",
+      "segmentDiff": "Diff",
+      "diffHeader": "Diff · HEAD → working tree",
+      "diffLegendAdded": "Added",
+      "diffLegendDeleted": "Deleted",
+      "sourceAria": "Raw source of {{name}}",
+      "codeAria": "Code preview of {{name}}",
+      "diffAria": "{{name}} compared with HEAD"
+    },
     "outline": {
       "empty": "No messages in this session",
       "label": "Outline",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -677,7 +677,6 @@
       "segmentRender": "Render",
       "segmentText": "Text",
       "segmentSplit": "Split",
-      "segmentDiff": "Diff",
       "diffHeader": "Diff · HEAD → working tree",
       "diffLegendAdded": "Added",
       "diffLegendDeleted": "Deleted",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -659,6 +659,32 @@
         "untracked": "未跟踪"
       }
     },
+    "filePreview": {
+      "panelAria": "文件预览",
+      "open": "预览",
+      "close": "关闭预览",
+      "loading": "正在读取文件…",
+      "readFailed": "读取文件失败",
+      "retry": "重试",
+      "binary": "二进制文件，无法预览",
+      "binaryHint": "该文件类型不支持预览",
+      "tooLarge": "文件过大，无法预览",
+      "tooLargeTextHint": "文本超过 1 MiB",
+      "tooLargeImageHint": "图片超过 10 MiB",
+      "noGitBaseline": "没有可对比的 git 基准",
+      "noGitBaselineHint": "该目录不是 git 仓库",
+      "segmentGroup": "视图档位",
+      "segmentRender": "渲染",
+      "segmentText": "文本",
+      "segmentSplit": "双栏",
+      "segmentDiff": "对比",
+      "diffHeader": "对比 · HEAD → 工作区",
+      "diffLegendAdded": "新增",
+      "diffLegendDeleted": "删除",
+      "sourceAria": "{{name}} 的原始源码",
+      "codeAria": "{{name}} 代码预览",
+      "diffAria": "{{name}} 与 HEAD 的对比"
+    },
     "outline": {
       "empty": "本会话还没有消息",
       "label": "大纲",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -677,7 +677,6 @@
       "segmentRender": "渲染",
       "segmentText": "文本",
       "segmentSplit": "双栏",
-      "segmentDiff": "对比",
       "diffHeader": "对比 · HEAD → 工作区",
       "diffLegendAdded": "新增",
       "diffLegendDeleted": "删除",

--- a/frontend/src/lib/file-preview/monaco-basic-languages.d.ts
+++ b/frontend/src/lib/file-preview/monaco-basic-languages.d.ts
@@ -1,0 +1,4 @@
+// monaco-editor 只为其公共 API（editor.api 等）提供类型；basic-languages 的
+// monaco.contribution 是纯侧效应注册模块（全部内置语言的词法 tokenizer），
+// 包内无 .d.ts。这里声明为空模块即可，只用于 `await import(...)` 触发注册。
+declare module "monaco-editor/basic-languages/monaco.contribution";

--- a/frontend/src/lib/file-preview/monaco-json.test.ts
+++ b/frontend/src/lib/file-preview/monaco-json.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { MonacoNS } from "./monaco-loader";
+import { jsonTokenProvider, registerJsonLanguage } from "./monaco-json";
+
+function fakeLanguages() {
+  const register = vi.fn();
+  const setLanguageConfiguration = vi.fn();
+  const setMonarchTokensProvider = vi.fn();
+  const languages = {
+    register,
+    setLanguageConfiguration,
+    setMonarchTokensProvider,
+  };
+  const monaco = { languages } as unknown as MonacoNS;
+  return {
+    monaco,
+    register,
+    setLanguageConfiguration,
+    setMonarchTokensProvider,
+  };
+}
+
+describe("registerJsonLanguage", () => {
+  it("registers the json language with the jsonc extension alias", () => {
+    const { monaco, register, setMonarchTokensProvider } = fakeLanguages();
+
+    registerJsonLanguage(monaco);
+
+    expect(register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "json",
+        extensions: expect.arrayContaining([".json", ".jsonc"]),
+      }),
+    );
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith(
+      "json",
+      jsonTokenProvider,
+    );
+  });
+
+  it("wires JSONC comment configuration (line + block) for the read-only editor", () => {
+    const { monaco, setLanguageConfiguration } = fakeLanguages();
+
+    registerJsonLanguage(monaco);
+
+    expect(setLanguageConfiguration).toHaveBeenCalledWith(
+      "json",
+      expect.objectContaining({
+        comments: {
+          lineComment: "//",
+          blockComment: ["/*", "*/"],
+        },
+      }),
+    );
+  });
+
+  it("tokenizer covers the full valid-JSON surface (no default-token leakage)", () => {
+    // Monarch 规则面:root 必须命中 whitespace / numbers / propertyName / strings /
+    // delimiters / brackets / 未引号字面量,合法 JSON 才不会被 defaultToken('invalid')
+    // 标红。propertyName 在 strings 之前(键先于字符串值判定)。
+    const root = jsonTokenProvider.tokenizer.root;
+    const included = new Set(
+      root
+        .map((r) => (r as { include?: string }).include)
+        .filter((v): v is string => Boolean(v)),
+    );
+    expect(included).toEqual(
+      new Set(["@whitespace", "@numbers", "@propertyName", "@strings"]),
+    );
+    const delims = root.some(
+      (r) => Array.isArray(r) && r[0] instanceof RegExp && r[1] === "delimiter",
+    );
+    const brackets = root.some(
+      (r) => Array.isArray(r) && r[1] === "delimiter.bracket",
+    );
+    // 未引号字面量 true/false/null 有专门规则,不然会露红。
+    const keywordRule = root.some(
+      (r) =>
+        Array.isArray(r) &&
+        r[0] instanceof RegExp &&
+        r[0].source.includes("true") &&
+        r[1] === "keyword",
+    );
+    // 键命中 string.key.json(默认主题给键专门配色)。
+    const keyRule = jsonTokenProvider.tokenizer.propertyName?.[0];
+    expect(delims).toBe(true);
+    expect(brackets).toBe(true);
+    expect(keywordRule).toBe(true);
+    expect(
+      Array.isArray(keyRule) &&
+        keyRule[0] instanceof RegExp &&
+        keyRule[1] === "string.key.json",
+    ).toBe(true);
+  });
+});

--- a/frontend/src/lib/file-preview/monaco-json.ts
+++ b/frontend/src/lib/file-preview/monaco-json.ts
@@ -1,0 +1,83 @@
+import type * as monacoApi from "monaco-editor/editor/editor.api";
+
+import type { MonacoNS } from "./monaco-loader";
+
+type MonarchLanguage = monacoApi.languages.IMonarchLanguage;
+
+// JSON / JSONC 的轻量 Monarch tokenizer。
+//
+// monaco-editor 0.56 起 JSON 移出了 basic-languages（basic-languages/
+// monaco.contribution 只注册纯词法语言，不含 json；完整 JSON 语言服务
+// vs/language/json 附带 worker + 校验器，体积大，与本项目「只读预览不引
+// language service」的体积决策冲突）。因此 json 不在加载的语言集里，monaco
+// 语言表把 .json/.jsonc 映射到 json 也只是映射到一个未注册的语言——预览按
+// 纯文本渲染，没有高亮（spec 设计决策 7「扩展名→语言识别」在 json 上落空）。
+//
+// 这里注册一个与 basic-languages 同级的 JSON 语言：只做 Monarch 词法着色，
+// 无 IntelliSense / worker。
+//
+// 规则面按「合法 JSON 全覆盖」构造：propertyName（键，string.key.json）在
+// strings 之前判定，未引号字面量 true/false/null 有专门规则，所以合法 JSON 不
+// 会落到 defaultToken('invalid') 露红；defaultToken 只对语法残缺的输入生效。
+export function registerJsonLanguage(monaco: MonacoNS): void {
+  monaco.languages.register({
+    id: "json",
+    extensions: [".json", ".jsonc"],
+    aliases: ["JSON", "JSONC"],
+  });
+  monaco.languages.setLanguageConfiguration("json", {
+    comments: {
+      lineComment: "//",
+      blockComment: ["/*", "*/"],
+    },
+    brackets: [
+      ["{", "}"],
+      ["[", "]"],
+    ],
+    autoClosingPairs: [
+      { open: "{", close: "}" },
+      { open: "[", close: "]" },
+      { open: '"', close: '"' },
+    ],
+  });
+  monaco.languages.setMonarchTokensProvider("json", jsonTokenProvider);
+}
+
+// 只读预览不需要对 JSON 正文做任何写操作，tokenizer 为纯函数式 Monarch 定义，
+// 独立导出便于单测直接断言结构。显式标注 IMonarchLanguage 让规则数组按元组
+// 上下文定型（否则 [regex, token] 会被推断成宽联合数组，过不了 tsc 的元组校验）。
+export const jsonTokenProvider: MonarchLanguage = {
+  defaultToken: "invalid",
+  tokenPostfix: ".json",
+  tokenizer: {
+    root: [
+      { include: "@whitespace" },
+      { include: "@numbers" },
+      // 键先于字符串判定："a": 命中 string.key.json；作为值的 "a" 落到
+      // @strings 的 string。
+      { include: "@propertyName" },
+      { include: "@strings" },
+      [/[{},:]/, "delimiter"],
+      [/[[\]]/, "delimiter.bracket"],
+      // 未引号的 JSON 字面量，合法 JSON 全覆盖的关键。
+      [/\b(?:true|false|null)\b/, "keyword"],
+    ],
+    whitespace: [
+      [/[ \t\r\n]+/, ""],
+      [/\/\*/, "comment", "@comment"],
+      [/\/\/.*$/, "comment"],
+    ],
+    comment: [
+      [/[^/*]+/, "comment"],
+      [/\*\//, "comment", "@pop"],
+      [/[/*]/, "comment"],
+    ],
+    propertyName: [[/"(?:[^"\\]|\\.)*"(?=\s*:)/, "string.key.json"]],
+    numbers: [
+      [/-?0[xX][0-9a-fA-F]+/, "number.hex"],
+      [/-?\d*\.\d+([eE][-+]?\d+)?/, "number.float"],
+      [/-?\d+([eE][-+]?\d+)?/, "number"],
+    ],
+    strings: [[/"(?:[^"\\]|\\.)*"/, "string"]],
+  },
+};

--- a/frontend/src/lib/file-preview/monaco-language.test.ts
+++ b/frontend/src/lib/file-preview/monaco-language.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { monacoLanguageForPath } from "./monaco-language";
+
+describe("monacoLanguageForPath", () => {
+  it("maps common extensions to monaco built-in language ids", () => {
+    expect(monacoLanguageForPath("src/main.go")).toBe("go");
+    expect(monacoLanguageForPath("src/App.tsx")).toBe("typescript");
+    expect(monacoLanguageForPath("server.js")).toBe("javascript");
+    expect(monacoLanguageForPath("styles.css")).toBe("css");
+    expect(monacoLanguageForPath("README.md")).toBe("markdown");
+    expect(monacoLanguageForPath("data.json")).toBe("json");
+    expect(monacoLanguageForPath("script.sh")).toBe("shell");
+    expect(monacoLanguageForPath("app.py")).toBe("python");
+    expect(monacoLanguageForPath("lib.rs")).toBe("rust");
+    expect(monacoLanguageForPath("config.yaml")).toBe("yaml");
+    expect(monacoLanguageForPath("model.h")).toBe("cpp");
+  });
+
+  it("matches case-insensitively and works on nested paths", () => {
+    expect(monacoLanguageForPath("/a/b/CONFIG.YML")).toBe("yaml");
+    expect(monacoLanguageForPath("dir/sub/file.TSX")).toBe("typescript");
+    expect(monacoLanguageForPath("cmd/agentred/main.go")).toBe("go");
+  });
+
+  it("recognizes Dockerfile by filename", () => {
+    expect(monacoLanguageForPath("Dockerfile")).toBe("dockerfile");
+    expect(monacoLanguageForPath("build/Dockerfile")).toBe("dockerfile");
+  });
+
+  it("returns plaintext for unknown or extensionless names", () => {
+    expect(monacoLanguageForPath("archive.zip")).toBe("plaintext");
+    expect(monacoLanguageForPath("noextension")).toBe("plaintext");
+    expect(monacoLanguageForPath("")).toBe("plaintext");
+    expect(monacoLanguageForPath("dir/.hidden")).toBe("plaintext");
+    expect(monacoLanguageForPath("Makefile")).toBe("plaintext");
+  });
+});

--- a/frontend/src/lib/file-preview/monaco-language.ts
+++ b/frontend/src/lib/file-preview/monaco-language.ts
@@ -1,0 +1,94 @@
+// 扩展名 / 文件名 → Monaco 内置语言 id。
+// 映射只覆盖 monaco-editor 0.56 实际注册的语言（editor.main.js 随包注册的
+// basic-languages + 核心 plaintext）；未知一律回退 plaintext（纯文本高亮）。
+// 桌面离线 + //go:embed，语言集完全来自本地包，不引 CDN 语言资源。
+
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  // web 前端 / 标记
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  json: "json",
+  jsonc: "json",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  css: "css",
+  scss: "scss",
+  sass: "scss",
+  less: "less",
+  // markdown / 文本格式
+  md: "markdown",
+  markdown: "markdown",
+  mdx: "mdx",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  cfg: "ini",
+  conf: "ini",
+  // shell / 脚本
+  sh: "shell",
+  bash: "shell",
+  zsh: "shell",
+  py: "python",
+  pyw: "python",
+  rb: "ruby",
+  php: "php",
+  lua: "lua",
+  r: "r",
+  pl: "perl",
+  ps1: "powershell",
+  psd1: "powershell",
+  psm1: "powershell",
+  bat: "bat",
+  cmd: "bat",
+  // 系统 / 编译型
+  c: "c",
+  h: "cpp",
+  cpp: "cpp",
+  cc: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  hh: "cpp",
+  cs: "csharp",
+  java: "java",
+  go: "go",
+  rs: "rust",
+  swift: "swift",
+  kt: "kotlin",
+  kts: "kotlin",
+  dart: "dart",
+  scala: "scala",
+  sc: "scala",
+  clj: "clojure",
+  cljs: "clojure",
+  cljc: "clojure",
+  groovy: "groovy",
+  gradle: "groovy",
+  sql: "sql",
+};
+
+// 按完整文件名（basename 小写）识别，覆盖 Dockerfile 这类无扩展名入口。
+const FILENAME_LANGUAGE: Record<string, string> = {
+  dockerfile: "dockerfile",
+};
+
+// 由文件路径推断 Monaco 语言 id；未知扩展名 → "plaintext"。
+export function monacoLanguageForPath(path: string): string {
+  const basename = (path.split("/").pop() ?? "").toLowerCase();
+  const byName = FILENAME_LANGUAGE[basename];
+  if (byName) return byName;
+  const dot = basename.lastIndexOf(".");
+  if (dot > 0) {
+    const language = EXTENSION_LANGUAGE[basename.slice(dot + 1)];
+    if (language) return language;
+  }
+  return "plaintext";
+}

--- a/frontend/src/lib/file-preview/monaco-loader.ts
+++ b/frontend/src/lib/file-preview/monaco-loader.ts
@@ -1,0 +1,41 @@
+// ── Monaco 加载接缝（mock seam）──────────────────────────────────────────────
+// 全仓库唯一触碰真实 Monaco 的模块。真实 monaco 走动态 import（懒加载独立 chunk，
+// 不进初始包）+ 动态 import 的 worker 环境模块，离线桌面可跑、happy-dom 单测绝不执行。
+//
+// 组件测试 / task 6 测试的两种接缝（任选其一，推荐 1）：
+//   1. 给组件传 monaco prop（fake 命名空间，见 file-preview 组件签名）；
+//   2. vi.mock("@/lib/file-preview/monaco-loader", () => ({ loadMonaco: vi.fn() }))
+//      ，把 loadMonaco 替换成 resolve fake 的 stub —— 组件不传 monaco prop 时
+//      走这条路径。
+//
+// spike 结论（task 5）：裸 monaco-editor + Vite `?worker`，不用 @monaco-editor/react。
+// 离线 + //go:embed 禁止 CDN，@monaco-editor/react 的 @monaco-editor/loader 默认
+// jsdelivr 拉取，即便 loader.config({ monaco }) 也是 CDN-first 设计；裸 monaco 无
+// loader 概念（零 CDN 面）、只多一个依赖、worker 由我们按需配。diff editor 与普通
+// editor 共用同一份动态 import 的 monaco 命名空间单例 → 复用同一 Monaco 实例。
+//
+// 体积控制：只读预览不需要 IntelliSense，故只动态加载 editor.api（核心编辑器）+
+// 全部 basic-languages 词法高亮（纯 tokenizer，无 worker）；绝不引入完整包
+// monaco-editor（editor.main 连带 ts/css/html/json 语言服务，ts.worker 单文件
+// ~7MB）或 esm/vs/language/* 语言服务。
+
+// editor.api 的类型面（editor / languages / Uri 等）对只读预览已够用。
+// monaco-editor 0.56 的 exports 映射自带 esm/vs/ 前缀，深导入子路径不带前缀。
+export type MonacoNS = typeof import("monaco-editor/editor/editor.api");
+
+export type MonacoCodeEditor = ReturnType<MonacoNS["editor"]["create"]>;
+export type MonacoDiffEditor = ReturnType<
+  MonacoNS["editor"]["createDiffEditor"]
+>;
+
+let cached: Promise<MonacoNS> | null = null;
+
+/** 动态加载 Monaco 命名空间（幂等，进程内单例）。 */
+export function loadMonaco(): Promise<MonacoNS> {
+  cached ??= (async () => {
+    await import("./monaco-worker-env");
+    await import("monaco-editor/basic-languages/monaco.contribution");
+    return import("monaco-editor/editor/editor.api");
+  })();
+  return cached;
+}

--- a/frontend/src/lib/file-preview/monaco-loader.ts
+++ b/frontend/src/lib/file-preview/monaco-loader.ts
@@ -35,7 +35,11 @@ export function loadMonaco(): Promise<MonacoNS> {
   cached ??= (async () => {
     await import("./monaco-worker-env");
     await import("monaco-editor/basic-languages/monaco.contribution");
-    return import("monaco-editor/editor/editor.api");
+    const monaco = await import("monaco-editor/editor/editor.api");
+    // json 不在 basic-languages 里（0.56 起移出），补一个纯词法的 JSON 语言。
+    const { registerJsonLanguage } = await import("./monaco-json");
+    registerJsonLanguage(monaco);
+    return monaco;
   })();
   return cached;
 }

--- a/frontend/src/lib/file-preview/monaco-worker-env.ts
+++ b/frontend/src/lib/file-preview/monaco-worker-env.ts
@@ -1,0 +1,15 @@
+import editorWorker from "monaco-editor/editor/editor.worker?worker";
+
+// Monaco 需要 self.MonacoEnvironment.getWorker 才能拿到编辑器 worker。
+// Vite `?worker` 把每个 worker 打成独立 chunk，跟随应用产物（//go:embed）加载，
+// 离线桌面不触网。注意 monaco-editor 0.56 的 exports 映射 `"./*": "./esm/vs/*.js"`
+// 已自带 esm/vs/ 前缀 —— 深导入必须写 monaco-editor/editor/editor.worker
+// （带 esm/vs/ 前缀会双写路径导致 Rollup 解析失败）。
+// 只读预览只需要 editor worker（文本模型 / 词法 / diff 计算）；
+// TS/JSON/CSS/HTML 等 language worker 只服务 IntelliSense，预览用不到，不打包。
+// 本模块只被 monaco-loader 动态 import，组件 / 测试永不静态触碰。
+self.MonacoEnvironment = {
+  getWorker() {
+    return new editorWorker();
+  },
+};

--- a/frontend/src/stores/__tests__/chat-sidebar-store.test.ts
+++ b/frontend/src/stores/__tests__/chat-sidebar-store.test.ts
@@ -161,30 +161,44 @@ describe("chat-sidebar-store", () => {
   });
 
   describe("preview selection", () => {
-    it("opens a file with a null segment (default) when nothing was selected", () => {
-      useChatSidebarStore.getState().openPreview(7, "README.md");
+    it("opens a file recording its source mode with a null segment when nothing was selected", () => {
+      useChatSidebarStore.getState().openPreview(7, "README.md", "directory");
       expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
         path: "README.md",
         segment: null,
+        sourceMode: "directory",
       });
     });
 
-    it("keeps the segment when switching files while the panel is open", () => {
-      useChatSidebarStore.getState().openPreview(7, "README.md");
+    it("keeps the segment when switching files in the same mode while the panel is open", () => {
+      useChatSidebarStore.getState().openPreview(7, "README.md", "directory");
       useChatSidebarStore.getState().setPreviewSegment(7, "split");
-      useChatSidebarStore.getState().openPreview(7, "guide.md");
+      useChatSidebarStore.getState().openPreview(7, "guide.md", "directory");
 
       expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
         path: "guide.md",
         segment: "split",
+        sourceMode: "directory",
+      });
+    });
+
+    it("resets the segment to the default when opening from a different mode", () => {
+      useChatSidebarStore.getState().openPreview(7, "README.md", "directory");
+      useChatSidebarStore.getState().setPreviewSegment(7, "split");
+      useChatSidebarStore.getState().openPreview(7, "guide.md", "changes");
+
+      expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+        path: "guide.md",
+        segment: null,
+        sourceMode: "changes",
       });
     });
 
     it("updates the segment for an existing selection only", () => {
-      useChatSidebarStore.getState().openPreview(7, "a.go");
-      useChatSidebarStore.getState().setPreviewSegment(7, "diff");
+      useChatSidebarStore.getState().openPreview(7, "a.go", "git");
+      useChatSidebarStore.getState().setPreviewSegment(7, "split");
       expect(useChatSidebarStore.getState().previewBySession[7].segment).toBe(
-        "diff",
+        "split",
       );
 
       // 没有选中文件时设置档位是 no-op。
@@ -195,16 +209,21 @@ describe("chat-sidebar-store", () => {
     });
 
     it("rejects an unknown segment at runtime by no-op", () => {
-      useChatSidebarStore.getState().openPreview(7, "a.go");
+      useChatSidebarStore.getState().openPreview(7, "a.go", "git");
       useChatSidebarStore.getState().setPreviewSegment(7, "bogus" as never);
       expect(
         useChatSidebarStore.getState().previewBySession[7].segment,
       ).toBeNull();
     });
 
+    it("rejects an unknown source mode at runtime by no-op", () => {
+      useChatSidebarStore.getState().openPreview(7, "a.md", "bogus" as never);
+      expect(useChatSidebarStore.getState().previewBySession).toEqual({});
+    });
+
     it("clears one session's preview without touching the others", () => {
-      useChatSidebarStore.getState().openPreview(7, "a.md");
-      useChatSidebarStore.getState().openPreview(8, "b.go");
+      useChatSidebarStore.getState().openPreview(7, "a.md", "changes");
+      useChatSidebarStore.getState().openPreview(8, "b.go", "directory");
 
       useChatSidebarStore.getState().clearPreview(7);
 
@@ -214,12 +233,13 @@ describe("chat-sidebar-store", () => {
       expect(useChatSidebarStore.getState().previewBySession[8]).toEqual({
         path: "b.go",
         segment: null,
+        sourceMode: "directory",
       });
     });
 
     it("ignores openPreview for a non-session id or an empty path", () => {
-      useChatSidebarStore.getState().openPreview(0, "a.md");
-      useChatSidebarStore.getState().openPreview(7, "");
+      useChatSidebarStore.getState().openPreview(0, "a.md", "directory");
+      useChatSidebarStore.getState().openPreview(7, "", "directory");
       expect(useChatSidebarStore.getState().previewBySession).toEqual({});
     });
 
@@ -231,11 +251,16 @@ describe("chat-sidebar-store", () => {
             open: true,
             activeTab: "files",
             previewBySession: {
-              7: { path: "README.md", segment: "split" },
-              8: { path: "a.go" },
+              7: {
+                path: "README.md",
+                segment: "split",
+                sourceMode: "directory",
+              },
+              8: { path: "a.go", sourceMode: "git" },
               9: { path: "" },
               notAnId: { path: "x.md" },
-              10: { path: "y.md", segment: "bogus" },
+              10: { path: "y.md", segment: "bogus", sourceMode: "changes" },
+              11: { path: "z.md", sourceMode: "bogus" },
             },
           },
           version: 0,
@@ -244,8 +269,12 @@ describe("chat-sidebar-store", () => {
       await useChatSidebarStore.persist.rehydrate();
 
       expect(useChatSidebarStore.getState().previewBySession).toEqual({
-        7: { path: "README.md", segment: "split" },
-        8: { path: "a.go", segment: null },
+        7: {
+          path: "README.md",
+          segment: "split",
+          sourceMode: "directory",
+        },
+        8: { path: "a.go", segment: null, sourceMode: "git" },
       });
     });
   });

--- a/frontend/src/stores/__tests__/chat-sidebar-store.test.ts
+++ b/frontend/src/stores/__tests__/chat-sidebar-store.test.ts
@@ -15,6 +15,7 @@ describe("chat-sidebar-store", () => {
       filesMode: "changes",
       showIgnored: false,
       gitBaselineBySession: {},
+      previewBySession: {},
     });
   });
 
@@ -157,5 +158,95 @@ describe("chat-sidebar-store", () => {
     await useChatSidebarStore.persist.rehydrate();
 
     expect(useChatSidebarStore.getState().gitBaselineBySession).toEqual({});
+  });
+
+  describe("preview selection", () => {
+    it("opens a file with a null segment (default) when nothing was selected", () => {
+      useChatSidebarStore.getState().openPreview(7, "README.md");
+      expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+        path: "README.md",
+        segment: null,
+      });
+    });
+
+    it("keeps the segment when switching files while the panel is open", () => {
+      useChatSidebarStore.getState().openPreview(7, "README.md");
+      useChatSidebarStore.getState().setPreviewSegment(7, "split");
+      useChatSidebarStore.getState().openPreview(7, "guide.md");
+
+      expect(useChatSidebarStore.getState().previewBySession[7]).toEqual({
+        path: "guide.md",
+        segment: "split",
+      });
+    });
+
+    it("updates the segment for an existing selection only", () => {
+      useChatSidebarStore.getState().openPreview(7, "a.go");
+      useChatSidebarStore.getState().setPreviewSegment(7, "diff");
+      expect(useChatSidebarStore.getState().previewBySession[7].segment).toBe(
+        "diff",
+      );
+
+      // 没有选中文件时设置档位是 no-op。
+      useChatSidebarStore.getState().setPreviewSegment(8, "text");
+      expect(
+        useChatSidebarStore.getState().previewBySession[8],
+      ).toBeUndefined();
+    });
+
+    it("rejects an unknown segment at runtime by no-op", () => {
+      useChatSidebarStore.getState().openPreview(7, "a.go");
+      useChatSidebarStore.getState().setPreviewSegment(7, "bogus" as never);
+      expect(
+        useChatSidebarStore.getState().previewBySession[7].segment,
+      ).toBeNull();
+    });
+
+    it("clears one session's preview without touching the others", () => {
+      useChatSidebarStore.getState().openPreview(7, "a.md");
+      useChatSidebarStore.getState().openPreview(8, "b.go");
+
+      useChatSidebarStore.getState().clearPreview(7);
+
+      expect(
+        useChatSidebarStore.getState().previewBySession[7],
+      ).toBeUndefined();
+      expect(useChatSidebarStore.getState().previewBySession[8]).toEqual({
+        path: "b.go",
+        segment: null,
+      });
+    });
+
+    it("ignores openPreview for a non-session id or an empty path", () => {
+      useChatSidebarStore.getState().openPreview(0, "a.md");
+      useChatSidebarStore.getState().openPreview(7, "");
+      expect(useChatSidebarStore.getState().previewBySession).toEqual({});
+    });
+
+    it("drops persisted previews that are not a session id to selection map", async () => {
+      localStorage.setItem(
+        "chat-sidebar-state",
+        JSON.stringify({
+          state: {
+            open: true,
+            activeTab: "files",
+            previewBySession: {
+              7: { path: "README.md", segment: "split" },
+              8: { path: "a.go" },
+              9: { path: "" },
+              notAnId: { path: "x.md" },
+              10: { path: "y.md", segment: "bogus" },
+            },
+          },
+          version: 0,
+        }),
+      );
+      await useChatSidebarStore.persist.rehydrate();
+
+      expect(useChatSidebarStore.getState().previewBySession).toEqual({
+        7: { path: "README.md", segment: "split" },
+        8: { path: "a.go", segment: null },
+      });
+    });
   });
 });

--- a/frontend/src/stores/chat-sidebar-store.ts
+++ b/frontend/src/stores/chat-sidebar-store.ts
@@ -6,13 +6,17 @@ export type ChatSidebarTab = "outline" | "files";
 /** 「文件」页内的三种视角：本次对话改过的文件 / 工作目录树 / git 变动。 */
 export type ChatFilesMode = "changes" | "directory" | "git";
 
-/** 预览面板按文件类型提供的视图档位（spec 决策 7）。 */
-export type FilePreviewSegment = "render" | "text" | "split" | "diff";
+/** 预览面板按文件类型提供的视图档位（spec 决策 7）；diff 已随需求修订去掉，仅 markdown 有意义。 */
+export type FilePreviewSegment = "render" | "text" | "split";
 
-/** 预览选中：path 是会话级 relPath；segment 为 null 表示用该文件类型的默认档。 */
+/** 打开预览的行来自哪个文件模式：目录 / Git / 变动。首视图由它决定（spec 决策 9）。 */
+export type PreviewSourceMode = "directory" | "git" | "changes";
+
+/** 预览选中：path 是会话级 relPath；sourceMode 是入口模式；segment 为 null 表示用 markdown 默认档。 */
 export type FilePreviewSelection = {
   path: string;
   segment: FilePreviewSegment | null;
+  sourceMode: PreviewSourceMode;
 };
 
 type ChatSidebarState = {
@@ -30,8 +34,12 @@ type ChatSidebarState = {
   setShowIgnored: (showIgnored: boolean) => void;
   setGitBaseline: (sessionId: number, ref: string) => void;
   clearGitBaseline: (sessionId: number) => void;
-  /** 打开 / 切换到某文件；面板开着时保留既有档位（spec 决策 12）。 */
-  openPreview: (sessionId: number, path: string) => void;
+  /** 打开 / 切换到某文件并记录入口模式；面板开着且模式不变时保留 markdown 档位，换模式则回默认档。 */
+  openPreview: (
+    sessionId: number,
+    path: string,
+    sourceMode: PreviewSourceMode,
+  ) => void;
   /** 更新当前选中文件的视图档位；无选中时为 no-op。 */
   setPreviewSegment: (sessionId: number, segment: FilePreviewSegment) => void;
   /** 关闭面板：清空该会话的预览选中。 */
@@ -50,7 +58,12 @@ const VALID_PREVIEW_SEGMENTS: ReadonlySet<FilePreviewSegment> = new Set([
   "render",
   "text",
   "split",
-  "diff",
+]);
+
+const VALID_SOURCE_MODES: ReadonlySet<PreviewSourceMode> = new Set([
+  "directory",
+  "git",
+  "changes",
 ]);
 
 // sanitizeBaselines 只保留「正整数会话 id → 非空 ref」的条目：这张表会被
@@ -70,8 +83,9 @@ function sanitizeBaselines(value: unknown): Record<number, string> {
   return Object.fromEntries(kept) as Record<number, string>;
 }
 
-// sanitizePreview 只保留「正整数会话 id → { path, segment? }」的合法条目：路径必须
-// 非空字符串,segment 缺失补 null、非法值丢弃整条。JSON 往返后键必然是字符串。
+// sanitizePreview 只保留「正整数会话 id → { path, segment?, sourceMode }」的合法条目：路径必须
+// 非空字符串,segment 缺失补 null、非法值丢弃整条；sourceMode 缺失 / 非法（旧版本持久化
+// 无此字段）也丢弃整条。JSON 往返后键必然是字符串。
 function sanitizePreview(value: unknown): Record<number, FilePreviewSelection> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const entries = Object.entries(value as Record<string, unknown>);
@@ -86,6 +100,9 @@ function sanitizePreview(value: unknown): Record<number, FilePreviewSelection> {
     ) {
       return false;
     }
+    if (!VALID_SOURCE_MODES.has(s.sourceMode as PreviewSourceMode)) {
+      return false;
+    }
     return true;
   });
   const normalized: Record<number, FilePreviewSelection> = Object.fromEntries(
@@ -96,6 +113,7 @@ function sanitizePreview(value: unknown): Record<number, FilePreviewSelection> {
         {
           path: s.path as string,
           segment: (s.segment as FilePreviewSegment) ?? null,
+          sourceMode: s.sourceMode as PreviewSourceMode,
         },
       ];
     }),
@@ -173,18 +191,26 @@ export const useChatSidebarStore = create<ChatSidebarState>()(
           delete next[sessionId];
           return { gitBaselineBySession: next };
         }),
-      openPreview: (sessionId, path) => {
+      openPreview: (sessionId, path, sourceMode) => {
         if (!Number.isInteger(sessionId) || sessionId <= 0 || path === "")
           return;
-        set((state) => ({
-          previewBySession: {
-            ...state.previewBySession,
-            [sessionId]: {
-              path,
-              segment: state.previewBySession[sessionId]?.segment ?? null,
+        if (!VALID_SOURCE_MODES.has(sourceMode)) return;
+        set((state) => {
+          const prev = state.previewBySession[sessionId];
+          // 入口模式决定首视图：换模式打开重设首视图（markdown 档位回默认）；
+          // 同一模式内切文件保留 markdown 档位（spec 决策 9 / 12）。
+          const sameMode = prev?.sourceMode === sourceMode;
+          return {
+            previewBySession: {
+              ...state.previewBySession,
+              [sessionId]: {
+                path,
+                sourceMode,
+                segment: sameMode ? (prev?.segment ?? null) : null,
+              },
             },
-          },
-        }));
+          };
+        });
       },
       setPreviewSegment: (sessionId, segment) => {
         if (!Number.isInteger(sessionId) || sessionId <= 0) return;

--- a/frontend/src/stores/chat-sidebar-store.ts
+++ b/frontend/src/stores/chat-sidebar-store.ts
@@ -6,6 +6,15 @@ export type ChatSidebarTab = "outline" | "files";
 /** 「文件」页内的三种视角：本次对话改过的文件 / 工作目录树 / git 变动。 */
 export type ChatFilesMode = "changes" | "directory" | "git";
 
+/** 预览面板按文件类型提供的视图档位（spec 决策 7）。 */
+export type FilePreviewSegment = "render" | "text" | "split" | "diff";
+
+/** 预览选中：path 是会话级 relPath；segment 为 null 表示用该文件类型的默认档。 */
+export type FilePreviewSelection = {
+  path: string;
+  segment: FilePreviewSegment | null;
+};
+
 type ChatSidebarState = {
   open: boolean;
   activeTab: ChatSidebarTab;
@@ -13,12 +22,20 @@ type ChatSidebarState = {
   showIgnored: boolean;
   /** Git 模式「本分支」档的对比基线，按会话记住（设计决策 9）。 */
   gitBaselineBySession: Record<number, string>;
+  /** 预览选中的文件与视图档位，按会话记住（spec 决策 12）。 */
+  previewBySession: Record<number, FilePreviewSelection>;
   setOpen: (open: boolean) => void;
   setActiveTab: (tab: ChatSidebarTab) => void;
   setFilesMode: (mode: ChatFilesMode) => void;
   setShowIgnored: (showIgnored: boolean) => void;
   setGitBaseline: (sessionId: number, ref: string) => void;
   clearGitBaseline: (sessionId: number) => void;
+  /** 打开 / 切换到某文件；面板开着时保留既有档位（spec 决策 12）。 */
+  openPreview: (sessionId: number, path: string) => void;
+  /** 更新当前选中文件的视图档位；无选中时为 no-op。 */
+  setPreviewSegment: (sessionId: number, segment: FilePreviewSegment) => void;
+  /** 关闭面板：清空该会话的预览选中。 */
+  clearPreview: (sessionId: number) => void;
 };
 
 const VALID_TABS: ReadonlySet<ChatSidebarTab> = new Set(["outline", "files"]);
@@ -27,6 +44,13 @@ const VALID_FILES_MODES: ReadonlySet<ChatFilesMode> = new Set([
   "changes",
   "directory",
   "git",
+]);
+
+const VALID_PREVIEW_SEGMENTS: ReadonlySet<FilePreviewSegment> = new Set([
+  "render",
+  "text",
+  "split",
+  "diff",
 ]);
 
 // sanitizeBaselines 只保留「正整数会话 id → 非空 ref」的条目：这张表会被
@@ -46,6 +70,45 @@ function sanitizeBaselines(value: unknown): Record<number, string> {
   return Object.fromEntries(kept) as Record<number, string>;
 }
 
+// sanitizePreview 只保留「正整数会话 id → { path, segment? }」的合法条目：路径必须
+// 非空字符串,segment 缺失补 null、非法值丢弃整条。JSON 往返后键必然是字符串。
+function sanitizePreview(value: unknown): Record<number, FilePreviewSelection> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const entries = Object.entries(value as Record<string, unknown>);
+  const kept = entries.filter(([key, sel]) => {
+    if (!(Number.isInteger(Number(key)) && Number(key) > 0)) return false;
+    if (!sel || typeof sel !== "object" || Array.isArray(sel)) return false;
+    const s = sel as Record<string, unknown>;
+    if (typeof s.path !== "string" || s.path === "") return false;
+    if (
+      s.segment != null &&
+      !VALID_PREVIEW_SEGMENTS.has(s.segment as FilePreviewSegment)
+    ) {
+      return false;
+    }
+    return true;
+  });
+  const normalized: Record<number, FilePreviewSelection> = Object.fromEntries(
+    kept.map(([key, sel]) => {
+      const s = sel as Record<string, unknown>;
+      return [
+        Number(key),
+        {
+          path: s.path as string,
+          segment: (s.segment as FilePreviewSegment) ?? null,
+        },
+      ];
+    }),
+  );
+  if (
+    kept.length === entries.length &&
+    Object.keys(normalized).length === entries.length
+  ) {
+    return value as Record<number, FilePreviewSelection>;
+  }
+  return normalized;
+}
+
 // 模式与「显示忽略项」是用户偏好，随侧栏状态一起持久化；持久化值可能来自更早
 // 的版本或被手改过的 localStorage，非法或缺失时一律回落到默认（模式回落到
 // 「变动」，忽略项回落到隐藏，基线表回落到空表）。
@@ -56,14 +119,22 @@ function sanitize(state: ChatSidebarState): ChatSidebarState {
   const showIgnored =
     typeof state.showIgnored === "boolean" ? state.showIgnored : false;
   const gitBaselineBySession = sanitizeBaselines(state.gitBaselineBySession);
+  const previewBySession = sanitizePreview(state.previewBySession);
   if (
     filesMode === state.filesMode &&
     showIgnored === state.showIgnored &&
-    gitBaselineBySession === state.gitBaselineBySession
+    gitBaselineBySession === state.gitBaselineBySession &&
+    previewBySession === state.previewBySession
   ) {
     return state;
   }
-  return { ...state, filesMode, showIgnored, gitBaselineBySession };
+  return {
+    ...state,
+    filesMode,
+    showIgnored,
+    gitBaselineBySession,
+    previewBySession,
+  };
 }
 
 export const useChatSidebarStore = create<ChatSidebarState>()(
@@ -74,6 +145,7 @@ export const useChatSidebarStore = create<ChatSidebarState>()(
       filesMode: "changes",
       showIgnored: false,
       gitBaselineBySession: {},
+      previewBySession: {},
       setOpen: (open) => set({ open }),
       setActiveTab: (tab) => {
         if (!VALID_TABS.has(tab)) return;
@@ -100,6 +172,40 @@ export const useChatSidebarStore = create<ChatSidebarState>()(
           const next = { ...state.gitBaselineBySession };
           delete next[sessionId];
           return { gitBaselineBySession: next };
+        }),
+      openPreview: (sessionId, path) => {
+        if (!Number.isInteger(sessionId) || sessionId <= 0 || path === "")
+          return;
+        set((state) => ({
+          previewBySession: {
+            ...state.previewBySession,
+            [sessionId]: {
+              path,
+              segment: state.previewBySession[sessionId]?.segment ?? null,
+            },
+          },
+        }));
+      },
+      setPreviewSegment: (sessionId, segment) => {
+        if (!Number.isInteger(sessionId) || sessionId <= 0) return;
+        if (!VALID_PREVIEW_SEGMENTS.has(segment)) return;
+        set((state) => {
+          const prev = state.previewBySession[sessionId];
+          if (!prev) return state;
+          return {
+            previewBySession: {
+              ...state.previewBySession,
+              [sessionId]: { ...prev, segment },
+            },
+          };
+        });
+      },
+      clearPreview: (sessionId) =>
+        set((state) => {
+          if (!(sessionId in state.previewBySession)) return state;
+          const next = { ...state.previewBySession };
+          delete next[sessionId];
+          return { previewBySession: next };
         }),
     }),
     {

--- a/internal/app/workspace_fs.go
+++ b/internal/app/workspace_fs.go
@@ -26,3 +26,17 @@ func (a *App) WorkspaceFsGitChanges(sessionID int64, scope, baseRef string) (*wo
 func (a *App) WorkspaceFsGitBranches(sessionID int64) (*workspace_fs_svc.GitBranchesView, error) {
 	return workspace_fs_svc.Default().GitBranches(a.ctx, sessionID)
 }
+
+// WorkspaceFsReadFile 读取会话工作目录下 relPath 所指文件的内容(会话级文件
+// 预览,纯读)。文本返回 UTF-8 正文;图片返回 base64 内容 + contentType;
+// binary/tooLarge 是视图标志。本地与远端(agentred)会话都走这一个方法,路由
+// 由服务层按会话解析出的 deviceID 决定;路径越界由服务层 / daemon 强制。
+func (a *App) WorkspaceFsReadFile(sessionID int64, relPath string) (*workspace_fs_svc.ReadFileView, error) {
+	return workspace_fs_svc.Default().ReadFile(a.ctx, sessionID, relPath)
+}
+
+// WorkspaceFsGitFileContent 取同一文件在 git HEAD 的版本(对比档左列)。文件未
+// 跟踪 / 不在 HEAD → 空基线(hasHead=false);非 git 仓库 → notARepo。
+func (a *App) WorkspaceFsGitFileContent(sessionID int64, relPath string) (*workspace_fs_svc.GitFileContentView, error) {
+	return workspace_fs_svc.Default().GitFileContent(a.ctx, sessionID, relPath)
+}

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -411,9 +411,23 @@ func TestIntegration_UnauthGuard(t *testing.T) {
 	// 未授权应回 -32001。
 	err = c.Call(callCtx, workspacefswire.MethodListDir, workspacefswire.ListDirReq{}, &workspacefswire.ListDirResp{})
 	require.Error(t, err, "workspacefs.listDir must be rejected without auth")
-	var wfsErr *rpc.Error
-	require.True(t, errors.As(err, &wfsErr), "error must be *rpc.Error")
-	assert.Equal(t, -32001, wfsErr.Code)
+	rpcErr = nil
+	require.True(t, errors.As(err, &rpcErr), "error must be *rpc.Error")
+	assert.Equal(t, -32001, rpcErr.Code)
+
+	// readFile / gitFileContent 同属 workspacefs.* 方法族,同样套 requireAuth
+	// 闭包,未授权应回 -32001。
+	err = c.Call(callCtx, workspacefswire.MethodReadFile, workspacefswire.ReadFileReq{}, &workspacefswire.ReadFileResp{})
+	require.Error(t, err, "workspacefs.readFile must be rejected without auth")
+	rpcErr = nil
+	require.True(t, errors.As(err, &rpcErr), "error must be *rpc.Error")
+	assert.Equal(t, -32001, rpcErr.Code)
+
+	err = c.Call(callCtx, workspacefswire.MethodGitFileContent, workspacefswire.GitFileContentReq{}, &workspacefswire.GitFileContentResp{})
+	require.Error(t, err, "workspacefs.gitFileContent must be rejected without auth")
+	rpcErr = nil
+	require.True(t, errors.As(err, &rpcErr), "error must be *rpc.Error")
+	assert.Equal(t, -32001, rpcErr.Code)
 }
 
 // TestIntegration_WorkspaceFsListDir_EndToEnd 验证 workspacefs.listDir 在鉴权
@@ -445,6 +459,30 @@ func TestIntegration_WorkspaceFsListDir_EndToEnd(t *testing.T) {
 	}
 	assert.Contains(t, names, "a.txt")
 	assert.False(t, names["a.txt"].IsDir)
+}
+
+// TestIntegration_WorkspaceFsReadFile_EndToEnd 验证 workspacefs.readFile 在鉴权
+// 后能端到端跑通一跳:配对拿 deviceToken,用它对 daemon 真实文件系统上的一个
+// 临时目录读文件内容,断言拿到真实正文而不是错误。未鉴权已由
+// TestIntegration_UnauthGuard 覆盖,这里只覆盖“鉴权后可用”这一半。gitFileContent
+// 与 readFile 共享同一套传输 / 鉴权 / 翻译管线,handler 层已单测,不再重复一跳。
+func TestIntegration_WorkspaceFsReadFile_EndToEnd(t *testing.T) {
+	dir, err := os.MkdirTemp("", "ard-wsfs")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	rig := bootRigInDir(t, dir)
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello world"), 0o644))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var resp workspacefswire.ReadFileResp
+	require.NoError(t, rig.cli.Call(ctx, workspacefswire.MethodReadFile, workspacefswire.ReadFileReq{Root: root, RelPath: "a.txt"}, &resp))
+	assert.Equal(t, "hello world", resp.Content)
+	assert.False(t, resp.Binary)
+	assert.False(t, resp.TooLarge)
 }
 
 // pacedBackendRunner emits events one at a time with a small inter-event gap so

--- a/internal/daemon/workspacefs/handler.go
+++ b/internal/daemon/workspacefs/handler.go
@@ -1,8 +1,8 @@
 // Package workspacefs 是 agentred daemon 端 workspacefs.* RPC 的 handler 实现。
-// 薄封装 internal/pkg/workspacefs 的 ListDir / GitChanges / GitBranches(设计
-// 决策 4:核心逻辑放叶子包,host 的本机分支与 daemon handler 共用同一份实
-// 现),把 sentinel 错误映射到 wire 层,由 register 把 sentinel 翻成
-// *rpc.Error 返给 dispatcher。
+// 薄封装 internal/pkg/workspacefs 的 ListDir / GitChanges / GitBranches /
+// ReadFile / GitFileContent(设计决策 4:核心逻辑放叶子包,host 的本机分支与
+// daemon handler 共用同一份实现),把 sentinel 错误映射到 wire 层,由 register
+// 把 sentinel 翻成 *rpc.Error 返给 dispatcher。
 package workspacefs
 
 import (
@@ -37,7 +37,8 @@ func NewHandlers(opts Options) *Handlers {
 // daemon)。生产传 requireAuth 包装,测试可传 identity。
 type WrapFunc = func(rpc.HandlerFunc) rpc.HandlerFunc
 
-// Register 把 ListDir / GitChanges / GitBranches 挂到 registry。
+// Register 把 ListDir / GitChanges / GitBranches / ReadFile / GitFileContent
+// 挂到 registry。
 //   - wrap 用来套 requireAuth(生产)或 identity(单测)
 //   - handler 返回的 wire sentinel 在此翻成 *rpc.Error,客户端 FromJSONRPCError
 //     反向 rehydrate
@@ -45,6 +46,8 @@ func Register(reg *rpc.Registry, h *Handlers, wrap WrapFunc) {
 	reg.Register(wire.MethodListDir, wrap(translateSentinel(handleListDir(h))))
 	reg.Register(wire.MethodGitChanges, wrap(translateSentinel(handleGitChanges(h))))
 	reg.Register(wire.MethodGitBranches, wrap(translateSentinel(handleGitBranches(h))))
+	reg.Register(wire.MethodReadFile, wrap(translateSentinel(handleReadFile(h))))
+	reg.Register(wire.MethodGitFileContent, wrap(translateSentinel(handleGitFileContent(h))))
 }
 
 func handleListDir(h *Handlers) rpc.HandlerFunc {
@@ -80,6 +83,30 @@ func handleGitBranches(h *Handlers) rpc.HandlerFunc {
 			}
 		}
 		return h.GitBranches(ctx, req)
+	}
+}
+
+func handleReadFile(h *Handlers) rpc.HandlerFunc {
+	return func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var req wire.ReadFileReq
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &req); err != nil {
+				return nil, rpc.ErrInvalidParams
+			}
+		}
+		return h.ReadFile(ctx, req)
+	}
+}
+
+func handleGitFileContent(h *Handlers) rpc.HandlerFunc {
+	return func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var req wire.GitFileContentReq
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &req); err != nil {
+				return nil, rpc.ErrInvalidParams
+			}
+		}
+		return h.GitFileContent(ctx, req)
 	}
 }
 

--- a/internal/daemon/workspacefs/handler_gitfilecontent.go
+++ b/internal/daemon/workspacefs/handler_gitfilecontent.go
@@ -1,0 +1,41 @@
+package workspacefs
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	"github.com/agentre-ai/agentre/internal/daemon/rpc"
+	pkgworkspacefs "github.com/agentre-ai/agentre/internal/pkg/workspacefs"
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs/wire"
+)
+
+// GitFileContent 返回 req.Root 下 req.RelPath 所指文件在 git HEAD 的版本(对比
+// 档左列,与工作区内容并排比较)。
+//   - root 为空 → wire.ErrNoCwd;非空但非绝对路径 → rpc.ErrInvalidParams;
+//     relPath 越界(含 ".."、绝对路径、跟随符号链接后逃出 root)→
+//     wire.ErrPathRefused,与 ReadFile 同一道边界。
+//   - 非 git 仓库 → NotARepo=true 的降级结果;文件未跟踪 / 不在 HEAD →
+//     HasHead=false 的空基线,均不报错(与 GitChanges / GitBranches 的容错
+//     约定一致)。
+func (h *Handlers) GitFileContent(ctx context.Context, req wire.GitFileContentReq) (*wire.GitFileContentResp, error) {
+	if req.Root != "" && !filepath.IsAbs(req.Root) {
+		return nil, rpc.ErrInvalidParams
+	}
+
+	res, err := pkgworkspacefs.GitFileContent(ctx, req.Root, req.RelPath)
+	if err != nil {
+		if errors.Is(err, pkgworkspacefs.ErrPathRefused) {
+			return nil, wire.ErrPathRefused
+		}
+		if errors.Is(err, pkgworkspacefs.ErrNoCwd) {
+			return nil, wire.ErrNoCwd
+		}
+		return nil, err
+	}
+	return &wire.GitFileContentResp{
+		Content:  res.Content,
+		NotARepo: res.NotARepo,
+		HasHead:  res.HasHead,
+	}, nil
+}

--- a/internal/daemon/workspacefs/handler_gitfilecontent_test.go
+++ b/internal/daemon/workspacefs/handler_gitfilecontent_test.go
@@ -1,0 +1,78 @@
+package workspacefs_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/daemon/rpc"
+	"github.com/agentre-ai/agentre/internal/daemon/workspacefs"
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs/wire"
+)
+
+func TestGitFileContent_Committed_HasHead(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("line1\nline2\n"), 0o644))
+	runGit(t, dir, "add", "a.txt")
+	runGit(t, dir, "commit", "-q", "-m", "seed")
+
+	resp, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: dir, RelPath: "a.txt"})
+	require.NoError(t, err)
+	assert.False(t, resp.NotARepo)
+	assert.True(t, resp.HasHead)
+	assert.Equal(t, "line1\nline2\n", resp.Content)
+}
+
+func TestGitFileContent_Untracked_EmptyBaseline(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("uncommitted"), 0o644))
+
+	resp, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: dir, RelPath: "new.txt"})
+	require.NoError(t, err)
+	assert.False(t, resp.NotARepo)
+	assert.False(t, resp.HasHead)
+	assert.Empty(t, resp.Content)
+}
+
+func TestGitFileContent_NonRepo_Degrades(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	dir := t.TempDir()
+
+	resp, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: dir, RelPath: "a.txt"})
+	require.NoError(t, err)
+	assert.True(t, resp.NotARepo)
+	assert.False(t, resp.HasHead)
+	assert.Empty(t, resp.Content)
+}
+
+func TestGitFileContent_RelPathEscape_PathRefused(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	dir := initRepo(t)
+
+	_, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: dir, RelPath: "../etc/passwd"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, wire.ErrPathRefused))
+}
+
+func TestGitFileContent_EmptyRoot_NoCwd(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+
+	_, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: ""})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, wire.ErrNoCwd))
+}
+
+func TestGitFileContent_RelativeRoot_InvalidParams(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+
+	_, err := h.GitFileContent(context.Background(), wire.GitFileContentReq{Root: "relative/root", RelPath: "a.txt"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rpc.ErrInvalidParams))
+}

--- a/internal/daemon/workspacefs/handler_readfile.go
+++ b/internal/daemon/workspacefs/handler_readfile.go
@@ -1,0 +1,42 @@
+package workspacefs
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	"github.com/agentre-ai/agentre/internal/daemon/rpc"
+	pkgworkspacefs "github.com/agentre-ai/agentre/internal/pkg/workspacefs"
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs/wire"
+)
+
+// ReadFile 读取 req.Root 下 req.RelPath 所指文件的内容(会话级文件预览,纯读)。
+//   - root 为空 → wire.ErrNoCwd(会话配置问题,不是路径问题);非空但非绝对
+//     路径 → rpc.ErrInvalidParams(与 ListDir 的 root 契约一致:root 是调用方
+//     已解析出的绝对工作目录)。
+//   - relPath 越界(含 ".."、绝对路径、跟随符号链接后逃出 root)→
+//     wire.ErrPathRefused,与 ListDir / GitFileContent 同一道边界。
+//   - 结果字段(binary / tooLarge / contentType)按叶子包的判定原样透传,不在
+//     这里新增错误码(spec 决策 5:binary/tooLarge 走视图字段)。
+func (h *Handlers) ReadFile(ctx context.Context, req wire.ReadFileReq) (*wire.ReadFileResp, error) {
+	if req.Root != "" && !filepath.IsAbs(req.Root) {
+		return nil, rpc.ErrInvalidParams
+	}
+
+	res, err := pkgworkspacefs.ReadFile(ctx, req.Root, req.RelPath)
+	if err != nil {
+		if errors.Is(err, pkgworkspacefs.ErrPathRefused) {
+			return nil, wire.ErrPathRefused
+		}
+		if errors.Is(err, pkgworkspacefs.ErrNoCwd) {
+			return nil, wire.ErrNoCwd
+		}
+		return nil, err
+	}
+	return &wire.ReadFileResp{
+		Content:     res.Content,
+		ContentType: res.ContentType,
+		Binary:      res.Binary,
+		TooLarge:    res.TooLarge,
+	}, nil
+}

--- a/internal/daemon/workspacefs/handler_readfile_test.go
+++ b/internal/daemon/workspacefs/handler_readfile_test.go
@@ -1,0 +1,69 @@
+package workspacefs_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/daemon/rpc"
+	"github.com/agentre-ai/agentre/internal/daemon/workspacefs"
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs/wire"
+)
+
+func TestReadFile_TextHappy(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644))
+
+	resp, err := h.ReadFile(context.Background(), wire.ReadFileReq{Root: root, RelPath: "a.txt"})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", resp.Content)
+	assert.Empty(t, resp.ContentType)
+	assert.False(t, resp.Binary)
+	assert.False(t, resp.TooLarge)
+}
+
+func TestReadFile_ImageBase64(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	root := t.TempDir()
+	raw := []byte{0x89, 0x50, 0x4e, 0x47} // 任意字节,png 扩展名即可
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pic.png"), raw, 0o644))
+
+	resp, err := h.ReadFile(context.Background(), wire.ReadFileReq{Root: root, RelPath: "pic.png"})
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", resp.ContentType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(raw), resp.Content)
+	assert.False(t, resp.Binary)
+	assert.False(t, resp.TooLarge)
+}
+
+func TestReadFile_RelPathEscape_PathRefused(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	root := t.TempDir()
+
+	_, err := h.ReadFile(context.Background(), wire.ReadFileReq{Root: root, RelPath: "../etc/passwd"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, wire.ErrPathRefused))
+}
+
+func TestReadFile_EmptyRoot_NoCwd(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+
+	_, err := h.ReadFile(context.Background(), wire.ReadFileReq{Root: ""})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, wire.ErrNoCwd))
+}
+
+func TestReadFile_RelativeRoot_InvalidParams(t *testing.T) {
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+
+	_, err := h.ReadFile(context.Background(), wire.ReadFileReq{Root: "relative/root", RelPath: "a.txt"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rpc.ErrInvalidParams))
+}

--- a/internal/daemon/workspacefs/handler_register_test.go
+++ b/internal/daemon/workspacefs/handler_register_test.go
@@ -46,4 +46,48 @@ func TestRegister_AllThreeMethods_TranslateSentinel(t *testing.T) {
 	resp, ok := res.(*wire.GitBranchesResp)
 	require.True(t, ok)
 	assert.True(t, resp.NotARepo)
+
+	// readFile 越界 relPath 触发 wire.ErrPathRefused,客户端拿到 *rpc.Error。
+	raw, _ = json.Marshal(wire.ReadFileReq{Root: dir, RelPath: "../etc"})
+	_, err = reg.Dispatch(context.Background(), wire.MethodReadFile, raw)
+	rpcErr = nil
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, wire.ErrCodePathRefused, rpcErr.Code)
+
+	// readFile 空 root 触发 wire.ErrNoCwd(会话配置问题,与越界区分)。
+	raw, _ = json.Marshal(wire.ReadFileReq{Root: ""})
+	_, err = reg.Dispatch(context.Background(), wire.MethodReadFile, raw)
+	rpcErr = nil
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, wire.ErrCodeNoCwd, rpcErr.Code)
+
+	// gitFileContent 在非仓库上降级(不报错),确认它也真的挂上了 registry。
+	raw, _ = json.Marshal(wire.GitFileContentReq{Root: dir, RelPath: "a.txt"})
+	res, err = reg.Dispatch(context.Background(), wire.MethodGitFileContent, raw)
+	require.NoError(t, err)
+	gfcResp, ok := res.(*wire.GitFileContentResp)
+	require.True(t, ok)
+	assert.True(t, gfcResp.NotARepo)
+}
+
+func TestRegister_ReadFileGitFileContent_TranslateSentinel(t *testing.T) {
+	reg := rpc.NewRegistry()
+	h := workspacefs.NewHandlers(workspacefs.Options{})
+	workspacefs.Register(reg, h, func(fn rpc.HandlerFunc) rpc.HandlerFunc { return fn })
+
+	// gitFileContent 越界 relPath 触发 wire.ErrPathRefused,与 readFile 同一道
+	// 边界(真仓库里仍先过路径闸门)。
+	repoDir := initRepo(t)
+	raw, _ := json.Marshal(wire.GitFileContentReq{Root: repoDir, RelPath: "../etc"})
+	_, err := reg.Dispatch(context.Background(), wire.MethodGitFileContent, raw)
+	var rpcErr *rpc.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, wire.ErrCodePathRefused, rpcErr.Code)
+
+	// gitFileContent 空 root 触发 wire.ErrNoCwd。
+	raw, _ = json.Marshal(wire.GitFileContentReq{Root: ""})
+	_, err = reg.Dispatch(context.Background(), wire.MethodGitFileContent, raw)
+	rpcErr = nil
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, wire.ErrCodeNoCwd, rpcErr.Code)
 }

--- a/internal/pkg/workspacefs/gitfilecontent.go
+++ b/internal/pkg/workspacefs/gitfilecontent.go
@@ -1,0 +1,77 @@
+package workspacefs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+// GitFileContentResult 是 GitFileContent 的返回结果(对比档左列:同一文件在
+// git HEAD 的版本,与工作区内容并排比较)。
+type GitFileContentResult struct {
+	Content  string // HEAD 的 blob 正文;NotARepo 或 !HasHead 时恒为空
+	NotARepo bool   // dir 不在任何 git 工作树内;为 true 时其余字段恒为零值
+	HasHead  bool   // 文件在 HEAD 存在;为 false 表示空基线(未跟踪/不在 HEAD,对比全部新增)
+}
+
+// GitFileContent 返回 dir 下 relPath 所指文件在 git HEAD 的版本,只读
+// `git show HEAD:<path>`(git 从对象库取 blob,不触碰工作区文件)。
+//   - dir 为空 → ErrNoCwd;relPath 越界(含 ".."、绝对路径、跟随符号链接后逃出
+//     dir)→ ErrPathRefused,与 ReadFile 同一套边界。
+//   - dir 不在任何 git 工作树内 → NotARepo=true 的降级结果,不报错(与
+//     GitChanges / GitBranches 的容错约定一致)。
+//   - 文件未跟踪 / 不在 HEAD(仅暂存未提交、工作区已删除但从未提交亦属此列)
+//     → HasHead=false 的空基线,不报错;工作区已删除但仍在 HEAD 的文件正常
+//     返回 HEAD 版本(对比删除文件正需要它)。
+//   - cwd 是仓库子目录时,relPath 经 workspacePrefix 换算成仓库根相对路径再
+//     交给 git——git 的 <rev>:<path> 路径恒相对仓库根、无视命令在哪个子目录
+//     跑,与 GitChanges 的路径折回同一先例。
+//   - 纯读:经 --no-optional-locks 不抢索引锁、不改 git 状态、不写文件、正文
+//     不进日志。
+func GitFileContent(ctx context.Context, dir, relPath string) (*GitFileContentResult, error) {
+	if dir == "" {
+		return nil, ErrNoCwd
+	}
+	path, err := resolveRelPath(dir, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// 跟随符号链接后再校验仍落在 dir 之内,与 ReadFile 同一道链接逃逸闸门:
+	// relPath 在工作区解析到 cwd 之外的请求一律拒绝,不因 git show 读的是对象
+	// 库就跳过。文件在 HEAD 里、工作区已删除(对比档恰要读这种)时 EvalSymlinks
+	// 报 ENOENT,此时没有链接可跟随,跳过重校验而不是让删除文件的对比读不出来。
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("workspacefs: resolve %q: %w", relPath, err)
+		}
+	} else {
+		dirResolved, rerr := filepath.EvalSymlinks(dir)
+		if rerr != nil {
+			return nil, fmt.Errorf("workspacefs: resolve cwd: %w", rerr)
+		}
+		if !pathWithin(dirResolved, resolved) {
+			return nil, ErrPathRefused
+		}
+	}
+
+	if !isInsideWorkTree(ctx, dir) {
+		return &GitFileContentResult{NotARepo: true}, nil
+	}
+
+	// relPath 相对 dir;git 的 <rev>:<path> 路径恒相对仓库根,先经 workspacePrefix
+	// 折成仓库根相对路径。前缀是 git 自己输出的 "/" 分隔形如 "sub/",relPath 契约
+	// 也是 "/" 分隔,直接拼接。
+	repoPath := workspacePrefix(ctx, dir) + filepath.ToSlash(relPath)
+	out, err := runGit(ctx, dir, nil, "show", "HEAD:"+repoPath)
+	if err != nil {
+		// 未跟踪 / 不在 HEAD(或路径是目录、HEAD 未生):git 拿不到 blob → 空基线,
+		// 不报错(单条 git 子命令容错的既有约定,同 git_changes.go 的 mergeBase
+		// 退化)。
+		return &GitFileContentResult{}, nil //nolint:nilerr // git 报错即"不在 HEAD",正是空基线的正常输入,不是失败
+	}
+	return &GitFileContentResult{Content: out, HasHead: true}, nil
+}

--- a/internal/pkg/workspacefs/gitfilecontent_test.go
+++ b/internal/pkg/workspacefs/gitfilecontent_test.go
@@ -1,0 +1,180 @@
+package workspacefs_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs"
+)
+
+func TestGitFileContent_ReadsHEADVersion(t *testing.T) {
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644))
+	runGit(t, dir, "add", "a.txt")
+	runGit(t, dir, "commit", "-q", "-m", "seed")
+	// 工作区被改动后,对比档左列必须仍取 HEAD 版本,而不是工作区内容。
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2\n"), 0o644))
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "a.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.True(t, res.HasHead)
+	assert.Equal(t, "v1\n", res.Content)
+}
+
+func TestGitFileContent_UntrackedFile_EmptyBaseline(t *testing.T) {
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("untracked\n"), 0o644))
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "new.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.False(t, res.HasHead, "未跟踪文件不在 HEAD → 空基线,对比档左列留空、全部新增")
+	assert.Equal(t, "", res.Content)
+}
+
+// 仅暂存未提交的文件同样不在 HEAD(HEAD 是上一次提交),对比档左列应读不到。
+func TestGitFileContent_StagedButUncommitted_EmptyBaseline(t *testing.T) {
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "staged.txt"), []byte("s\n"), 0o644))
+	runGit(t, dir, "add", "staged.txt")
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "staged.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.False(t, res.HasHead)
+	assert.Equal(t, "", res.Content)
+}
+
+// 工作区已删除、但文件仍提交在 HEAD 里:对比档左列必须还能读到 HEAD 版本
+// (这正是对比删除文件要看的)。git show 读对象库,不依赖工作区文件存在。
+func TestGitFileContent_DeletedInWorktree_StillReadsHEAD(t *testing.T) {
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gone.txt"), []byte("old\n"), 0o644))
+	runGit(t, dir, "add", "gone.txt")
+	runGit(t, dir, "commit", "-q", "-m", "seed")
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.txt")))
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "gone.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.True(t, res.HasHead)
+	assert.Equal(t, "old\n", res.Content)
+}
+
+// 会话工作目录常常只是仓库里的一个子目录。git 的 <rev>:<path> 路径恒相对
+// 仓库根(无视命令在哪个子目录跑),所以 relPath 必须先经 workspacePrefix
+// 换算成仓库根相对路径,否则 git 会在仓库根下找不到该路径。
+func TestGitFileContent_WorkspaceInRepoSubdir(t *testing.T) {
+	root := initRepo(t)
+	require.NoError(t, os.Mkdir(filepath.Join(root, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "inner.txt"), []byte("v1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "outside.txt"), []byte("o\n"), 0o644))
+	runGit(t, root, "add", "sub/inner.txt", "outside.txt")
+	runGit(t, root, "commit", "-q", "-m", "seed")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "inner.txt"), []byte("v2\n"), 0o644))
+
+	dir := filepath.Join(root, "sub")
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "inner.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.True(t, res.HasHead)
+	assert.Equal(t, "v1\n", res.Content, "relPath 相对 cwd,换算成仓库根相对路径后取到 sub/inner.txt 的 HEAD 版本")
+
+	// 越界仍拒绝:不能用 ".." 从子目录折回仓库根去读 outside.txt。
+	_, err = workspacefs.GitFileContent(context.Background(), dir, "../outside.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused))
+}
+
+func TestGitFileContent_NonRepo_NotARepo(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x\n"), 0o644))
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "a.txt")
+	require.NoError(t, err)
+	assert.True(t, res.NotARepo)
+	assert.False(t, res.HasHead)
+	assert.Equal(t, "", res.Content)
+}
+
+func TestGitFileContent_EmptyCwdRejected(t *testing.T) {
+	_, err := workspacefs.GitFileContent(context.Background(), "", "a.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrNoCwd), "cwd 为空应拒绝,与 ReadFile 同一 sentinel")
+}
+
+func TestGitFileContent_EscapeRejected(t *testing.T) {
+	dir := initRepo(t)
+	cases := []string{"..", "../a.txt", "/etc/passwd", "sub/../..", "a/../../../etc/passwd"}
+	for _, rp := range cases {
+		_, err := workspacefs.GitFileContent(context.Background(), dir, rp)
+		assert.Truef(t, errors.Is(err, workspacefs.ErrPathRefused), "relPath=%q err=%v", rp, err)
+	}
+}
+
+// 跟随符号链接逃出 cwd 必须拒绝:即使 git show 读的是对象库,relPath 在
+// 工作区解析到 cwd 之外也不放行(与 ReadFile 同一道链接逃逸闸门)。
+func TestGitFileContent_SymlinkEscapeRejected(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "work")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	outside := filepath.Join(parent, "secret.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "link.txt")))
+	if _, err := os.Lstat(filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	_, err := workspacefs.GitFileContent(context.Background(), dir, "link.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused), "跟随符号链接逃出 cwd 应拒绝")
+}
+
+// cwd 内的符号链接不拒绝。HEAD 里链接以"目标路径"为 blob 内容存储,git show
+// 返回的就是这条链接 blob(而不是去工作区跟随链接读目标文件)——这恰好证明
+// GitFileContent 读的是 HEAD 快照,不经工作区。
+func TestGitFileContent_SymlinkInsideCwd_ReadsHEADBlob(t *testing.T) {
+	dir := initRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.txt"), []byte("v1\n"), 0o644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(dir, "link.txt")))
+	if _, err := os.Lstat(filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	runGit(t, dir, "add", "real.txt", "link.txt")
+	runGit(t, dir, "commit", "-q", "-m", "sym")
+
+	res, err := workspacefs.GitFileContent(context.Background(), dir, "link.txt")
+	require.NoError(t, err)
+	assert.False(t, res.NotARepo)
+	assert.True(t, res.HasHead)
+	assert.Equal(t, "real.txt", res.Content, "HEAD 里符号链接的 blob 是目标路径字符串,不跟随到 real.txt 的正文")
+}
+
+// 文件在 HEAD 里、工作区版本里是逃逸链接:git show 读的是对象库,本不会漏
+// 内容,但链接逃逸闸门必须先于 git 判据,拒绝而不是返回 HEAD blob。
+func TestGitFileContent_HEADExistsButWorktreeSymlinkEscapes_StillRefused(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "work")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("v1\n"), 0o644))
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "config", "user.email", "t@t")
+	runGit(t, dir, "config", "user.name", "t")
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-q", "-m", "seed")
+	// 工作区把 tracked.txt 换成指向 cwd 之外的符号链接。
+	require.NoError(t, os.Remove(filepath.Join(dir, "tracked.txt")))
+	outside := filepath.Join(parent, "secret.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "tracked.txt")))
+	if _, err := os.Lstat(filepath.Join(dir, "tracked.txt")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	_, err := workspacefs.GitFileContent(context.Background(), dir, "tracked.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused))
+}

--- a/internal/pkg/workspacefs/readfile.go
+++ b/internal/pkg/workspacefs/readfile.go
@@ -1,0 +1,137 @@
+package workspacefs
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrNoCwd 表示调用 ReadFile 时未提供工作目录(root 为空)。映射到既有错误码
+// WorkspaceFsNoCwd(20800 段),与"越界"的 ErrPathRefused 区分开——cwd 为空是
+// 会话配置问题,不是路径问题。
+var ErrNoCwd = errors.New("workspacefs: no cwd")
+
+// maxImageSize 是图片(扩展名 allowlist)被判定为过大前允许读取的字节上限。
+// 与文本阈值 maxUntrackedTextSize 分开:图片是唯一允许传输的二进制,阈值单列,
+// 给真实照片留余量(spec 设计决策 4)。
+const maxImageSize = 10 << 20 // 10 MiB
+
+// ReadFileResult 是 ReadFile 的返回结果。
+type ReadFileResult struct {
+	Content     string // 文本为 UTF-8 正文;图片为 base64 编码;binary/tooLarge 时恒为空
+	ContentType string // 图片的 MIME(如 image/png、image/svg+xml);文本恒为空串
+	Binary      bool   // 非图片二进制(内容含 NUL);为 true 时 Content 为空
+	TooLarge    bool   // 超过各自类型阈值(文本 1 MiB / 图片 10 MiB),未读取内容
+}
+
+// ReadFile 读取 root 下 relPath 所指文件的内容(会话级文件预览,纯读)。
+//   - root 是会话已解析的绝对工作目录,是路径越界校验的信任边界;root 为
+//     空串 → ErrNoCwd。
+//   - relPath 相对 root;含 ".."、绝对路径,或跟随符号链接解析后逃出 root 的
+//     请求一律拒绝为 ErrPathRefused(与 ListDir 的 resolveRelPath 同源,额外
+//     多一道符号链接跟随后的重校验——读文件比列目录更需要防"链接逃逸出 cwd
+//     再读出内容")。
+//   - 目录 / 非常规文件(符号链接已解析后)同样拒绝为 ErrPathRefused:本包错误
+//     族里没有"非文件"档,复用一个明确哨兵让调用方统一映射到
+//     WorkspaceFsPathRefused,而不是新开错误码段。
+//   - 文本(markdown / 代码 / 文本):>1MiB 判 TooLarge 不整读;≤1MiB 读入后含
+//     NUL 判 Binary 不返回正文,否则返回 UTF-8 正文。
+//   - 图片:扩展名 allowlist(png/jpg/jpeg/gif/webp/avif/bmp/ico/svg)判定,是
+//     图片则 >10MiB 判 TooLarge,否则返回 base64 内容 + MIME;图片是唯一允许
+//     传输的二进制(设计决策 4)。
+//   - 纯读:不写文件、不改 git 状态;正文与图片内容不进日志(本包无日志)。
+func ReadFile(ctx context.Context, root, relPath string) (*ReadFileResult, error) {
+	if root == "" {
+		return nil, ErrNoCwd
+	}
+	path, err := resolveRelPath(root, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// 跟随符号链接后再校验仍落在 root 之内:链接逃逸出 cwd 的文件内容不能经本
+	// 接口读出。root 自身可能含链接,故两侧都 EvalSymlinks 再比较。
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		// 不存在 / 断链:无法读取,按读取失败处理,不当作越界。
+		return nil, fmt.Errorf("workspacefs: resolve %q: %w", relPath, err)
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("workspacefs: resolve cwd: %w", err)
+	}
+	if !pathWithin(rootResolved, resolved) {
+		return nil, ErrPathRefused
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("workspacefs: stat %q: %w", relPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, ErrPathRefused
+	}
+
+	mime, isImage := imageMIME(relPath)
+	limit := int64(maxUntrackedTextSize)
+	if isImage {
+		limit = maxImageSize
+	}
+	if info.Size() > limit {
+		return &ReadFileResult{TooLarge: true}, nil
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("workspacefs: read %q: %w", relPath, err)
+	}
+	if isImage {
+		return &ReadFileResult{
+			Content:     base64.StdEncoding.EncodeToString(data),
+			ContentType: mime,
+		}, nil
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		return &ReadFileResult{Binary: true}, nil
+	}
+	return &ReadFileResult{Content: string(data)}, nil
+}
+
+// pathWithin 判定 path 与 root 相同或位于 root 子树内(路径边界校验)。
+func pathWithin(root, path string) bool {
+	if path == root {
+		return true
+	}
+	return strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// imageMIME 按扩展名 allowlist 判定文件是否为图片,并返回其 MIME。判定基于
+// 调用方传入的 relPath(与前端预览按钮的 allowlist 一致),大小写不敏感。svg
+// 返回 image/svg+xml(经 <img> 渲染,img 上下文不执行脚本,防 XSS)。
+func imageMIME(name string) (string, bool) {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".png":
+		return "image/png", true
+	case ".jpg", ".jpeg":
+		return "image/jpeg", true
+	case ".gif":
+		return "image/gif", true
+	case ".webp":
+		return "image/webp", true
+	case ".avif":
+		return "image/avif", true
+	case ".bmp":
+		return "image/bmp", true
+	case ".ico":
+		return "image/x-icon", true
+	case ".svg":
+		return "image/svg+xml", true
+	default:
+		return "", false
+	}
+}

--- a/internal/pkg/workspacefs/readfile_test.go
+++ b/internal/pkg/workspacefs/readfile_test.go
@@ -1,0 +1,180 @@
+package workspacefs_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/pkg/workspacefs"
+)
+
+func TestReadFile_Text(t *testing.T) {
+	dir := t.TempDir()
+	content := "hello\nworld\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "note.md"), []byte(content), 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "note.md")
+	require.NoError(t, err)
+	assert.Equal(t, content, res.Content)
+	assert.Equal(t, "", res.ContentType)
+	assert.False(t, res.Binary)
+	assert.False(t, res.TooLarge)
+}
+
+func TestReadFile_NestedRelPath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "a.txt"), []byte("x"), 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "sub/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "x", res.Content)
+}
+
+func TestReadFile_EscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x"), 0o644))
+	cases := []string{"..", "../a.txt", "sub/../..", "/etc/passwd", "a/../../../etc/passwd"}
+	for _, rp := range cases {
+		_, err := workspacefs.ReadFile(context.Background(), dir, rp)
+		assert.Truef(t, errors.Is(err, workspacefs.ErrPathRefused), "relPath=%q err=%v", rp, err)
+	}
+}
+
+func TestReadFile_SymlinkEscapeRejected(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "work")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	outside := filepath.Join(parent, "secret.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "link.txt")))
+
+	_, err := workspacefs.ReadFile(context.Background(), dir, "link.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused), "跟随符号链接逃出 cwd 应拒绝")
+}
+
+func TestReadFile_SymlinkInsideCwd(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.txt"), []byte("hi"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "real.txt"), filepath.Join(dir, "link.txt")))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "link.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "hi", res.Content, "cwd 内符号链接可正常跟随读取")
+}
+
+func TestReadFile_NULBinary(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blob.bin"), []byte{0x68, 0x00, 0x69}, 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "blob.bin")
+	require.NoError(t, err)
+	assert.True(t, res.Binary)
+	assert.Equal(t, "", res.Content)
+	assert.False(t, res.TooLarge)
+}
+
+func TestReadFile_TextTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	data := bytes.Repeat([]byte("a"), 1<<20+1)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.txt"), data, 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "big.txt")
+	require.NoError(t, err)
+	assert.True(t, res.TooLarge)
+	assert.Equal(t, "", res.Content)
+	assert.False(t, res.Binary)
+}
+
+func TestReadFile_TextAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	data := bytes.Repeat([]byte("a"), 1<<20)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "edge.txt"), data, 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "edge.txt")
+	require.NoError(t, err)
+	assert.False(t, res.TooLarge)
+	assert.Equal(t, string(data), res.Content)
+}
+
+func TestReadFile_Image(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		ext  string
+		mime string
+	}{
+		{"png", ".png", "image/png"},
+		{"jpg", ".jpg", "image/jpeg"},
+		{"jpeg", ".jpeg", "image/jpeg"},
+		{"gif", ".gif", "image/gif"},
+		{"webp", ".webp", "image/webp"},
+		{"avif", ".avif", "image/avif"},
+		{"bmp", ".bmp", "image/bmp"},
+		{"ico", ".ico", "image/x-icon"},
+		{"svg", ".svg", "image/svg+xml"},
+	}
+	// 含 NUL 的字节:证明图片是唯一允许传输的二进制,不因含 NUL 被当作 binary。
+	raw := []byte{0x00, 0x01, 0x02, 0xff}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "img"+tc.ext)
+			require.NoError(t, os.WriteFile(path, raw, 0o644))
+
+			res, err := workspacefs.ReadFile(context.Background(), dir, "img"+tc.ext)
+			require.NoError(t, err)
+			assert.False(t, res.Binary)
+			assert.False(t, res.TooLarge)
+			assert.Equal(t, tc.mime, res.ContentType)
+			assert.Equal(t, base64.StdEncoding.EncodeToString(raw), res.Content)
+		})
+	}
+}
+
+func TestReadFile_ImageTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	data := bytes.Repeat([]byte{0xab}, 10<<20+1)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.png"), data, 0o644))
+
+	res, err := workspacefs.ReadFile(context.Background(), dir, "big.png")
+	require.NoError(t, err)
+	assert.True(t, res.TooLarge)
+	assert.Equal(t, "", res.Content)
+	assert.False(t, res.Binary)
+}
+
+func TestReadFile_DirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+
+	_, err := workspacefs.ReadFile(context.Background(), dir, "sub")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused), "目录不是可读文件,应拒绝")
+}
+
+func TestReadFile_SymlinkToDirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "real"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "real"), filepath.Join(dir, "linkdir")))
+
+	_, err := workspacefs.ReadFile(context.Background(), dir, "linkdir")
+	assert.True(t, errors.Is(err, workspacefs.ErrPathRefused))
+}
+
+func TestReadFile_EmptyCwdRejected(t *testing.T) {
+	_, err := workspacefs.ReadFile(context.Background(), "", "a.txt")
+	assert.True(t, errors.Is(err, workspacefs.ErrNoCwd), "cwd 为空应拒绝")
+}
+
+func TestReadFile_MissingFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	_, err := workspacefs.ReadFile(context.Background(), dir, "nope.txt")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, workspacefs.ErrPathRefused), "不存在的文件是读取失败,不是越界")
+}

--- a/internal/pkg/workspacefs/wire/wire.go
+++ b/internal/pkg/workspacefs/wire/wire.go
@@ -12,7 +12,7 @@
 // 命名约定与 internal/pkg/remotefs/wire 一致:
 //   - 方法在 "workspacefs.*" 命名空间下
 //   - 字段名 lowerCamelCase
-//   - 错误码 -32040..-32041 是稳定 wire 值,与既有方法族的 code 段不重叠
+//   - 错误码 -32040..-32042 是稳定 wire 值,与既有方法族的 code 段不重叠
 //     (remotefs.* 占 -32030..-32035,agentruntime remote wire 占
 //     -32010..-32014),wrapGuarded handler 返回 *rpc.Error 由本包翻译,
 //     客户端用 FromJSONRPCError rehydrate。
@@ -27,9 +27,11 @@ import (
 // ── RPC method names ────────────────────────────────────────────────────────
 
 const (
-	MethodListDir     = "workspacefs.listDir"
-	MethodGitChanges  = "workspacefs.gitChanges"
-	MethodGitBranches = "workspacefs.gitBranches"
+	MethodListDir        = "workspacefs.listDir"
+	MethodGitChanges     = "workspacefs.gitChanges"
+	MethodGitBranches    = "workspacefs.gitBranches"
+	MethodReadFile       = "workspacefs.readFile"
+	MethodGitFileContent = "workspacefs.gitFileContent"
 )
 
 // ── Error codes ─────────────────────────────────────────────────────────────
@@ -37,6 +39,7 @@ const (
 const (
 	ErrCodePathRefused      = -32040
 	ErrCodeBaselineRequired = -32041
+	ErrCodeNoCwd            = -32042
 )
 
 // ── Sentinel errors ─────────────────────────────────────────────────────────
@@ -48,6 +51,10 @@ var (
 	// ErrBaselineRequired 镜像 internal/pkg/workspacefs.ErrBaselineRequired:
 	// GitChanges 的 scope=="branch" 时 baseRef 为空。
 	ErrBaselineRequired = errors.New("workspacefs: baseline required for branch scope")
+	// ErrNoCwd 镜像 internal/pkg/workspacefs.ErrNoCwd:调用方未提供工作目录
+	// (root 为空)。与"越界"的 ErrPathRefused 区分开——cwd 为空是会话配置问题,
+	// 不是路径问题。
+	ErrNoCwd = errors.New("workspacefs: no cwd")
 )
 
 // ToJSONRPCError 把 workspacefs sentinel 包成 *rpc.Error,daemon handler 返回。
@@ -58,6 +65,8 @@ func ToJSONRPCError(err error) *rpc.Error {
 		return &rpc.Error{Code: ErrCodePathRefused, Message: err.Error()}
 	case errors.Is(err, ErrBaselineRequired):
 		return &rpc.Error{Code: ErrCodeBaselineRequired, Message: err.Error()}
+	case errors.Is(err, ErrNoCwd):
+		return &rpc.Error{Code: ErrCodeNoCwd, Message: err.Error()}
 	}
 	return nil
 }
@@ -74,6 +83,8 @@ func FromJSONRPCError(err error) error {
 		return ErrPathRefused
 	case ErrCodeBaselineRequired:
 		return ErrBaselineRequired
+	case ErrCodeNoCwd:
+		return ErrNoCwd
 	}
 	return err
 }
@@ -157,4 +168,44 @@ type GitBranchesResp struct {
 	Branches        []Branch `json:"branches"`
 	CurrentBranch   string   `json:"currentBranch,omitempty"`   // detached HEAD 时为空
 	DefaultBaseline string   `json:"defaultBaseline,omitempty"` // 三级都不命中时为空
+}
+
+// ── ReadFile ────────────────────────────────────────────────────────────────
+
+// ReadFileReq.Root 是会话已解析出的工作目录绝对路径(契约同 ListDirReq.Root:
+// 必填且必须是绝对路径);root 为空 → ErrNoCwd(会话配置问题,与越界区分),
+// RelPath 越界 → ErrPathRefused。
+//
+// 镜像 internal/pkg/workspacefs.ReadFile 的入参,host 侧远端分支与 daemon 共享
+// 同一套路径边界语义。
+type ReadFileReq struct {
+	Root    string `json:"root"`
+	RelPath string `json:"relPath"`
+}
+
+// ReadFileResp 镜像 internal/pkg/workspacefs.ReadFileResult:文本为 UTF-8 正文,
+// 图片为 base64 内容 + ContentType(如 image/png);Binary / TooLarge 为 true 时
+// Content 恒为空。
+type ReadFileResp struct {
+	Content     string `json:"content"`
+	ContentType string `json:"contentType,omitempty"`
+	Binary      bool   `json:"binary,omitempty"`
+	TooLarge    bool   `json:"tooLarge,omitempty"`
+}
+
+// ── GitFileContent ──────────────────────────────────────────────────────────
+
+// GitFileContentReq 的 Root / RelPath 契约与 ReadFileReq 相同:root 为空 →
+// ErrNoCwd,relPath 越界 → ErrPathRefused。
+type GitFileContentReq struct {
+	Root    string `json:"root"`
+	RelPath string `json:"relPath"`
+}
+
+// GitFileContentResp 镜像 internal/pkg/workspacefs.GitFileContentResult:对比档左
+// 列 = 同一文件在 git HEAD 的版本;NotARepo / !HasHead 时 Content 恒为空。
+type GitFileContentResp struct {
+	Content  string `json:"content"`
+	NotARepo bool   `json:"notARepo,omitempty"` // true 时其余字段恒为零值
+	HasHead  bool   `json:"hasHead,omitempty"`  // false 表示空基线(未跟踪/不在 HEAD)
 }

--- a/internal/pkg/workspacefs/wire/wire_test.go
+++ b/internal/pkg/workspacefs/wire/wire_test.go
@@ -19,6 +19,7 @@ func TestSentinelRoundTrip(t *testing.T) {
 	}{
 		{"PathRefused", wire.ErrPathRefused, wire.ErrCodePathRefused},
 		{"BaselineRequired", wire.ErrBaselineRequired, wire.ErrCodeBaselineRequired},
+		{"NoCwd", wire.ErrNoCwd, wire.ErrCodeNoCwd},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -52,7 +53,7 @@ func TestFromJSONRPCError_UnknownCode(t *testing.T) {
 // 这条守卫就只在写它的那天成立。remotefs 认不出来时按约定原样返回,拿到的还是
 // 同一个 *rpc.Error;一旦翻出了别的 sentinel,就是撞号了。
 func TestErrorCodes_DoNotOverlapRemotefs(t *testing.T) {
-	for _, code := range []int{wire.ErrCodePathRefused, wire.ErrCodeBaselineRequired} {
+	for _, code := range []int{wire.ErrCodePathRefused, wire.ErrCodeBaselineRequired, wire.ErrCodeNoCwd} {
 		src := &rpc.Error{Code: code, Message: "x"}
 		assert.Samef(t, src, remotefswire.FromJSONRPCError(src),
 			"workspacefs code %d 被 remotefs.* 翻成了它自己的 sentinel,两个方法族撞号", code)

--- a/internal/service/workspace_fs_svc/mock_workspace_fs_svc/mock_svc.go
+++ b/internal/service/workspace_fs_svc/mock_workspace_fs_svc/mock_svc.go
@@ -71,6 +71,21 @@ func (mr *MockWorkspaceFsSvcMockRecorder) GitChanges(ctx, sessionID, scope, base
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GitChanges", reflect.TypeOf((*MockWorkspaceFsSvc)(nil).GitChanges), ctx, sessionID, scope, baseRef)
 }
 
+// GitFileContent mocks base method.
+func (m *MockWorkspaceFsSvc) GitFileContent(ctx context.Context, sessionID int64, relPath string) (*workspace_fs_svc.GitFileContentView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GitFileContent", ctx, sessionID, relPath)
+	ret0, _ := ret[0].(*workspace_fs_svc.GitFileContentView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GitFileContent indicates an expected call of GitFileContent.
+func (mr *MockWorkspaceFsSvcMockRecorder) GitFileContent(ctx, sessionID, relPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GitFileContent", reflect.TypeOf((*MockWorkspaceFsSvc)(nil).GitFileContent), ctx, sessionID, relPath)
+}
+
 // ListDir mocks base method.
 func (m *MockWorkspaceFsSvc) ListDir(ctx context.Context, sessionID int64, relPath string, includeIgnored bool) (*workspace_fs_svc.ListDirView, error) {
 	m.ctrl.T.Helper()
@@ -84,4 +99,19 @@ func (m *MockWorkspaceFsSvc) ListDir(ctx context.Context, sessionID int64, relPa
 func (mr *MockWorkspaceFsSvcMockRecorder) ListDir(ctx, sessionID, relPath, includeIgnored any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDir", reflect.TypeOf((*MockWorkspaceFsSvc)(nil).ListDir), ctx, sessionID, relPath, includeIgnored)
+}
+
+// ReadFile mocks base method.
+func (m *MockWorkspaceFsSvc) ReadFile(ctx context.Context, sessionID int64, relPath string) (*workspace_fs_svc.ReadFileView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFile", ctx, sessionID, relPath)
+	ret0, _ := ret[0].(*workspace_fs_svc.ReadFileView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadFile indicates an expected call of ReadFile.
+func (mr *MockWorkspaceFsSvcMockRecorder) ReadFile(ctx, sessionID, relPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockWorkspaceFsSvc)(nil).ReadFile), ctx, sessionID, relPath)
 }

--- a/internal/service/workspace_fs_svc/svc.go
+++ b/internal/service/workspace_fs_svc/svc.go
@@ -52,6 +52,13 @@ type WorkspaceFsSvc interface {
 	GitChanges(ctx context.Context, sessionID int64, scope, baseRef string) (*GitChangesView, error)
 	// GitBranches 取分支清单 + 当前分支 + 推断出的默认基线。
 	GitBranches(ctx context.Context, sessionID int64) (*GitBranchesView, error)
+	// ReadFile 读取会话工作目录下 relPath 所指文件的内容(会话级文件预览,纯读)。
+	// 文本为 UTF-8 正文;图片为 base64 内容 + contentType;binary/tooLarge 是
+	// 视图标志,不是错误(设计决策 5)。
+	ReadFile(ctx context.Context, sessionID int64, relPath string) (*ReadFileView, error)
+	// GitFileContent 取同一文件在 git HEAD 的版本(对比档左列);未跟踪/不在
+	// HEAD → 空基线(HasHead=false),非 git 仓库 → NotARepo,均不报错。
+	GitFileContent(ctx context.Context, sessionID int64, relPath string) (*GitFileContentView, error)
 }
 
 // ── views ───────────────────────────────────────────────────────────────────
@@ -99,6 +106,24 @@ type GitBranchesView struct {
 	CurrentBranch   string       `json:"currentBranch"`   // detached HEAD 时为空
 	DefaultBaseline string       `json:"defaultBaseline"` // 推断不出时为空
 	Branches        []BranchView `json:"branches"`
+}
+
+// ReadFileView 是 ReadFile 的返回值:文本为 UTF-8 正文(content),图片为 base64
+// 内容 + contentType(如 image/png);binary/tooLarge 为 true 时 content 恒为空。
+// 这三个标志是视图字段,不新增错误码(spec 决策 5)。
+type ReadFileView struct {
+	Content     string `json:"content"`
+	ContentType string `json:"contentType,omitempty"`
+	Binary      bool   `json:"binary,omitempty"`
+	TooLarge    bool   `json:"tooLarge,omitempty"`
+}
+
+// GitFileContentView 是 GitFileContent 的返回值:同一文件在 git HEAD 的版本
+// (对比档左列);NotARepo / !HasHead 时 content 恒为空。
+type GitFileContentView struct {
+	Content  string `json:"content"`
+	NotARepo bool   `json:"notARepo,omitempty"`
+	HasHead  bool   `json:"hasHead,omitempty"` // false 表示空基线(未跟踪/不在 HEAD)
 }
 
 // ── impl ────────────────────────────────────────────────────────────────────
@@ -198,6 +223,66 @@ func (s *workspaceFsImpl) GitBranches(ctx context.Context, sessionID int64) (*Gi
 		return nil, err
 	}
 	return s.gitBranches(ctx, deviceID, cwd)
+}
+
+// ReadFile 按 deviceID 路由:本机直接调叶子包 internal/pkg/workspacefs.ReadFile;
+// 远端经租约调 workspacefs.readFile RPC(daemon 侧是同一份叶子实现)。cwd 由
+// workspace() 在服务层强制,前端只传 sessionID + relPath,路径边界由叶子包 /
+// daemon 强制(硬不变量 2)。
+func (s *workspaceFsImpl) ReadFile(ctx context.Context, sessionID int64, relPath string) (*ReadFileView, error) {
+	deviceID, cwd, err := s.workspace(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if deviceID == 0 {
+		res, lerr := workspacefs.ReadFile(ctx, cwd, relPath)
+		if lerr != nil {
+			return nil, mapLocalErr(ctx, lerr)
+		}
+		return &ReadFileView{
+			Content: res.Content, ContentType: res.ContentType,
+			Binary: res.Binary, TooLarge: res.TooLarge,
+		}, nil
+	}
+
+	var resp wire.ReadFileResp
+	req := wire.ReadFileReq{Root: cwd, RelPath: relPath}
+	if cerr := s.call(ctx, deviceID, wire.MethodReadFile, req, &resp); cerr != nil {
+		return nil, cerr
+	}
+	return &ReadFileView{
+		Content: resp.Content, ContentType: resp.ContentType,
+		Binary: resp.Binary, TooLarge: resp.TooLarge,
+	}, nil
+}
+
+// GitFileContent 按 deviceID 路由:本机直接调叶子包 workspacefs.GitFileContent;
+// 远端经租约调 workspacefs.gitFileContent RPC。notARepo / hasHead 是视图字段。
+func (s *workspaceFsImpl) GitFileContent(ctx context.Context, sessionID int64, relPath string) (*GitFileContentView, error) {
+	deviceID, cwd, err := s.workspace(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if deviceID == 0 {
+		res, lerr := workspacefs.GitFileContent(ctx, cwd, relPath)
+		if lerr != nil {
+			return nil, mapLocalErr(ctx, lerr)
+		}
+		return &GitFileContentView{
+			Content: res.Content, NotARepo: res.NotARepo, HasHead: res.HasHead,
+		}, nil
+	}
+
+	var resp wire.GitFileContentResp
+	req := wire.GitFileContentReq{Root: cwd, RelPath: relPath}
+	if cerr := s.call(ctx, deviceID, wire.MethodGitFileContent, req, &resp); cerr != nil {
+		return nil, cerr
+	}
+	return &GitFileContentView{
+		Content: resp.Content, NotARepo: resp.NotARepo, HasHead: resp.HasHead,
+	}, nil
 }
 
 // gitBranches 是 GitBranches 与「本分支」档基线解析共用的取数步骤。

--- a/internal/service/workspace_fs_svc/svc_test.go
+++ b/internal/service/workspace_fs_svc/svc_test.go
@@ -410,6 +410,219 @@ func TestGitChanges_LocalBranchScope_EndToEnd(t *testing.T) {
 	})
 }
 
+// ── ReadFile:按 deviceID 路由 + 视图字段透传 ───────────────────────────────
+
+func TestReadFile_RoutesByDeviceID(t *testing.T) {
+	convey.Convey("ReadFile 按 deviceID 路由", t, func() {
+		convey.Convey("deviceID=0 → 本机 in-process,不借租约", func() {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello\n"), 0o644))
+			r := newRig(t, 0, dir)
+			// rd 上没有任何 EXPECT:一旦走了远端分支,gomock 会直接判错。
+
+			view, err := r.svc.ReadFile(r.ctx, 42, "a.txt")
+			require.NoError(t, err)
+			assert.False(t, view.Binary)
+			assert.False(t, view.TooLarge)
+			assert.Equal(t, "hello\n", view.Content)
+		})
+
+		convey.Convey("deviceID≠0 → 走 RPC,root 用服务解析出的 cwd", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodReadFile, wire.ReadFileReq{Root: "/remote/work", RelPath: "a.txt"}).
+				DoAndReturn(func(_ context.Context, _ string, _ any, out any) error {
+					resp := out.(*wire.ReadFileResp)
+					resp.Content = "remote body\n"
+					return nil
+				})
+
+			view, err := r.svc.ReadFile(r.ctx, 42, "a.txt")
+			require.NoError(t, err)
+			assert.Equal(t, "remote body\n", view.Content)
+			assert.False(t, view.Binary)
+			assert.False(t, view.TooLarge)
+		})
+	})
+}
+
+func TestReadFile_ViewFlagsPassThrough(t *testing.T) {
+	convey.Convey("binary / tooLarge / contentType 是视图字段,不是错误码", t, func() {
+		convey.Convey("本机:含 NUL 的文件 → Binary 标志,不报错", func() {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "bin.dat"), []byte("a\x00b"), 0o644))
+			r := newRig(t, 0, dir)
+
+			view, err := r.svc.ReadFile(r.ctx, 42, "bin.dat")
+			require.NoError(t, err)
+			assert.True(t, view.Binary)
+			assert.Empty(t, view.Content)
+		})
+
+		convey.Convey("远端:wire 字段原样透传(图片 base64 + contentType)", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodReadFile, wire.ReadFileReq{Root: "/remote/work", RelPath: "img.png"}).
+				DoAndReturn(func(_ context.Context, _ string, _ any, out any) error {
+					resp := out.(*wire.ReadFileResp)
+					resp.Content = "aGVsbG8="
+					resp.ContentType = "image/png"
+					return nil
+				})
+
+			view, err := r.svc.ReadFile(r.ctx, 42, "img.png")
+			require.NoError(t, err)
+			assert.Equal(t, "aGVsbG8=", view.Content)
+			assert.Equal(t, "image/png", view.ContentType)
+		})
+	})
+}
+
+func TestReadFile_ErrorMapping(t *testing.T) {
+	convey.Convey("ReadFile 错误映射复用 20800 段", t, func() {
+		convey.Convey("cwd 为空 → WorkspaceFsNoCwd,不借租约", func() {
+			r := newRig(t, 7, "")
+			_, err := r.svc.ReadFile(r.ctx, 42, "a.txt")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsNoCwd).Error(), err.Error())
+		})
+
+		convey.Convey("本机越界 → WorkspaceFsPathRefused", func() {
+			r := newRig(t, 0, t.TempDir())
+			_, err := r.svc.ReadFile(r.ctx, 42, "../etc/passwd")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsPathRefused).Error(), err.Error())
+		})
+
+		convey.Convey("远端越界 → 同一个 WorkspaceFsPathRefused", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodReadFile, gomock.Any()).
+				Return(&rpc.Error{Code: wire.ErrCodePathRefused, Message: "refused"})
+			_, err := r.svc.ReadFile(r.ctx, 42, "../etc/passwd")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsPathRefused).Error(), err.Error())
+		})
+
+		convey.Convey("远端方法不存在 → WorkspaceFsDaemonOutdated", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodReadFile, gomock.Any()).
+				Return(&rpc.Error{Code: -32601, Message: "Method not found"})
+			_, err := r.svc.ReadFile(r.ctx, 42, "a.txt")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsDaemonOutdated).Error(), err.Error())
+		})
+
+		convey.Convey("借不到租约 → WorkspaceFsDeviceOffline", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.rd.EXPECT().Pool().Return(r.pool)
+			r.pool.EXPECT().Borrow(r.ctx, int64(7)).Return(nil, errors.New("dial fail"))
+			_, err := r.svc.ReadFile(r.ctx, 42, "a.txt")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsDeviceOffline).Error(), err.Error())
+		})
+	})
+}
+
+// ── GitFileContent:按 deviceID 路由 + 错误映射 ──────────────────────────────
+
+func TestGitFileContent_RoutesByDeviceID(t *testing.T) {
+	convey.Convey("GitFileContent 按 deviceID 路由", t, func() {
+		convey.Convey("deviceID=0 → 本机叶子包读 HEAD 版本", func() {
+			dir := initRepo(t)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644))
+			runGit(t, dir, "add", "a.txt")
+			runGit(t, dir, "commit", "-q", "-m", "seed")
+			// 工作区被改动后,对比档左列必须仍取 HEAD 版本,而不是工作区内容。
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2\n"), 0o644))
+			r := newRig(t, 0, dir)
+
+			view, err := r.svc.GitFileContent(r.ctx, 42, "a.txt")
+			require.NoError(t, err)
+			assert.False(t, view.NotARepo)
+			assert.True(t, view.HasHead)
+			assert.Equal(t, "v1\n", view.Content)
+		})
+
+		convey.Convey("deviceID=0 未跟踪 → 空基线标志,不报错", func() {
+			dir := initRepo(t)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("x\n"), 0o644))
+			r := newRig(t, 0, dir)
+
+			view, err := r.svc.GitFileContent(r.ctx, 42, "new.txt")
+			require.NoError(t, err)
+			assert.False(t, view.NotARepo)
+			assert.False(t, view.HasHead)
+			assert.Empty(t, view.Content)
+		})
+
+		convey.Convey("deviceID=0 非 git 目录 → NotARepo,不报错", func() {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x\n"), 0o644))
+			r := newRig(t, 0, dir)
+
+			view, err := r.svc.GitFileContent(r.ctx, 42, "a.txt")
+			require.NoError(t, err)
+			assert.True(t, view.NotARepo)
+			assert.False(t, view.HasHead)
+			assert.Empty(t, view.Content)
+		})
+
+		convey.Convey("deviceID≠0 → 走 RPC,root 用服务解析出的 cwd", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodGitFileContent, wire.GitFileContentReq{Root: "/remote/work", RelPath: "a.txt"}).
+				DoAndReturn(func(_ context.Context, _ string, _ any, out any) error {
+					resp := out.(*wire.GitFileContentResp)
+					resp.Content = "head body\n"
+					resp.HasHead = true
+					return nil
+				})
+
+			view, err := r.svc.GitFileContent(r.ctx, 42, "a.txt")
+			require.NoError(t, err)
+			assert.False(t, view.NotARepo)
+			assert.True(t, view.HasHead)
+			assert.Equal(t, "head body\n", view.Content)
+		})
+	})
+}
+
+func TestGitFileContent_ErrorMapping(t *testing.T) {
+	convey.Convey("GitFileContent 错误映射复用 20800 段", t, func() {
+		convey.Convey("本机越界 → WorkspaceFsPathRefused", func() {
+			dir := initRepo(t)
+			r := newRig(t, 0, dir)
+			_, err := r.svc.GitFileContent(r.ctx, 42, "../outside")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsPathRefused).Error(), err.Error())
+		})
+
+		convey.Convey("远端越界 → 同一个 WorkspaceFsPathRefused", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodGitFileContent, gomock.Any()).
+				Return(&rpc.Error{Code: wire.ErrCodePathRefused, Message: "refused"})
+			_, err := r.svc.GitFileContent(r.ctx, 42, "../etc/passwd")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsPathRefused).Error(), err.Error())
+		})
+
+		convey.Convey("远端方法不存在 → WorkspaceFsDaemonOutdated", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.expectCall(wire.MethodGitFileContent, gomock.Any()).
+				Return(&rpc.Error{Code: -32601, Message: "Method not found"})
+			_, err := r.svc.GitFileContent(r.ctx, 42, "a.txt")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsDaemonOutdated).Error(), err.Error())
+		})
+
+		convey.Convey("借不到租约 → WorkspaceFsDeviceOffline", func() {
+			r := newRig(t, 7, "/remote/work")
+			r.rd.EXPECT().Pool().Return(r.pool)
+			r.pool.EXPECT().Borrow(r.ctx, int64(7)).Return(nil, errors.New("dial fail"))
+			_, err := r.svc.GitFileContent(r.ctx, 42, "a.txt")
+			require.Error(t, err)
+			assert.Equal(t, i18n.NewError(r.ctx, code.WorkspaceFsDeviceOffline).Error(), err.Error())
+		})
+	})
+}
+
 // ── 包级注入 ────────────────────────────────────────────────────────────────
 
 func TestRegisterSessionWorkspaceResolver(t *testing.T) {


### PR DESCRIPTION
## 摘要

会话「文件」面板三模式（变动 / 目录 / Git）新增**右侧可拖拽调宽预览面板**：文件行有独立「预览」(Eye) 按钮，点击在右侧面板渲染内容。读取是会话级（`sessionID` + 相对 cwd 的 `relPath`）、带 cwd 边界（复用 `ErrPathRefused`）、本机与远端（agentred）同一语义。

- **markdown**（`.md` / `.markdown`，不含 `.mdx`）：渲染 / 文本 / 双栏三档（默认渲染），渲染走既有 `MarkdownText`（GFM），源码走 Monaco 只读。
- **代码 / 文本**：Monaco 只读，**无分段控件**；首视图由入口模式决定——**目录打开 = 内容，Git / 变动打开 = 直接显示与 git HEAD 的对比**（Monaco diff，左 HEAD 右工作区，只读，增删图例）。
- **图片**：`<img>` data URL 渲染（棋盘格底、alt=文件名），SVG 经 `<img>`（不执行脚本）。
- 文本 >1MiB / 图片 >10MiB → tooLarge 态；含 NUL 且非图片 → binary 态；错误态复用既有 20800 错误码 + `panel-feedback`。
- **doneTick**（本会话轮次结束）自动重读刷新；按会话存储选中文件与档位，切会话清空。
- 面板入场纯右滑 200ms 无淡入、正文切换淡入 150ms，全部 `motion-reduce:` 安全。
- 后端：叶子包 `workspacefs.ReadFile` / `GitFileContent` + wire/daemon RPC 族 + `workspace_fs_svc` 按 deviceID 路由；Monaco 裸 `monaco-editor` + Vite `?worker` 本地打包、懒加载不进初始包、不引 CDN loader（桌面离线 + `//go:embed`）。

## 测试

- 后端 `GOWORK=off make test-backend`：全绿（119+ 包，0 FAIL）。
- 前端 `pnpm test`：220 文件 / 2084 测试全绿；`tsc -b` / `eslint` 0。
- 本地 e2e（scratch，真实 Wails IPC + 真实 Monaco）：`cd e2e && GOWORK=off pnpm run test:scratch` **1 passed**，12 张截图 + 独立佐证（`git status` M README.md / M main.go）。报告：`e2e/scratch/2026-08-07-session-file-preview/report.md`。
- spec 轴 + code 轴双轮 review-and-fix 已过（修复：无 cwd 按钮、切文件错帧、JSON 高亮、Monaco 主题、diff TextModel 泄漏、关面板竞态）。

## Standing findings（已知限制，未在本轮修复）

- **F1**：git 模式打开**已删除**文件（HEAD 仍在）→ 面板显示 read failed 死路；`GitFileContent` 支持已删除文件（返回 HEAD 版本），但 readState 先短路。修复需 leaf→wire→svc→panel 加 not-found 信号（spec 决策 5 属主，超出本轮）。
- **O1**：非 git cwd + 变动模式打开代码文件 → 只见「没有可对比的 git 基准」空态，内容不可达（决策 9 设计降级，spec 轴确认合规）。

## 未 observed（有单测覆盖，e2e fake 无法驱动）

- 变动模式预览按钮（fake 不产生文件编辑行，无行可点）。
- notARepo / 未跟踪空左列（验证 cwd 是全跟踪 git 仓库）。
- 远端 agentred 一致性（e2e 无 daemon）。
- 动画节奏观感（class 级已验证 `motion-reduce:animate-none`）。
