### PR TITLE
🎨 Agent 后端类型选择器：两列单选卡片 + CLI 探测徽标（含远端探测）

### DIFF
--- a/frontend/src/components/agentre/__tests__/agent-backends.test.tsx
+++ b/frontend/src/components/agentre/__tests__/agent-backends.test.tsx
@@ -566,7 +566,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "本机 Pi" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Pi Agent CLI/ }),
+      within(dialog).getByRole("radio", { name: /Pi Agent CLI/ }),
     );
 
     const input = within(dialog).getByPlaceholderText(
@@ -655,7 +655,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "Pi 绑供应商" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Pi Agent CLI/ }),
+      within(dialog).getByRole("radio", { name: /Pi Agent CLI/ }),
     );
 
     await user.click(
@@ -726,7 +726,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "Pi 空模型" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Pi Agent CLI/ }),
+      within(dialog).getByRole("radio", { name: /Pi Agent CLI/ }),
     );
     await user.click(
       within(dialog).getByRole("combobox", { name: "LLM Provider" }),
@@ -757,7 +757,7 @@ describe("AgentBackendsPanel", () => {
 
     // 切换到 Claude Code CLI 类型 → provider 默认为空（CLI 自身登录）。
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
@@ -791,7 +791,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "本地 claude" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
@@ -826,7 +826,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "远端 claude" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     await user.click(
@@ -884,7 +884,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "远端 claude" } },
     );
     await user.click(
-      within(editorDialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(editorDialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
     await user.click(
       within(editorDialog).getByRole("combobox", { name: "Runtime Device" }),
@@ -938,7 +938,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "远端 claude" } },
     );
     await user.click(
-      within(editorDialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(editorDialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
     await user.click(
       within(editorDialog).getByRole("combobox", { name: "Runtime Device" }),
@@ -995,7 +995,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "远端 claude" } },
     );
     await user.click(
-      within(editorDialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(editorDialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
     await user.click(
       within(editorDialog).getByRole("combobox", { name: "Runtime Device" }),
@@ -1062,7 +1062,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "已同步 claude" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
     await user.click(
       within(dialog).getByRole("combobox", { name: "Runtime Device" }),
@@ -1149,7 +1149,7 @@ describe("AgentBackendsPanel", () => {
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     await waitFor(() => {
@@ -1174,7 +1174,7 @@ describe("AgentBackendsPanel", () => {
     await screen.findByRole("list", { name: "Agent backend list" });
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: /Codex CLI/ }));
+    await user.click(within(dialog).getByRole("radio", { name: /Codex CLI/ }));
 
     await waitFor(() => {
       expect(resolveFn).toHaveBeenCalledWith(
@@ -1195,7 +1195,7 @@ describe("AgentBackendsPanel", () => {
     await screen.findByRole("list", { name: "Agent backend list" });
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: /Codex CLI/ }));
+    await user.click(within(dialog).getByRole("radio", { name: /Codex CLI/ }));
     await user.click(
       within(dialog).getByRole("combobox", { name: "Approval Policy" }),
     );
@@ -1227,7 +1227,7 @@ describe("AgentBackendsPanel", () => {
       within(dialog).getByPlaceholderText("Example: Local · Claude Code"),
       { target: { value: "codex xhigh" } },
     );
-    await user.click(within(dialog).getByRole("button", { name: /Codex CLI/ }));
+    await user.click(within(dialog).getByRole("radio", { name: /Codex CLI/ }));
 
     await user.click(
       within(dialog).getByRole("combobox", { name: "Reasoning Effort" }),
@@ -1264,7 +1264,7 @@ describe("AgentBackendsPanel", () => {
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     // 给一点时机让 ResolveCLIPath 的 Promise 完成；命中分支已被其它用例覆盖，这里仅断终态。
@@ -1287,7 +1287,7 @@ describe("AgentBackendsPanel", () => {
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     const input = within(dialog).getByPlaceholderText(
@@ -1298,10 +1298,12 @@ describe("AgentBackendsPanel", () => {
     // 用户手改了值，然后点按钮重识别 → 按钮要覆盖手填值。
     fireEvent.change(input, { target: { value: "/wrong/path" } });
     nextPath = "/second/claude";
+    // 打开对话框时会对三个 CLI 各探一次，所以只能比「点按钮前后」的增量，不能比总次数。
+    const callsBeforeDetect = resolveFn.mock.calls.length;
     await user.click(within(dialog).getByRole("button", { name: /Detect/ }));
 
     await waitFor(() => expect(input.value).toBe("/second/claude"));
-    expect(resolveFn).toHaveBeenCalledTimes(2);
+    expect(resolveFn.mock.calls.length).toBe(callsBeforeDetect + 1);
   });
 
   it("自动识别按钮未命中时显示 $PATH 提示且不改 input", async () => {
@@ -1316,7 +1318,7 @@ describe("AgentBackendsPanel", () => {
     await screen.findByRole("list", { name: "Agent backend list" });
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: /Codex CLI/ }));
+    await user.click(within(dialog).getByRole("radio", { name: /Codex CLI/ }));
 
     const input = within(dialog).getByPlaceholderText(
       "/usr/local/bin/codex",
@@ -1421,7 +1423,7 @@ describe("AgentBackendsPanel", () => {
       { target: { value: "远端 claude" } },
     );
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     // 选远端 device
@@ -1475,7 +1477,7 @@ describe("AgentBackendsPanel", () => {
 
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: /Claude Code CLI/ }),
+      within(dialog).getByRole("radio", { name: /Claude Code CLI/ }),
     );
 
     // 不改 device → 保持本地
@@ -1538,7 +1540,7 @@ describe("AgentBackendsPanel", () => {
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: "OpenClaw Gateway" }),
+      within(dialog).getByRole("radio", { name: "OpenClaw Gateway" }),
     );
 
     await user.clear(within(dialog).getByLabelText("Name"));
@@ -1653,7 +1655,7 @@ describe("AgentBackendsPanel", () => {
     await user.click(screen.getByRole("button", { name: /New Backend/ }));
     const dialog = await screen.findByRole("dialog");
     await user.click(
-      within(dialog).getByRole("button", { name: "OpenClaw Gateway" }),
+      within(dialog).getByRole("radio", { name: "OpenClaw Gateway" }),
     );
     expect(
       within(dialog).getByText(
@@ -1699,6 +1701,359 @@ describe("AgentBackendsPanel", () => {
   });
 });
 
+describe("Agent backend type picker", () => {
+  async function openCreateDialog(user: ReturnType<typeof userEvent.setup>) {
+    render(<AgentBackendsPanel />);
+    await screen.findByRole("list", { name: "Agent backend list" });
+    await user.click(screen.getByRole("button", { name: /New Backend/ }));
+    return screen.findByRole("dialog");
+  }
+
+  it("Given the create dialog, When it opens, Then the five types render as a single-choice radiogroup with the current type checked", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    expect(within(group).getAllByRole("radio")).toHaveLength(5);
+    expect(
+      within(group).getByRole("radio", { name: /Built-in Agent/ }),
+    ).toBeChecked();
+    expect(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    ).not.toBeChecked();
+
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+    expect(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    ).toBeChecked();
+    expect(
+      within(group).getByRole("radio", { name: /Built-in Agent/ }),
+    ).not.toBeChecked();
+  });
+
+  it("Given local CLIs on $PATH, When the create dialog opens, Then every CLI type is probed and shows an installed / not-installed badge", async () => {
+    const user = userEvent.setup();
+    const resolveFn = vi.fn((req: unknown) => {
+      const { type } = req as { type: string };
+      return Promise.resolve(
+        type === "piagent"
+          ? { path: "", found: false }
+          : { path: `/usr/local/bin/${type}`, found: true },
+      );
+    });
+    installAppMock({ ResolveAgentBackendCLIPath: resolveFn });
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    await waitFor(() => {
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+        ).getByText("Installed"),
+      ).toBeInTheDocument();
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Pi Agent CLI/ }),
+        ).getByText("Not installed"),
+      ).toBeInTheDocument();
+    });
+
+    for (const type of ["claudecode", "codex", "piagent"]) {
+      expect(resolveFn).toHaveBeenCalledWith(
+        expect.objectContaining({ type, deviceId: "" }),
+      );
+    }
+  });
+
+  it("Given probes still in flight, When the create dialog has just opened, Then CLI types show a detecting badge and stay selectable", async () => {
+    const user = userEvent.setup();
+    let release: (v: { path: string; found: boolean }) => void = () => {};
+    installAppMock({
+      ResolveAgentBackendCLIPath: vi.fn(
+        () =>
+          new Promise<{ path: string; found: boolean }>((resolve) => {
+            release = resolve;
+          }),
+      ),
+    });
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+    const codex = within(group).getByRole("radio", { name: /Codex CLI/ });
+
+    await waitFor(() =>
+      expect(within(codex).getByText(/Detecting/)).toBeInTheDocument(),
+    );
+    expect(codex).toBeEnabled();
+
+    await user.click(codex);
+    expect(
+      within(group).getByRole("radio", { name: /Codex CLI/ }),
+    ).toBeChecked();
+
+    release({ path: "/usr/local/bin/codex", found: true });
+  });
+
+  it("Given a probe that already answered, When that CLI type is selected, Then the path is reused without another round-trip", async () => {
+    const user = userEvent.setup();
+    const resolveFn = vi.fn((req: unknown) => {
+      const { type } = req as { type: string };
+      return Promise.resolve({ path: `/usr/local/bin/${type}`, found: true });
+    });
+    installAppMock({ ResolveAgentBackendCLIPath: resolveFn });
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+    await waitFor(() =>
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+        ).getByText("Installed"),
+      ).toBeInTheDocument(),
+    );
+
+    // 探测已经给出结论了，再点这个类型不该重新拨一次 —— 远端设备上这是一次真实的网络往返，
+    // 而方向键会逐个 onChange，代价按键盘步数累加。
+    const callsBeforeSelect = resolveFn.mock.calls.length;
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+
+    await waitFor(() => {
+      const input = within(dialog).getByPlaceholderText(
+        "/usr/local/bin/claude",
+      ) as HTMLInputElement;
+      expect(input.value).toBe("/usr/local/bin/claudecode");
+    });
+    expect(resolveFn.mock.calls.length).toBe(callsBeforeSelect);
+  });
+
+  it("Given non-CLI types, When the picker renders, Then Built-in carries a local-only badge and OpenClaw carries no badge", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    expect(
+      within(
+        within(group).getByRole("radio", { name: /Built-in Agent/ }),
+      ).getByText("Local only"),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("radio", { name: /OpenClaw Gateway/ }),
+    ).toHaveAccessibleName("OpenClaw Gateway");
+  });
+
+  it("Given a remote device is selected, When the CLI probe re-runs, Then it targets that device and refreshes the badges", async () => {
+    const user = userEvent.setup();
+    const resolveFn = vi.fn((req: unknown) => {
+      const { type, deviceId } = req as { type: string; deviceId: string };
+      // 本机没装 codex，远端 linux-srv 装了 —— 徽标必须跟着设备变。
+      return Promise.resolve(
+        deviceId === "7" && type === "codex"
+          ? { path: "/opt/codex", found: true }
+          : { path: "", found: false },
+      );
+    });
+    installAppMock({
+      ResolveAgentBackendCLIPath: resolveFn,
+      RemoteDeviceList: vi.fn(() =>
+        Promise.resolve([{ id: 7, name: "linux-srv", online: true }]),
+      ),
+    });
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    await waitFor(() =>
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Codex CLI/ }),
+        ).getByText("Not installed"),
+      ).toBeInTheDocument(),
+    );
+
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+    await user.click(
+      within(dialog).getByRole("combobox", { name: "Runtime Device" }),
+    );
+    await user.click(screen.getByRole("option", { name: /linux-srv/ }));
+
+    await waitFor(() => {
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Codex CLI/ }),
+        ).getByText("Installed"),
+      ).toBeInTheDocument();
+    });
+    expect(resolveFn).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "codex", deviceId: "7" }),
+    );
+  });
+
+  it("Given an unreachable remote device, When the probe rejects, Then the badge says the probe failed instead of claiming the CLI is missing", async () => {
+    const user = userEvent.setup();
+    installAppMock({
+      ResolveAgentBackendCLIPath: vi.fn((req: unknown) => {
+        const { deviceId } = req as { deviceId: string };
+        return deviceId === "7"
+          ? Promise.reject(new Error("device offline"))
+          : Promise.resolve({ path: "", found: false });
+      }),
+      RemoteDeviceList: vi.fn(() =>
+        Promise.resolve([{ id: 7, name: "linux-srv", online: true }]),
+      ),
+    });
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+    await user.click(
+      within(dialog).getByRole("combobox", { name: "Runtime Device" }),
+    );
+    await user.click(screen.getByRole("option", { name: /linux-srv/ }));
+
+    await waitFor(() => {
+      expect(
+        within(
+          within(group).getByRole("radio", { name: /Codex CLI/ }),
+        ).getByText("Probe failed"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(
+        within(group).getByRole("radio", { name: /Codex CLI/ }),
+      ).queryByText("Not installed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Given the type field, When the create dialog renders, Then it precedes the name field", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+    const nameInput = within(dialog).getByPlaceholderText(
+      "Example: Local · Claude Code",
+    );
+
+    expect(
+      group.compareDocumentPosition(nameInput) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("Given an untouched name, When the type changes, Then the name is prefilled from the type and keeps following further changes", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+    const nameInput = within(dialog).getByPlaceholderText(
+      "Example: Local · Claude Code",
+    ) as HTMLInputElement;
+
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+    expect(nameInput.value).toBe("Local · Claude Code");
+
+    await user.click(within(group).getByRole("radio", { name: /Codex CLI/ }));
+    expect(nameInput.value).toBe("Local · Codex");
+  });
+
+  it("Given a name the user typed, When the type changes, Then the typed name is preserved", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+    const nameInput = within(dialog).getByPlaceholderText(
+      "Example: Local · Claude Code",
+    ) as HTMLInputElement;
+
+    fireEvent.change(nameInput, { target: { value: "my backend" } });
+    await user.click(
+      within(group).getByRole("radio", { name: /Claude Code CLI/ }),
+    );
+
+    expect(nameInput.value).toBe("my backend");
+  });
+
+  it("Given an existing backend, When the edit dialog opens, Then the type is a read-only summary with a locked hint and no radiogroup", async () => {
+    const user = userEvent.setup();
+    installAppMock({
+      ListAgentBackends: vi.fn(() =>
+        Promise.resolve({
+          items: [
+            {
+              id: 1,
+              type: "claudecode",
+              name: "本机 claude",
+              llmProviderKey: "",
+              cliPath: "/usr/local/bin/claude",
+              agentCount: 0,
+              createtime: 0,
+              updatetime: 0,
+            },
+          ],
+        }),
+      ),
+    });
+    render(<AgentBackendsPanel />);
+
+    await screen.findByText("本机 claude");
+    const row = screen
+      .getByText("本机 claude")
+      .closest('[role="listitem"]') as HTMLElement;
+    await user.click(within(row).getByRole("button", { name: /Edit/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).queryByRole("radiogroup", { name: "Type" }),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).getByText("Claude Code CLI")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("Cannot be changed after creation"),
+    ).toBeInTheDocument();
+  });
+
+  it("Given keyboard focus inside the group, When arrow keys are pressed, Then the checked type moves without a mouse", async () => {
+    const user = userEvent.setup();
+    installAppMock();
+
+    const dialog = await openCreateDialog(user);
+    const group = within(dialog).getByRole("radiogroup", { name: "Type" });
+
+    within(group)
+      .getByRole("radio", { name: /Built-in Agent/ })
+      .focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(
+      within(group).getByRole("radio", { name: /OpenClaw Gateway/ }),
+    ).toBeChecked();
+    expect(
+      within(group).getByRole("radio", { name: /OpenClaw Gateway/ }),
+    ).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}{ArrowUp}");
+    expect(
+      within(group).getByRole("radio", { name: /Pi Agent CLI/ }),
+    ).toBeChecked();
+  });
+});
 
 describe("truncateFlashText", () => {
   it("短文本原样返回，truncated=false", () => {

--- a/frontend/src/components/agentre/agent-backends.tsx
+++ b/frontend/src/components/agentre/agent-backends.tsx
@@ -27,7 +27,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import i18n from "@/i18n";
 import { cn } from "@/lib/utils";
 
@@ -79,6 +78,24 @@ type BackendType = "builtin" | "claudecode" | "codex" | "piagent" | "openclaw";
 // wailsjs/go/models is generated at build time and not present in this worktree.
 type DeviceView = { id: number; name: string; online: boolean };
 type ProviderSummary = { key?: string; name?: string; type?: string };
+
+// 选择器里的展示顺序：三个 CLI 引擎在前（最常用且需要装命令行），内置与网关收尾。
+// openclaw 排最后是因为它在两列网格里独占整行，避免出现空格子。
+const BACKEND_TYPE_ORDER: BackendType[] = [
+  "claudecode",
+  "codex",
+  "piagent",
+  "builtin",
+  "openclaw",
+];
+
+// 打开新建对话框时会对这三个类型各探一次目标机的 $PATH。
+const CLI_BACKEND_TYPES: BackendType[] = ["claudecode", "codex", "piagent"];
+
+// probing → 请求在飞；installed/missing → 目标机 $PATH 的结论；
+// failed → 远端不可达（离线 / 超时 / 探测报错），此时不能谎报「未安装」。
+type CLIProbeState = "probing" | "installed" | "missing" | "failed";
+type CLIProbe = { state: CLIProbeState; path: string };
 
 const backendTypeMeta: Record<
   BackendType,
@@ -691,6 +708,7 @@ function Toolbar({
         <Button
           type="button"
           size="sm"
+          data-testid="agent-backend-create"
           className="h-[30px] gap-1.5 px-3 text-xs"
           onClick={onCreate}
         >
@@ -969,6 +987,11 @@ function BackendEditor({
   const [cliProbeMiss, setCliProbeMiss] = React.useState<string | null>(null);
   // 名称一旦被用户敲过就不再跟着类型走；编辑态本来就带着既有名字，视同已敲过。
   const nameTouchedRef = React.useRef(state.kind === "edit");
+  // 类型选择器右侧徽标的数据源：三个 CLI 引擎在目标机 $PATH 里的探测结果。
+  const [cliProbes, setCliProbes] = React.useState<
+    Partial<Record<BackendType, CLIProbe>>
+  >({});
+  const cliProbeGenerationRef = React.useRef(0);
 
   const filteredProviders = React.useMemo(
     () => matchingProviders(type, providers),
@@ -998,6 +1021,40 @@ function BackendEditor({
     return r.found ? r.path : null;
   }
 
+  // 新建时对三个 CLI 引擎各探一次目标机的 $PATH，让「装没装」在选类型这一步就可见，
+  // 而不是选完之后才在 CLI 路径字段撞墙。换运行设备（本机 ↔ 远端）要整组重探。
+  // 探测不阻塞选择：飞行中的类型照样可以点。
+  React.useEffect(() => {
+    if (state.kind !== "create") return;
+    const generation = ++cliProbeGenerationRef.current;
+    setCliProbes(
+      Object.fromEntries(
+        CLI_BACKEND_TYPES.map((cliType) => [
+          cliType,
+          { state: "probing", path: "" },
+        ]),
+      ) as Partial<Record<BackendType, CLIProbe>>,
+    );
+    for (const cliType of CLI_BACKEND_TYPES) {
+      void (async () => {
+        let probe: CLIProbe;
+        try {
+          const r = await probeCLIPath(cliType, deviceId);
+          probe = {
+            state: r.found ? "installed" : "missing",
+            path: r.found ? r.path : "",
+          };
+        } catch {
+          // 远端离线 / 超时 / 探测报错：只能说「没探到」，不能说「没装」。
+          probe = { state: "failed", path: "" };
+        }
+        // 换设备后旧一轮的迟到结果直接丢弃，避免徽标显示上一台机器的结论。
+        if (cliProbeGenerationRef.current !== generation) return;
+        setCliProbes((prev) => ({ ...prev, [cliType]: probe }));
+      })();
+    }
+  }, [state.kind, deviceId]);
+
   // 没被用户敲过的名称跟着「设备 · 类型」走，省掉一次手输。
   // 只有 CLI 引擎带设备前缀 —— 它们才能派到远端；内置 / 网关直接用类型名。
   function defaultBackendName(bt: BackendType, dev: string): string {
@@ -1011,6 +1068,13 @@ function BackendEditor({
       device: deviceName,
       name: t(`agentBackends.backendType.${bt}.shortLabel`),
     });
+  }
+
+  function handleDeviceChange(nextDeviceId: string) {
+    setDeviceId(nextDeviceId);
+    if (!nameTouchedRef.current) {
+      setName(defaultBackendName(type, nextDeviceId));
+    }
   }
 
   function handleTypeChange(nextType: BackendType) {
@@ -1049,14 +1113,24 @@ function BackendEditor({
     // 切类型时清空 cliPath，避免 claude / codex 两个不同的可执行文件串台。
     setCliPath("");
     setCliProbeMiss(null);
-    // create 模式下，切到 CLI 类型自动尝试探测一次，命中就填进去；用户随时可手改/清空。
-    // edit 模式 type 是 disabled 的，所以这里不会跑；编辑场景只靠 Input 旁的「自动识别」按钮。
+    // create 模式下切到 CLI 类型要把识别到的路径自动填进去；用户随时可手改/清空。
+    // edit 模式不渲染选择器，所以这里不会跑；编辑场景只靠 Input 旁的「自动识别」按钮。
     if (state.kind === "create" && isCliBackend(nextType)) {
-      void (async () => {
-        // 新建流程的隐式自动填：静默吞错，远端不可达就当没识别到。
-        const path = await detectCLIPath(nextType, deviceId).catch(() => null);
-        if (path) setCliPath(path);
-      })();
+      const probed = cliProbes[nextType];
+      if (probed?.state === "installed") {
+        // 打开对话框时那一轮探测已经给出结论，直接复用 —— 远端设备上这能省掉一次真实往返，
+        // 而方向键换选项会逐个触发本函数，代价按键盘步数累加。
+        setCliPath(probed.path);
+      } else if (probed?.state !== "missing") {
+        // 只有「还没探完 / 探测失败」才补一发；已知未安装就不用再问一次。
+        void (async () => {
+          // 新建流程的隐式自动填：静默吞错，远端不可达就当没识别到。
+          const path = await detectCLIPath(nextType, deviceId).catch(
+            () => null,
+          );
+          if (path) setCliPath(path);
+        })();
+      }
     }
   }
 
@@ -1498,14 +1572,20 @@ function BackendEditor({
         }
       >
         {/* 类型排在名称之前：它决定了下面出现哪些字段，也决定名称的默认值。 */}
-        <div className="flex flex-col gap-1.5 text-xs">
-          <span className="font-medium">{t("agentBackends.fields.type")}</span>
-          <BackendTypeSegmented
-            value={type}
-            onChange={handleTypeChange}
-            disabled={state.kind === "edit"}
-          />
-        </div>
+        {state.kind === "edit" ? (
+          <BackendTypeReadonly type={type} />
+        ) : (
+          <div className="flex flex-col gap-1.5 text-xs">
+            <span className="font-medium">
+              {t("agentBackends.fields.type")}
+            </span>
+            <BackendTypePicker
+              value={type}
+              onChange={handleTypeChange}
+              probes={cliProbes}
+            />
+          </div>
+        )}
 
         <label className="flex flex-col gap-1.5 text-xs">
           <span className="font-medium">{t("agentBackends.fields.name")}</span>
@@ -1527,7 +1607,7 @@ function BackendEditor({
           </span>
           <Select
             value={deviceIdToSelectValue(deviceId)}
-            onValueChange={(v) => setDeviceId(selectValueToDeviceId(v))}
+            onValueChange={(v) => handleDeviceChange(selectValueToDeviceId(v))}
             disabled={type === "builtin" || type === "openclaw"}
           >
             <SelectTrigger aria-label={t("agentBackends.fields.device")}>
@@ -1794,44 +1874,152 @@ function BackendEditor({
   );
 }
 
-function BackendTypeSegmented({
+// 类型选择器：两列卡片，每张只放「logo + 名称 + 一个徽标」。
+// 不放整句说明 —— 徽标只承载「选之前才有用、选之后就看不到」的事实
+// （CLI 装没装 / 内置只能跑本机），其余前置条件选中后表单自己会呈现。
+function BackendTypePicker({
   value,
   onChange,
-  disabled,
+  probes,
 }: {
   value: BackendType;
   onChange: (v: BackendType) => void;
-  disabled?: boolean;
+  probes: Partial<Record<BackendType, CLIProbe>>;
 }) {
   const { t } = useTranslation();
-  const items = Object.keys(backendTypeMeta) as BackendType[];
+  const groupRef = React.useRef<HTMLDivElement>(null);
+
+  // radiogroup 的键盘契约：方向键换选项并把焦点带过去（Tab 只进出整组）。
+  function moveSelection(delta: number) {
+    const from = BACKEND_TYPE_ORDER.indexOf(value);
+    const total = BACKEND_TYPE_ORDER.length;
+    const next = BACKEND_TYPE_ORDER[(from + delta + total) % total];
+    onChange(next);
+    groupRef.current
+      ?.querySelector<HTMLButtonElement>(`[data-backend-type="${next}"]`)
+      ?.focus();
+  }
+
   return (
-    <ToggleGroup
-      type="single"
-      variant="outline"
-      value={value}
-      onValueChange={(next) => {
-        if (next) onChange(next as BackendType);
-      }}
-      className="grid w-full grid-cols-3 gap-1"
+    <div
+      ref={groupRef}
+      role="radiogroup"
       aria-label={t("agentBackends.fields.type")}
+      // 对话框是 w-full max-w-xl —— 窗口窄于 sm 时它跟着缩，两列会把
+      // 「Claude Code CLI + 未安装」挤到截断，所以窄窗退回单列。
+      className="grid grid-cols-1 gap-1.5 sm:grid-cols-2"
+      onKeyDown={(e) => {
+        if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+          e.preventDefault();
+          moveSelection(1);
+        } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+          e.preventDefault();
+          moveSelection(-1);
+        }
+      }}
     >
-      {items.map((backendType) => (
-        <ToggleGroupItem
-          key={backendType}
-          value={backendType}
-          disabled={disabled || backendTypeMeta[backendType].disabled}
-          role="button"
-          aria-pressed={value === backendType}
-          className="min-w-0 px-1.5 text-xs"
-        >
-          <span aria-hidden="true">
-            <AgentBackendLogo backendType={backendType} className="size-4" />
-          </span>
-          {t(`agentBackends.backendType.${backendType}.label`)}
-        </ToggleGroupItem>
-      ))}
-    </ToggleGroup>
+      {BACKEND_TYPE_ORDER.map((backendType) => {
+        const checked = value === backendType;
+        return (
+          <button
+            key={backendType}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            data-backend-type={backendType}
+            disabled={backendTypeMeta[backendType].disabled}
+            // roving tabindex：整组只有选中项可 Tab 聚焦。
+            tabIndex={checked ? 0 : -1}
+            onClick={() => onChange(backendType)}
+            className={cn(
+              "flex min-w-0 items-center gap-2 rounded-md border px-2.5 py-2 text-left outline-none transition-colors",
+              "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+              "disabled:pointer-events-none disabled:opacity-50",
+              checked
+                ? "border-primary bg-primary-soft"
+                : "border-border bg-card hover:border-border-strong hover:bg-accent/60",
+              // 5 个选项排两列会空一格,让网关独占末行收尾。单列时不能加 span-2:
+              // 那会在 1 列的网格里撑出一条隐式列,把整行顶出容器。
+              backendType === "openclaw" && "sm:col-span-2",
+            )}
+          >
+            <span aria-hidden="true">
+              <AgentBackendLogo backendType={backendType} className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1 truncate text-xs font-semibold">
+              {t(`agentBackends.backendType.${backendType}.label`)}
+            </span>
+            <BackendTypeBadge type={backendType} probe={probes[backendType]} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function BackendTypeBadge({
+  type,
+  probe,
+}: {
+  type: BackendType;
+  probe?: CLIProbe;
+}) {
+  const { t } = useTranslation();
+  // 内置引擎的意外之处是「运行设备」会被禁用 —— 提前说，省得用户选完才发现派不出去。
+  if (type === "builtin") {
+    return (
+      <span className="shrink-0 rounded-full border border-border bg-secondary px-1.5 text-2xs text-muted-foreground">
+        {t("agentBackends.backendType.builtin.badge")}
+      </span>
+    );
+  }
+  // 网关不给徽标：它要填什么，选中之后表单自己会说。
+  if (!isCliBackend(type) || !probe) return null;
+
+  const tone =
+    probe.state === "installed"
+      ? "border-status-running/30 bg-status-running-bg text-status-running"
+      : probe.state === "probing"
+        ? "border-border bg-secondary text-muted-foreground"
+        : "border-status-waiting/30 bg-status-waiting-bg text-status-waiting";
+  return (
+    <span
+      // e2e 用它断言探测结论，避免拿 i18n 文案当定位符。
+      data-probe-state={probe.state}
+      className={cn(
+        "flex shrink-0 items-center gap-1 rounded-full border px-1.5 text-2xs",
+        tone,
+      )}
+      title={probe.state === "installed" ? probe.path : undefined}
+    >
+      {probe.state === "probing" ? (
+        <Loader2 className="size-2.5 animate-spin" aria-hidden="true" />
+      ) : null}
+      {t(`agentBackends.backendType.probe.${probe.state}`)}
+    </span>
+  );
+}
+
+// 编辑态：类型创建后不可改。渲染整组再 disabled 只是白占地方，换成一行只读摘要。
+function BackendTypeReadonly({ type }: { type: BackendType }) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-1.5 text-xs">
+      <div className="flex items-baseline gap-2">
+        <span className="font-medium">{t("agentBackends.fields.type")}</span>
+        <span className="text-2xs text-muted-foreground">
+          {t("agentBackends.fields.typeLocked")}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 rounded-md border border-border bg-secondary px-2.5 py-2">
+        <span aria-hidden="true">
+          <AgentBackendLogo backendType={type} className="size-4" />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs font-semibold">
+          {t(`agentBackends.backendType.${type}.label`)}
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/agentre/settings.tsx
+++ b/frontend/src/components/agentre/settings.tsx
@@ -254,6 +254,7 @@ function SettingsNavButton({
       key={item.labelKey}
       type="button"
       variant="ghost"
+      data-testid={pageId ? `settings-nav-${pageId}` : undefined}
       aria-current={active ? "page" : undefined}
       className={cn(
         "h-[30px] shrink-0 justify-start gap-2 px-2.5 text-sm font-normal whitespace-nowrap text-foreground lg:w-full",


### PR DESCRIPTION
## 这轮解决什么

「新增 Agent 后端」的类型选择，5 个引擎挤在 3×2 格 ToggleGroup 里，只有图标和 12px 标签。四个具体问题：

- **选中态几乎不可见** —— `toggle.tsx` 的 `data-[state=on]:bg-accent` 与 `hover:bg-accent` 同色；亮色下 `#f4f4f5` 压在 `#ffffff` 卡片上，鼠标划过时分不清「悬停」和「已选」
- **零说明** —— i18n 的 `backendType.*` 只有 label。五个引擎前置条件天差地别（内置必须绑供应商且只能本机 / 三个 CLI 各需对应命令行 / OpenClaw 要网关地址+Token），选之前一律看不到
- **3 列 2 行留一个空格**，第二行两项左对齐视觉断裂；窄窗下「OpenClaw Gateway」被裁成「OpenClaw Gatewa」
- **可用性未知** —— 机器上没装 `codex` 也照样能选中，要等 CLI 路径字段探测失败才知道

方案是先画 mockup 定的：三套形态（单列说明卡片 / 双列紧凑卡片 / 分组下拉）对比后选了双列，再按「不要多余说明」收敛到零说明的一档。

## 改了什么

**类型选择器**：两列单选卡片，每张只有 logo + 名称 + 一个徽标，**不放整句说明**。徽标只承载「选之前才有用、选之后就看不到」的事实：

| 类型 | 徽标 | 为什么是它 |
|---|---|---|
| Claude Code / Codex / Pi Agent | 已安装 / 未安装 / 探测中 | 打开对话框即并发探测目标机 `$PATH` |
| 内置 Agent | 仅本机 | 选它之后「运行设备」会被禁用，属于选完才发现的意外 |
| OpenClaw Gateway | 无 | 它要填什么，选中后表单自己会说 |

5 项排两列会空一格，让网关独占末行收尾。选中态改成 `border-primary` + `bg-primary-soft`，与 hover 一眼可分。

**远端设备一并支持**：切「运行设备」整组重探（`ResolveAgentBackendCLIPath` 本就带 deviceID，派到那台 daemon 扫它自己的 `$PATH`）。三处细节：

- **generation 守卫** —— 换设备后旧一轮的迟到结果直接丢弃，不会显示上一台机器的结论
- **`failed` 独立于 `missing`** —— 远端离线 / 超时 / 拨号失败只能说「没探到」，不能谎报「没装」
- **复用探测缓存** —— 已有确定结论时不再重发。远端上每次点类型都是一次真实网络往返，而方向键换选项会逐个触发，代价按键盘步数累加

**顺带两处**：类型移到名称之前，并按「设备 · 类型」给名称默认值（用户敲过就不再覆盖）；编辑态从「渲染 5 格再整组 disabled」（占 80px 只传达一个事实）换成一行只读摘要 + 「创建后不可更改」。

**无障碍 / 响应式**：`role="radiogroup"` + `role="radio"` + roving tabindex，方向键换选项并带走焦点；窄窗退回单列（对话框是 `w-full max-w-xl`，会跟着窗口缩，且单列下不能加 `col-span-2` —— 那会撑出一条隐式列把行顶出容器）。

## 验证

TDD 先红后绿：12 个新行为测试先全红且原因正确，再实现。现有 19 处 `getByRole("button", …)` 的类型点击随语义改成 `radio`。

**真机验证**跑在真实 Wails app + Playwright（`e2e/scratch`，1 passed）。**7 条 holds，1 条 not observed。**

决定性观察：种一台「在线但拨不通」的远端 agentred（`last_seen_at` 在 5 分钟窗口内 → 显示在线可选中，URL 指向没人监听的端口 → 真实拨号必然失败），选中后三个 CLI 徽标全部变 `Probe failed` 而不是 `Not installed`，切回本机又恢复 `Installed`。落库由独立的只读 SQLite 查询确认：`{"type":"claudecode","cli_path":"/Users/…/bin/claude","device_id":""}`。徽标 `title` 回读到绝对路径，说明探测拿的是真实 `$PATH` 解析结果而非布尔。

**not observed：CLI 未安装时的 `missing` 徽标** —— 验证机器上 claude / codex / pi 三个都装着，真机走不到那条分支，它只有单测覆盖（用例里 piagent 返回 `found:false`）。合并即接受这一点。

门控：`tsc -b` exit 0 · `pnpm lint` 0 error · 全量 vitest 2473/2473。

## 已知遗留（本轮未处理）

**切运行设备后「CLI 路径」字段仍留着上一台机器的路径。** 选 Claude Code（本机探到 `/usr/local/bin/claude`）→ 切到远端 → 徽标会重探刷新，但路径字段还是本机那条。这在本轮之前就存在（切设备从来不重新识别），但本轮让它更显眼：徽标说远端「已安装」、路径却显示本机路径。根治要给 `cliPath` 加「用户是否手改过」的标记、让探测结果在未手改时回填 —— 与本轮给名称做的一样。经确认本轮不处理。

## 自检 / Checklist

- [x] Changes tested / 已完成测试（单测 2473 全绿 + 真机 e2e scratch）
- [ ] Code reviewed by human / 代码通过人工检查
