### PR TITLE
✨ 已有会话切换 LLM 供应商，并让会话级供应商真正决定上游

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ e2e/scratch/*
 coverage.out
 coverage.html
 
+# 本机凭证:验证 / 联调用的真实供应商 key 放这里,永不入库
+.env
+.env.local
+
 # Binary files
 /agentre
 /agentred

--- a/docs/specs/2026-08-09-new-session-provider-select.md
+++ b/docs/specs/2026-08-09-new-session-provider-select.md
@@ -2,7 +2,9 @@
 
 <!-- File: docs/specs/2026-08-09-new-session-provider-select.md -->
 
-> Status: Approved
+> Status: Approved（决策 2 的「不可事后修改」与决策 7 已被
+> [2026-08-10 已有会话切换 LLM 供应商](./2026-08-10-session-provider-switch.md) 取代，
+> 见下方逐条标注；其余部分仍然有效）
 > Owner: chat experience / backend
 > Last updated: 2026-08-09
 
@@ -15,7 +17,7 @@
 3. **`chat_messages.model` 保留**：仍是每轮实际运行模型的观测字段（transcript 展示），它不是 #26 模型切换的一部分。
 4. **新 UI 文案全部走 i18n**：新增 key 同时覆盖 `zh-CN/common.json` 与 `en/common.json`；`i18n.test.ts` 校验通过。控件用 shadcn `Popover`，不引入原生 `<select>`。
 5. **远端 agentred 执行同样生效**：会话级 provider 选择随 wire 透传，daemon 按 key 从自己的配置自解。
-6. **已有会话不再有模型/供应商切换器，也不显示只读供应商徽标**（用户决策：最干净，观测靠 transcript 每消息 `model` 字段）。
+6. ~~**已有会话不再有模型/供应商切换器，也不显示只读供应商徽标**（用户决策：最干净，观测靠 transcript 每消息 `model` 字段）。~~ **被 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 取代**：已有会话在 composer 常显供应商选择器（不可切时 disabled + tooltip），切换自下一轮生效。本规格其余不变量仍然有效。
 
 ## Problem
 
@@ -35,12 +37,12 @@
 | # | Decision | Basis and rejected option |
 |---|---|---|
 | 1 | **整体移除 #26 会话级模型切换**：删 `model_override` 列、`SetChatSessionModel`、`SendRequest.ModelOverride`、模型偏离提示、四后端 `ModelOverride` 消费、远端 wire `ModelOverride` | 用户决策 B：未发版清理干净；能力被本特性覆盖。拒绝保留 `model_override` 与供应商选择并存——两套选择器复杂且无必要 |
-| 2 | **新增会话级 `provider_key`（text，`''`=跟随 agent 绑定）**，新建会话随首条消息落库，**不可事后修改** | 会话需要一个稳定的供应商归属，类比被移除的 `model_override` 但粒度更粗。拒绝写回 agent 绑定——会全局污染其它会话 |
+| 2 | **新增会话级 `provider_key`（text，`''`=跟随 agent 绑定）**，新建会话随首条消息落库，~~**不可事后修改**~~ → **可事后修改**（「不可事后修改」这一条被 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 决策 1 取代：新增单列更新 `UpdateProviderKey` + `chat_svc.SetChatSessionProvider`，切换自下一轮生效；本行其余部分不变） | 会话需要一个稳定的供应商归属，类比被移除的 `model_override` 但粒度更粗。拒绝写回 agent 绑定——会全局污染其它会话 |
 | 3 | **供应商解析：会话 `provider_key` > agent 绑定**，在 `resolveAgentBackend` 同一解析点生效 | 现状 `prov` 由 `be.LLMProviderKey` 解析（`internal/service/chat_svc/chat.go`）；插一层会话优先即可。拒绝为会话 clone 改写共享实体 |
 | 4 | **新建会话 pill = 供应商选择器，只列与后端兼容的供应商**：builtin→全部；claudecode→anthropic；codex→openai-response；piagent→anthropic/openai-chat/openai-response；openclaw 不渲染 | 兼容性是后端硬约束（`ProviderTypeMatch`，`internal/model/entity/agent_backend_entity/kinds.go`），列不兼容项必然失败。拒绝列全部再报错 |
 | 5 | **未绑供应商（CLI 登录态）的新建会话也显示供应商选择器**（用户 Q1） | 让 CLI 后端的新会话可选 agentre 供应商接管；不选则保持 CLI 登录态。拒绝保留自由输入模型 id——模型选择在新建会话消失 |
 | 6 | **模型 = 所选供应商默认模型（`provider.Model`）**，新建会话不再有模型选择 | 用户 Option C："选完就用该供应商的默认模型（最简，不涉及模型选择）" |
-| 7 | **已有会话不渲染任何切换器，也不显示只读供应商徽标**（用户决策 b） | 用户决策：最干净。观测靠 transcript 每消息 `model` 字段 |
+| 7 | ~~**已有会话不渲染任何切换器，也不显示只读供应商徽标**（用户决策 b）~~ **被 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 决策 10 取代**：已有会话渲染同一颗 pill，不可切换时 `disabled` + tooltip 说明原因 | 原基础（用户决策 b：最干净，观测靠 transcript 每消息 `model`）已被推翻——隐藏让用户以为功能消失 |
 | 8 | **会话 `provider_key` 指向的供应商被删/停用 → 回退 agent 绑定 + transcript 一条持久 notice**（复用既有 `NoticeBlock` 渲染，不是被删的模型偏离提示） | 用户 Q3；避免会话永久卡死（`ChatAgentNotChattable` 会把会话堵死）。notice 每次回退都追加，与 #26 偏离提示"每次发生都提示"先例一致 |
 | 9 | **远端透传**：remote `RunRequest.LLMProviderKey` 改为 effectiveProviderKey（会话 `provider_key` 优先），daemon 按 key 自解 | 现状已按 `LLMProviderKey` 透传（`chat.go` remote 路径），替换为 effective 即可；daemon 自家 `ProviderLookup` 与 gateway 不变 |
 | 10 | **迁移做法 1（改基线）**：直接改 `migrations/202608080006_chat.go`，删 `model_override` 列、加 `provider_key` 列 | 未发版 + 迁移历史已压平 + gormigrate 无 checksum；用户豁免"不修改既有迁移"硬规则；本地 dev 库需删除重建。拒绝追加 DROP patch——留"建→删"不干净 |
@@ -50,21 +52,21 @@
 
 - `chat_sessions`：`model_override` 删除，新增 `provider_key TEXT NOT NULL DEFAULT ''`（在基线迁移 `202608080006_chat.go` 内直接改，见决策 10；本地 dev 库需重建）。
 - `chat_entity.Session`：删 `ModelOverride`，加 `ProviderKey`（gorm column `provider_key`）。
-- `chat_svc.SendRequest.ProviderKey string`：仅新建会话生效，随首条消息与 Session 一同 Create 落库；已有会话忽略（B 不允许事后改，无 Setter）。
+- `chat_svc.SendRequest.ProviderKey string`：仅新建会话生效，随首条消息与 Session 一同 Create 落库；已有会话在 `Send` 里仍忽略该字段——改供应商走 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 的 `SetChatSessionProvider`（原文「不允许事后改，无 Setter」已被取代）。
 - `agentruntime.RunRequest`：删 `ModelOverride`；remote 路径 `LLMProviderKey` 改为 effectiveProviderKey。
 - 前端：删 `useModelPill` 的模型列表 / 自由输入 / `SetChatSessionModel` 调用；新建会话改为供应商选择器；`ChatSessionDetail` 移除 `ModelOverride` / `ProviderDefaultModel` / `LLMProviderKey`——三者仅被旧 pill 消费（已核实 session 级 `llmProviderKey` 唯一消费者是 chat-panel 的 ModelPill）；`LLMProviderType` 保留（仍有 Usage token 语义）。
 
 ## 会话创建与解析流程
 
 - **新建会话（Send）**：`SendRequest.ProviderKey` 非空时校验——供应商必须存在、`IsActive()` 且与后端 kind 兼容（`ProviderTypeMatch`），否则 Send 报错（复用不可对话的错误语义，不在落库后才发现）。校验通过后与 Session 一起 Create 落库。
-- **已有会话**：无任何切换器；解析 `effectiveProviderKey = firstNonEmpty(sess.ProviderKey, be.LLMProviderKey)`。
+- **已有会话**：解析 `effectiveProviderKey = firstNonEmpty(sess.ProviderKey, be.LLMProviderKey)`（「无任何切换器」已被 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 取代：composer 常显选择器，切换自下一轮生效）。
 - **本地**：在 `resolveAgentBackend` 同一解析点按 effectiveProviderKey 解析 `prov`；builtin 仍要求有可用供应商（否则不可对话，走既有 `NewSessionChatGuard`）。
 - **远端**：wire 透传 effectiveProviderKey；daemon 从自家配置按 key 解析；daemon 缺该 key / 非 active → 回退 agent 绑定并回传信号，桌面端据此追加 notice（与本地 Q3 一致）。
 - **回退（Q3）**：会话 `provider_key` 指向的供应商缺失或非 active → 本轮改用 agent 绑定解析，transcript 追加一条持久 notice：「所选供应商 X 不可用，已回退 agent 绑定」。`provider_key` 不清除（供应商恢复后自动回到会话所选）。
 
 ## UI（新建会话供应商选择器）
 
-- 摆放：composer 动作行原 ModelPill 位置；**仅 `sessionId===0`（新建会话）** 且后端为 builtin / claudecode / codex / piagent 时渲染；openclaw 不渲染（不消费 agentre provider）。
+- 摆放：composer 动作行原 ModelPill 位置；后端为 builtin / claudecode / codex / piagent 时渲染；openclaw 不渲染（不消费 agentre provider）。（原文的「**仅 `sessionId===0`（新建会话）**」已被 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 决策 10 取代：已有会话同样渲染，不可切换时 disabled + tooltip。）
 - 形态：沿用 pill + `Popover` 模式（`h-6 rounded-md border px-2 text-2xs font-medium` + caret，图标用供应商/立方体图标，供应商名等宽字体截断）。
 - 弹层：头部"供应商"标题；列表第一项"跟随 agent 绑定"（未选时该项高亮；选中具体供应商后点击可清回；未绑 agent 时该项语义为"不选，走 CLI 登录态"）；其下兼容供应商列表（名称 + 类型 + 默认模型 `provider.Model`），当前选中项高亮（`primary-soft` + 实心点徽标）。
 - 未选时 pill 标签：agent 已绑 → 显示 agent 绑定供应商名；未绑 → "选择供应商"占位文案。
@@ -81,7 +83,7 @@
 
 ## Out of scope
 
-- **已有会话改供应商/模型**：B 明确禁止；会话建好后不可换（换需新建会话）。
+- ~~**已有会话改供应商/模型**：B 明确禁止；会话建好后不可换（换需新建会话）。~~ 改**供应商**已由 [2026-08-10 规格](./2026-08-10-session-provider-switch.md) 实现；改**模型**仍不在范围内（会话固定用所选供应商的默认模型）。
 - **回退时自动清除 `provider_key`**：保留，供应商恢复后自动回到会话所选。
 - **openclaw 供应商选择**：openclaw 不消费 agentre provider。
 - **模型列表 / 自由输入模型 id UI**：新建会话不再有模型概念。

--- a/docs/specs/2026-08-10-provider-notice-fixes.md
+++ b/docs/specs/2026-08-10-provider-notice-fixes.md
@@ -1,0 +1,82 @@
+# 供应商 notice 的两处显示缺陷
+
+<!-- File: docs/specs/2026-08-10-provider-notice-fixes.md -->
+
+> Status: Approved
+> Owner: chat experience
+> Last updated: 2026-08-10
+
+**Objective:** 让供应商切换 notice 在 transcript 里读得懂——显示供应商名而不是 UUID，并且不再
+在它上方误画一条「后台任务完成 · 已自动续跑」横幅。
+
+**Hard invariant:** 不改变供应商切换本身的任何行为（校验、落库、生效时机、网关路由、子进程
+重启），只改 notice 的负载内容与 transcript 的行判定；真实的自主续轮横幅必须照常出现。
+
+## Problem
+
+1. **切换 notice 显示原始 provider key（UUID）。** 用户在 pill 上选的是供应商名，transcript 里
+   回看到的却是 `Switched to provider 36a04495-dfe9-40ef-a3c5-2b62468db6b1 from here`。渲染处
+   直接把 key 插进文案（`frontend/src/components/agentre/transcript-row-view.tsx:716-718`），
+   而负载里本来就只有 key（`internal/service/chat_svc/session_provider.go:191`）。既有的供应商
+   回退 notice 同源同形（`transcript-row-view.tsx:721-723`）。真机证据：
+   `e2e/scratch/2026-08-10-session-provider-switch/report.md` 的 R1 与截图 `v4-switch-notice.png`。
+2. **切换 notice 会误触发「后台任务完成 · 已自动续跑」横幅。** 自主续轮的判定是启发式的——
+   「assistant 消息且紧邻前一条不是 user」（`frontend/src/components/agentre/chat.tsx:1319-1327`）。
+   切换 notice 是一条独立的 assistant 消息，插在上一轮回复之后，正好构成 `assistant→assistant`，
+   于是被判成自主续轮。规格从未要求这条横幅，用户会以为后台真的跑了一轮任务。同一份报告的 R2
+   给出了对照组：未切换过的会话没有这条横幅。
+
+## Actors and user stories
+
+1. 作为回看 transcript 的用户，我希望看到「改用了哪个供应商」的名字，以便和我在 pill 上选的对上。
+2. 作为切换过供应商的用户，我不希望 transcript 里出现我没做过的「后台任务自动续跑」提示。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | **notice 负载增加供应商显示名**，前端优先用它、为空时回退到 key | 名字只有产出 notice 的后端手里有（前端的供应商列表可能还没拉、或该供应商已被删）。拒绝前端按 key 查名——列表是异步且可能缺项，会出现「有时有名有时是 UUID」的不稳定文案 |
+| 2 | **回退 notice 一并带名**，查不到供应商时保持显示 key | 与切换 notice 同源同形，同一次改动覆盖；回退的典型诱因就是供应商被删，此时没有名字可显示，key 是唯一能给的信息 |
+| 3 | **修正自主续轮的行判定：只含 notice 块的消息不参与 user/assistant 相邻关系**，既不自己算自主轮，也不打断它前后两条消息的判定 | 改的是判定本身的不完备（它假设 assistant 消息只有「轮回复」一种，而现在有第三种：系统 notice 行），不是在消费端给生产端打补丁。拒绝「不再用独立消息承载切换 notice」——切换发生在轮之外，它本就没有可挂靠的轮，且该形状是上一轮规格的决策 9 |
+
+## notice 负载与渲染
+
+切换 notice 与回退 notice 的结构化负载都增加一个供应商显示名字段；后端在产出 notice 时按当前
+解析到的供应商实体填入，取不到（供应商已删）时留空。
+
+前端渲染这两类 notice 时，显示名非空就用它，为空则回退到 key，文案本身不变。切换回「跟随
+agent 绑定」时没有供应商，沿用既有的专用文案，不受影响。
+
+## 自主续轮横幅的判定
+
+一条消息若其内容块全部是 notice，则视为系统提示行：它自己永远不被判为自主续轮，且在判断其它
+消息的「紧邻前一条」时被跳过——即它前后的真实轮之间的相邻关系保持不变。
+
+真实的自主续轮（CLI 后台任务完成后自主跑的一轮）必须照常显示横幅，包括「切换 notice 之后紧
+接着发生一次自主续轮」这种叠加情形。
+
+## Out of scope
+
+- 供应商切换的任何行为（校验 / 落库 / 生效时机 / 网关路由 / 子进程重启）。
+- 上一轮遗留的其它未观察项（远端 agentred、轮进行中切换）。
+- 自主续轮判定改用显式标记（本轮只让 notice 行透明；把启发式换成后端下发的显式字段是更大的改动，没有当前需求驱动）。
+
+## Testing decisions
+
+| Seam | 验证内容 | Prior art |
+|---|---|---|
+| `chat_svc` 单元（mockgen repo mock，不连 DB） | 切换 notice 负载带供应商显示名；供应商取不到时留空；回退 notice 同样 | `session_provider` 与 `chat_internal_test.go` 既有 notice 用例 |
+| 前端（vitest） | 有名时渲染名、无名时回退 key；只含 notice 块的消息不产生自主续轮横幅，且不改变其前后消息的判定；真实自主续轮仍出横幅 | `transcript-row-view-notice.test.tsx`、`chat.tsx` 的 autonomousIds 既有用例 |
+
+**无法自动化的部分**：真机上「切换后 transcript 读起来是否真的对得上 pill 里选的名字」由收尾的
+运行时验证补一张截图，并入上一轮的 `e2e/scratch/2026-08-10-session-provider-switch/report.md`。
+
+## Links
+
+- 上一轮规格：[2026-08-10 已有会话切换 LLM 供应商](./2026-08-10-session-provider-switch.md)（本轮修的是它交付后运行时暴露的两个显示问题，不改它的任何已批准行为）
+- 真机证据与两个缺陷的原始记录：`e2e/scratch/2026-08-10-session-provider-switch/report.md` 的 R1 / R2（本地，未入库）
+- 设计评审用的 mockup：`.dev-kit/artifacts/2026-08-10-provider-notice-fixes/mockups/notice-fixes.html`（本地，未入库；notice 与横幅按 `transcript-row-view.tsx` / `auto-trigger-banner.tsx` 的真实结构还原，token 取自 `frontend/src/styles/globals.css`）。约束性结论以本文正文为准，图仅为佐证。
+
+## Open questions
+
+无。

--- a/docs/specs/2026-08-10-session-provider-switch.md
+++ b/docs/specs/2026-08-10-session-provider-switch.md
@@ -1,0 +1,137 @@
+# 已有会话切换 LLM 供应商（并让会话级供应商真正决定上游）
+
+<!-- File: docs/specs/2026-08-10-session-provider-switch.md -->
+
+> Status: Draft
+> Owner: chat experience / backend
+> Last updated: 2026-08-10
+
+**Objective:** 用户能在**已有会话**的 composer 里换 LLM 供应商，自下一轮生效、正在跑的轮不受影响；同时把会话级 `provider_key` 贯穿到所有后端的真实执行路径——今天它在 claudecode / codex（本地与远端）上只改了 `--model`，并不决定请求实际打到哪个供应商。
+
+**Hard invariants:**
+
+1. **`provider_key` 为空的会话行为完全不变**：仍按 `agent_backend.LLMProviderKey → llm_provider` 解析；CLI 后端未绑供应商时走 CLI 自身登录态。
+2. **切换只换供应商**：agent / backend / cli_path / reasoning_effort / permission mode / cwd / 执行目标钉住关系一律不变；选择不写回 agent 绑定，不污染其它会话。
+3. **不打断正在进行的轮**：切换在轮中允许，但当前轮已 spawn 的子进程不被 evict、不被重启、不改写；新供应商自下一轮生效。
+4. **不可切换时禁用而非隐藏**（用户决策）：选择器在所有会话状态下都渲染，不满足切换条件时 `disabled` 并通过 tooltip 说明原因。
+5. **新 UI 文案全部走 i18n**：新增 key 同时覆盖 `zh-CN/common.json` 与 `en/common.json`，`i18n.test.ts` 通过；控件复用既有 shadcn `Popover` pill，不引入原生 `<select>`。
+6. **远端 agentred 执行同样生效**：切换后的供应商随 wire 透传，daemon 按 key 自解，并同样贯穿到 daemon 侧网关路由。
+7. **供应商密钥不跨机器**：`APIKey` / `BaseURL` 始终由执行侧（desktop 本机或 daemon 本机）从自己的配置解析，wire 只过 key。
+
+## Problem
+
+1. **已有会话无法换供应商。** 供应商选择器只在 `sessionId === 0` 渲染（`frontend/src/components/agentre/chat-panel.tsx:2848`），首条消息落库后即消失；后端也没有 Setter——`docs/specs/2026-08-09-new-session-provider-select.md` 决策 2 明确「不可事后修改」。用户报告：「在对话输出时，选择供应商怎么没了」，并指出被移除的 #26 曾承诺「除非是用登录态，否则可以在对话中切换」。
+2. **会话级供应商在 claudecode / codex 上不决定真实上游。** 网关 token 的路由信息来自 agent 绑定：`signChatTokenFor` 调 `IssueToken(ctx, be, 0)`（`internal/service/chat_svc/chat.go:4575`），entry 里 `MainProviderKey = b.LLMProviderKey`（`internal/pkg/httpgateway/token_registry.go:97`）；转发时按该 entry 取 `BaseURL` / `APIKey`，并把请求体的 model **重写成该 provider 的 model**（`internal/pkg/httpgateway/llmforward.go:75-97`）。会话选的供应商只进到 `req.Provider` → CLI 的 `--model`（`internal/pkg/agentruntime/runtimes/claudecode/session.go:236`），随后被网关改回去。远端 daemon 同构：`ensureSessionToken(ctx, em.rid, &be)`（`internal/daemon/handlers/runtime.go:384`、`1443`）。结果是 #33 已发布的「新建会话选供应商」在这两个后端上就是无效的。
+3. **CLI 登录态后端上会话供应商完全无法接管。** `BuildClaudeCodeEnv` 只在 `b.LLMProviderKey != ""` 时才设 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`（`internal/pkg/agentruntime/clienv.go:48-53`），codex 更早一步——`shouldSignChatGateway` 对未绑 provider 的 codex 直接返回 false（`internal/service/chat_svc/chat.go:4505-4513`），连 token 都不签。两处门控读的都是 agent 绑定，所以 `2026-08-09-new-session-provider-select.md` 决策 5 承诺的「未绑 agent 的新建会话也能选一个 agentre 供应商接管该会话」在这两个后端上从未兑现。
+4. **会话选了不同供应商后，头部展示与用量语义按 agent 绑定算。** `LoadSession` 用 `be.LLMProviderKey` 解析 prov（`internal/service/chat_svc/chat.go:573-575`），据此填 `LLMProviderType`（前端据它决定 Anthropic 系 / OpenAI 系的 prompt token 叠加口径）与 `ContextWindow`（`chat.go:583-586`）。会话供应商与 agent 绑定不同类型 / 不同上下文窗口时，用量条和上下文占比显示错误。
+5. **「复制启动命令」按 agent 绑定拼。** 该入口独立解析 `be.LLMProviderKey → prov` 并据此签 token（`internal/service/chat_svc/chat.go:674-693`），复制出来的命令用的是 agent 绑定的供应商，与会话实际执行的不一致。
+
+问题 2–5 是同一个根因的四个面：**会话级供应商没有一个统一的解析口径，各消费点各自读 `be.LLMProviderKey`**。
+
+## Actors and user stories
+
+1. 作为对话中的用户，我希望换一个 LLM 供应商继续这段对话，以便同一段上下文换个模型/厂商接着跑，而不必新建会话重述背景。
+2. 作为 CLI 登录态（agent 未绑供应商）会话的用户，我希望能中途切到一个 agentre 供应商接管，也能再切回登录态。
+3. 作为选了会话级供应商的用户，我希望请求真的打到我选的那个供应商，且头部上下文用量按它计算。
+4. 作为远端 `agentred` 会话的用户，我希望切换在远端同样生效。
+5. 作为切换过供应商的用户，我希望回看 transcript 时能看出从哪一条开始换的供应商。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | **`chat_sessions.provider_key` 从「落库后不可改」放开为可改**，新增单列更新 `UpdateProviderKey` + `chat_svc.SetChatSessionProvider` + Wails 绑定 | 用户要求对话中可切；单列更新与既有 `UpdatePermissionMode` / `UpdateExecDaemon` 同形（`internal/repository/chat_repo/session.go:409-427`）。拒绝走全量 `Update`——会把并发轮写入的状态字段一起盖掉 |
+| 2 | **引入唯一的有效供应商解析口 `effectiveProviderKey = firstNonEmpty(sess.ProviderKey, be.LLMProviderKey)`，所有消费点改读它**：turn 解析、网关 token 路由、CLI env / config 门控、LoadSession 展示、复制启动命令、远端 wire | 问题 2–5 是同一根因的四个面；`chat.go:3722` 已在 remote 路径用了这个表达式，把它提成共用解析口而不是再抄三份。拒绝在各消费点分别加 `if sess.ProviderKey != ""` 补丁——正是当前缺陷的成因 |
+| 3 | **网关 token 的身份不变、路由可变**：`TokenEntry` 的供应商来源改为签发时传入的 effective key，并新增「按 token 更新其 provider key」的能力；切换时更新既有 entry，不重签 token | token 是**会话级常驻**且首轮就烤进子进程 env，跨轮复用（`chat.go:4557-4562`）；重签会让在跑的子进程手里的 token 失效（正是被修过的 401 事故）。拒绝每轮重签——同一事故的回归 |
+| 4 | **供应商变化触发子进程 evict + 重 spawn，比对键从 model 扩展为 (effectiveProviderKey, model)** | claudecode 已有 `launchedModel != claudeEffectiveModel(req)` 的 evict 先例（`internal/pkg/agentruntime/runtimes/claudecode/runtime.go:564`），codex 有等价的 `modelChanged`（`runtimes/codex/runtime.go:113-118`）；但两个不同供应商可以配同一个 model id，只比 model 会漏掉换供应商。拒绝无条件 respawn——会让不换供应商的普通续轮也白重启 |
+| 5 | **piagent 不需要新增 evict 逻辑** | piagent 不使用 `CLISessionPool`，每轮按 `req.Provider` 重新装配 provider 扩展与 `--model agentre-<key>/<model>`（`runtimes/piagent/session.go:335-337`），换供应商下一轮自然生效 |
+| 6 | **CLI env / config 的网关门控改按 effective provider 判定**：claudecode 的 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` 与 codex 的 `shouldSignChatGateway` + `BuildCodexConfig` 都以「本轮是否有 effective provider」为准 | 兑现 #33 决策 5 的既有承诺（问题 3），也是登录态双向切换的前提。拒绝只在 backend 已绑时才允许会话切换——会把用户决策「登录态双向可切」砍掉 |
+| 7 | **登录态会话双向可切**（用户决策）：未绑 agent 的会话可选一个 agentre 供应商接管，也可选回「跟随 agent 绑定」回到 CLI 登录态 | 用户决策；修好决策 6 后技术上对称，上下文靠 `--resume` 不丢。拒绝 #26 的「登录态已有会话灰显」——那是在没有会话级供应商概念时的限制，现已不成立 |
+| 8 | **自下一轮生效，轮中允许切**（用户决策） | 沿用 #26 已定语义；当前轮的子进程已用旧供应商 spawn，改写它等于打断用户正在看的输出。拒绝「立即生效」——需要中断并重启在跑的轮，代价与风险都不成立；拒绝「轮中禁用」——长轮期间无法预设下一轮 |
+| 9 | **切换成功后向 transcript 追加一条持久 notice**（用户决策），复用既有 `NoticeBlock` 与 providerFallback 同一套渲染（`chat.go:718-762`） | 用户决策；两个供应商配同一 model 时，逐条消息的 `model` 字段看不出分界。拒绝不留痕——回看时无法定位切换点 |
+| 10 | **选择器在已有会话同样渲染，不满足条件时 `disabled` + tooltip 说明**（用户决策），取代 #33 决策 7 的「已有会话不渲染任何切换器」 | 用户决策：隐藏让用户以为功能消失（本轮起因就是这个报告）。禁用态覆盖：openclaw 后端、无兼容供应商、供应商列表加载中、列表拉取失败 |
+| 11 | **切换时复用新建会话那套校验**（存在 / `IsActive` / `ProviderTypeMatch`），不通过则拒绝写库并原样报错，会话保持原供应商 | 与 `validateNewSessionProvider`（`chat.go:1723-1743`）同一口径，避免出现「写进去了但下一轮必然失败」的会话。拒绝先落库后校验 |
+| 12 | **远端切换沿用「wire 只过 key、daemon 自解」**：每轮 run 已透传 effectiveProviderKey（`chat.go:3722`），daemon 侧把同样的 effective key 用到它自己的网关 token 路由上 | 硬不变量 7；daemon 侧已有按 effective key 解析 provider 的分支（`internal/daemon/handlers/runtime.go:349-376`），缺的只是网关 token 那一段。拒绝把 desktop 的 provider 实体下发给 daemon——密钥越线 |
+| 13 | **`docs/specs/2026-08-09-new-session-provider-select.md` 的决策 7 与「不可事后改」标注为被本规格取代**，不删除原文件 | 该规格其余部分（新建会话选择器、回退 notice、迁移）仍然有效，只有这两条被推翻。拒绝整篇 Superseded——会连带作废仍生效的决策 |
+
+## 有效供应商解析（唯一口径）
+
+会话任意一轮的有效供应商 = `sess.ProviderKey` 非空时取它，否则取 `be.LLMProviderKey`；两者都空表示「无供应商」，即 CLI 自身登录态（builtin 后端此时不可对话，走既有 `NewSessionChatGuard`）。
+
+这个口径是**唯一**的：turn 解析、网关 token 签发与路由、CLI 子进程 env / config 的网关门控、`LoadSession` 的展示字段、复制启动命令、远端 wire 透传，全部读同一个解析结果。任何消费点不得再直接读 `be.LLMProviderKey` 来决定「这一轮用谁」。
+
+会话所选供应商缺失 / 停用 / 与后端 kind 不兼容时，该轮回退 agent 绑定并追加既有的 providerFallback notice，`provider_key` 不清除（既有行为，不变）。
+
+## 切换流程与生效时机
+
+用户在已有会话的 composer 里打开供应商选择器并选中一项：前端调用后端切换接口，后端按决策 11 校验后写入 `chat_sessions.provider_key` 并返回成功；前端更新 pill 显示。选「跟随 agent 绑定」写入空串。
+
+切换**不触碰正在进行的轮**：不 evict 子进程、不改写已下发的 env、不重签 token、不中断流式输出。下一轮起 turn 解析读到新的 effective key，据此解析 provider、更新该会话网关 token 的路由、并在供应商变化时 evict 重 spawn 子进程。
+
+弹层底部常显一行说明「切换自下一轮生效，正在进行的回合不受影响」。
+
+切换成功后向 transcript 追加一条持久 notice，说明从此处起改用哪个供应商（选回「跟随 agent 绑定」时说明改为跟随绑定 / CLI 登录态）。notice 与既有 providerFallback notice 同为结构化负载 + 前端 `t()` 渲染，不把原始 JSON 泄漏给前端。
+
+## 网关路由与子进程重启
+
+网关 token 在整段会话内保持同一个字符串（它已烤进子进程 env）；切换供应商改变的是该 token 在网关内的**路由目标**。签发时按 effective key 填入，切换后的下一轮把既有 token 的 provider key 更新为新的 effective key。token 找不到对应 entry / entry 的 provider 缺失或停用时，转发端点维持既有的 401 / 502 行为。
+
+CLI 子进程在本轮 effective provider 与 spawn 时不一致时 evict 并重 spawn（claudecode / codex）：`--model`、`ANTHROPIC_BASE_URL`、codex 的 `model_provider` config 都是启动期参数，运行时改不掉。重 spawn 通过 `--resume` / `thread/resume` 续上原 CLI 会话，对话上下文不丢。登录态 ↔ 供应商两个方向都要重 spawn，因为网关相关 env 的有无本身就是启动期差异。
+
+## 登录态与后端可用性
+
+agent 未绑供应商的会话（CLI 登录态）可以选一个兼容的 agentre 供应商接管：该轮起签发网关 token、装配网关 env / config，请求经本机网关转发到所选供应商。选回「跟随 agent 绑定」则下一轮不装配网关 env，回到 CLI 自身登录态。
+
+openclaw 后端不消费 agentre provider：选择器渲染为 disabled，tooltip 说明该后端不使用 agentre 供应商。
+
+## 展示口径
+
+`LoadSession` 返回的会话级供应商类型与上下文窗口按 effective provider 解析；`ChatSessionDetail` 增加会话当前 `providerKey` 与 agent 绑定 key 两个字段，供前端渲染 pill 标签（已选具体供应商 → 供应商名；未选 → agent 绑定供应商名；两者皆无 → 「选择供应商」占位）。运行时上报的 `session.ContextWindow` 优先级不变（既有 `resolveContextWindowWithRuntime` 顺序）。
+
+「复制启动命令」按 effective provider 解析供应商与签发 token，使复制出的命令与该会话实际执行一致。
+
+## UI 与禁用状态
+
+已有会话复用新建会话那颗 pill（同一组件、同一弹层、同一位置），差异只在数据来源与禁用条件。
+
+| 会话/后端状态 | pill | 说明 |
+|---|---|---|
+| builtin / claudecode / codex / piagent，有兼容供应商 | 可用 | 已选高亮 + 可清回「跟随 agent 绑定」 |
+| 轮进行中 | 可用 | 弹层底部常显「自下一轮生效」 |
+| openclaw 后端 | disabled | tooltip：该后端不使用 agentre 供应商 |
+| 无兼容供应商 | disabled | tooltip：没有与该后端类型匹配的可用供应商 |
+| 供应商列表加载中 | disabled | 既有行为 |
+| 列表拉取失败 | 可用 | 弹层底部错误行（既有行为） |
+
+pill 与列表项的 `aria-label` / `title` / `aria-selected` 与键盘可达性沿用既有实现；禁用态的原因通过 tooltip 暴露，不只靠视觉灰显。
+
+## Out of scope
+
+- **回合内立即切换 / 中断当前轮换供应商**（决策 8 已拒绝）。
+- **会话级模型选择**：本轮仍是「用所选供应商的默认模型」，不恢复 #26 的模型列表或自由输入（`2026-08-09` 规格决策 6 不变）。
+- **openclaw 供应商选择**：该后端不消费 agentre provider。
+- **切换写回 agent 绑定**：硬不变量 2。
+- **回退时自动清除 `provider_key`**：既有行为保留。
+- **新增迁移**：`provider_key` 列已存在（基线 `migrations/202608080006_chat.go`），本轮不动 schema。
+
+## Testing decisions
+
+| Seam | 验证内容 | Prior art |
+|---|---|---|
+| `chat_svc` 单元（mockgen repo mock，不连 DB） | 切换校验（不存在 / inactive / 不兼容 → 报错且不写库）；切换成功写 `provider_key` 并产出 notice；切回空串；effective 解析（会话 > agent 绑定 > 空）；轮中切换不影响本轮已解析的 provider | `chat_test.go` 的 runTurn / 权限模式 / `chat_internal_test.go` 的 `TestPrepareTurnRun_Remote*` |
+| `chat_repo` 单元（sqlmock） | `UpdateProviderKey` 只更新该列 | `session_test.go` 既有单列更新用例 |
+| `httpgateway` 单元 | 按 effective key 签发的 entry 路由到该供应商；更新既有 token 的 provider key 后转发目标随之改变且 token 字符串不变；provider 缺失 / 停用维持 502 | `token_registry_test.go` / `llmforward_test.go` |
+| `agentruntime` 单元 | claudecode / codex：effective provider 变化 → evict 重 spawn；未变 → 复用；claudecode env 与 codex config 在「backend 未绑但会话选了供应商」时装配网关参数，在「两者都无」时不装配 | `clienv_test.go`、`runtimes/claudecode/runtime_test.go`、`runtimes/codex` 既有 modelChanged 用例 |
+| daemon handler 单元 | 远端按 effective key 解析并用于自家网关 token 路由；会话 key 缺失时回退 agent 绑定并回传 fallback 信号（既有语义不回归） | `internal/daemon/handlers` 既有 runtime 用例 |
+| 前端（vitest） | 已有会话渲染 pill 并显示当前会话供应商；禁用状态表逐条（openclaw / 无兼容供应商 / 加载中）；选中调用切换接口并更新显示；i18n key 覆盖 | `model-pill.test.tsx`、`chat-panel.test.tsx` |
+
+**无法自动化的部分**：真实 claude / codex CLI 在换供应商后重 spawn 并 `--resume` 续上原会话、请求真的打到新供应商的上游——这依赖真 CLI 与真供应商凭证。由收尾阶段的真机运行观测覆盖：开启 Debug Logging 后确认重 spawn 发生、网关转发目标为新供应商、对话上下文未丢，按 `docs/verification.md` 在 `e2e/scratch/2026-08-10-session-provider-switch/` 留证据。
+
+## Links
+
+- 前序规格：[2026-08-09 新建会话选择 LLM 供应商](./2026-08-09-new-session-provider-select.md)（其决策 7「已有会话不渲染任何切换器」与决策 2「不可事后修改」被本规格取代）
+- 历史规格：[2026-08-06 会话内切换 LLM 模型](./2026-08-06-session-model-switch.md)（已 Superseded，本规格不恢复其模型选择能力）
+
+## Open questions
+
+无。

--- a/frontend/src/components/agentre/__tests__/chat-panel.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat-panel.test.tsx
@@ -42,6 +42,7 @@ const appMocks = vi.hoisted(() => ({
   GetChatGoal: vi.fn(),
   ListLLMProviders: vi.fn().mockResolvedValue({ items: [] }),
   LoadChatSession: vi.fn(),
+  SetChatSessionProvider: vi.fn(),
   MarkChatSessionRead: vi.fn().mockResolvedValue({}),
   RegenerateChatMessage: vi.fn(),
   RenameChatSession: vi.fn(),
@@ -2911,9 +2912,11 @@ describe("ChatPanel · 新对话 PermissionModePill", () => {
     expect(pill).toHaveTextContent("Acme Claude");
   });
 
-  it("openclaw 新建会话不渲染供应商选择器（openclaw 不消费 agentre provider）", () => {
+  it("openclaw 新建会话渲染 disabled pill（决策 10：禁用而非隐藏，不消费 agentre provider）", async () => {
     resetStore();
     mockSessionStore.session = null;
+    // 本文件无 beforeEach 清 mock，先前测试的调用会累计 —— 这里先清掉只看本测试。
+    appMocks.ListLLMProviders.mockClear();
     render(
       <ChatPanel
         sessionId={0}
@@ -2929,27 +2932,13 @@ describe("ChatPanel · 新对话 PermissionModePill", () => {
       />,
     );
 
-    expect(screen.queryByTestId("provider-pill")).not.toBeInTheDocument();
+    const pill = await screen.findByTestId("provider-pill");
+    expect(pill).toBeDisabled();
+    expect(appMocks.ListLLMProviders).not.toHaveBeenCalled();
   });
 
-  it("已有会话（含 openclaw）不渲染供应商选择器（决策 7：无 pill、无只读徽标）", () => {
+  it("已有会话渲染供应商选择器并显示会话当前供应商（决策 10：取代『无 pill』的旧决策 7）", async () => {
     resetStore();
-    mockSessionStore.session = makeSession({
-      backendType: "claudecode",
-      llmProviderKey: "acme-anthropic",
-    });
-    render(<ChatPanel sessionId={42} newSessionAgent={null} />);
-
-    expect(screen.queryByTestId("provider-pill")).not.toBeInTheDocument();
-  });
-
-  it("已有会话不拉 ListLLMProviders：供应商选择器只在新建会话渲染", async () => {
-    resetStore();
-    mockSessionStore.session = makeSession({
-      backendType: "claudecode",
-      llmProviderKey: "acme-anthropic",
-    });
-    // 本文件无 beforeEach 清 mock，先前测试的调用会累计 —— 这里先清掉只看本测试。
     appMocks.ListLLMProviders.mockClear();
     appMocks.ListLLMProviders.mockResolvedValue({
       items: [
@@ -2962,13 +2951,76 @@ describe("ChatPanel · 新对话 PermissionModePill", () => {
         },
       ],
     });
-
+    mockSessionStore.session = makeSession({
+      backendType: "claudecode",
+      providerKey: "acme-anthropic",
+      agentProviderKey: "acme-anthropic",
+    });
     render(<ChatPanel sessionId={42} newSessionAgent={null} />);
 
-    await waitFor(() => {
-      expect(screen.queryByTestId("provider-pill")).not.toBeInTheDocument();
+    const pill = await screen.findByTestId("provider-pill");
+    await waitFor(() => expect(pill).not.toBeDisabled());
+    expect(pill).toHaveTextContent("Acme");
+    expect(appMocks.ListLLMProviders).toHaveBeenCalled();
+  });
+
+  it("已有会话 openclaw 渲染 disabled pill + tooltip（决策 10）", async () => {
+    resetStore();
+    mockSessionStore.session = makeSession({
+      backendType: "openclaw",
+      providerKey: "",
+      agentProviderKey: "",
     });
-    expect(appMocks.ListLLMProviders).not.toHaveBeenCalled();
+    render(<ChatPanel sessionId={43} newSessionAgent={null} />);
+
+    const pill = await screen.findByTestId("provider-pill");
+    expect(pill).toBeDisabled();
+    expect(pill).toHaveAttribute(
+      "title",
+      "This backend does not use agentre providers",
+    );
+  });
+
+  it("已有会话选中供应商：调用 SetChatSessionProvider(sessionId, providerKey) 并 reload 会话以取新的切换 notice", async () => {
+    resetStore();
+    appMocks.ListLLMProviders.mockClear();
+    appMocks.ListLLMProviders.mockResolvedValue({
+      items: [
+        {
+          id: 11,
+          providerKey: "acme-anthropic",
+          name: "Acme",
+          type: "anthropic",
+          model: "claude-sonnet-4-5",
+        },
+      ],
+    });
+    appMocks.SetChatSessionProvider.mockResolvedValue({
+      providerKey: "acme-anthropic",
+      agentProviderKey: "",
+    });
+    reloadSpy.mockClear();
+    mockSessionStore.session = makeSession({
+      backendType: "claudecode",
+      providerKey: "",
+      agentProviderKey: "",
+    });
+    render(<ChatPanel sessionId={42} newSessionAgent={null} />);
+
+    const pill = await screen.findByTestId("provider-pill");
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    const user = userEvent.setup();
+    await user.click(pill);
+    await user.click(within(screen.getByRole("listbox")).getByText("Acme"));
+
+    await waitFor(() => {
+      expect(appMocks.SetChatSessionProvider).toHaveBeenCalledWith({
+        sessionId: 42,
+        providerKey: "acme-anthropic",
+      });
+    });
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled());
   });
 });
 

--- a/frontend/src/components/agentre/__tests__/chat.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat.test.tsx
@@ -699,6 +699,26 @@ describe("ChatTranscript autonomous turn banner", () => {
     );
     expect(screen.queryAllByRole("separator")).toHaveLength(0);
   });
+
+  it("notice 垫在 user 与它的 assistant 回复之间,不把这一轮误判成自主续轮", () => {
+    // 决策 3 的另一半:notice 行「在判断其它消息的『紧邻前一条』时被跳过」。这里
+    // msg(3) 紧邻的前一条**真实**消息是 msg(1) 这条 user —— 正常轮,不该出 banner。
+    // 真实成因:用户发完消息、assistant 还没落地时在 pill 上切了供应商,切换 notice
+    // 就落在两者中间(NextSeq 排在在途 assistant 之后同理)。notice 若不透明,它会
+    // 顶替 user 成为「紧邻前一条」,把一条普通轮误判成自主续轮 —— 正是 R2 的形状。
+    render(
+      <ChatTranscript
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        messages={[
+          msg(1, "user", "帮我查一下"),
+          noticeMsg(2),
+          msg(3, "assistant", "好的,我查到……"),
+        ]}
+      />,
+    );
+    expect(screen.queryAllByRole("separator")).toHaveLength(0);
+  });
 });
 
 describe("ChatTranscript virtualization", () => {

--- a/frontend/src/components/agentre/__tests__/chat.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat.test.tsx
@@ -592,6 +592,25 @@ describe("ChatTranscript autonomous turn banner", () => {
     } as chat_svc.ChatMessage;
   }
 
+  // emptyMsg:轮刚起、内容还没落地的 assistant 行(autonomous_turn.go / Send 建行时
+  // BlocksJSON 恒为 "[]")。与 noticeMsg 的区别正是判定要认的那条界:没有块 ≠ 块全是
+  // notice。
+  function emptyMsg(id: number): chat_svc.ChatMessage {
+    return {
+      blocks: [] as ChatBlockData[],
+      completionTokens: 0,
+      createtime: new Date("2026-05-17T10:30:00Z").getTime(),
+      durationMs: 0,
+      errorText: "",
+      id,
+      model: "",
+      promptTokens: 0,
+      role: "assistant",
+      seq: id,
+      sessionId: 1,
+    } as chat_svc.ChatMessage;
+  }
+
   // noticeMsg:供应商切换/回退 notice 的落库形状——独立的 assistant 消息,blocks 只有
   // 一个 type: "notice" 块(session_provider.go 的 encodeProviderSwitch 同源同形)。
   function noticeMsg(id: number): chat_svc.ChatMessage {
@@ -718,6 +737,29 @@ describe("ChatTranscript autonomous turn banner", () => {
       />,
     );
     expect(screen.queryAllByRole("separator")).toHaveLength(0);
+  });
+
+  it("自主续轮刚起、内容还没落地(blocks 为空)时横幅就该在", () => {
+    // 决策 3 认的是「内容块**全部是 notice**」,空 blocks 不是 notice 行 —— 这条守的
+    // 是判定别把「还没有内容的消息」一并吞掉。真实形状:autonomous_turn.go 建自主轮
+    // assistant 行时 BlocksJSON 恒为 "[]",chat-panel 的 autonomous_started 分支立刻
+    // 把这条空消息插进 messages,横幅正要在这一刻出现,而不是等第一段文字流完。
+    const { container } = render(
+      <ChatTranscript
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        messages={[
+          msg(1, "user", "后台跑吧，完了叫我"),
+          msg(2, "assistant", "后台任务我先跑着，完了叫你。"),
+          emptyMsg(3),
+        ]}
+      />,
+    );
+    const pendingRow = container.querySelector('[data-message-id="3"]');
+    expect(pendingRow).not.toBeNull();
+    expect(
+      within(pendingRow as HTMLElement).getByRole("separator"),
+    ).toHaveTextContent(/auto-continued|自动继续/);
   });
 });
 

--- a/frontend/src/components/agentre/__tests__/chat.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat.test.tsx
@@ -592,6 +592,32 @@ describe("ChatTranscript autonomous turn banner", () => {
     } as chat_svc.ChatMessage;
   }
 
+  // noticeMsg:供应商切换/回退 notice 的落库形状——独立的 assistant 消息,blocks 只有
+  // 一个 type: "notice" 块(session_provider.go 的 encodeProviderSwitch 同源同形)。
+  function noticeMsg(id: number): chat_svc.ChatMessage {
+    return {
+      blocks: [
+        {
+          level: "info",
+          noticeKind: "switch",
+          providerKey: "session-key",
+          providerName: "中转 · GLM 5.2",
+          type: "notice",
+        } as ChatBlockData,
+      ],
+      completionTokens: 0,
+      createtime: new Date("2026-05-17T10:30:00Z").getTime(),
+      durationMs: 0,
+      errorText: "",
+      id,
+      model: "",
+      promptTokens: 0,
+      role: "assistant",
+      seq: id,
+      sessionId: 1,
+    } as chat_svc.ChatMessage;
+  }
+
   it("自主续轮(assistant 紧邻前一条 assistant,无 user 行)前渲染 AutoTriggerBanner", () => {
     render(
       <ChatTranscript
@@ -621,6 +647,53 @@ describe("ChatTranscript autonomous turn banner", () => {
           msg(2, "assistant", "hello"),
           msg(3, "user", "again"),
           msg(4, "assistant", "ok"),
+        ]}
+      />,
+    );
+    expect(screen.queryAllByRole("separator")).toHaveLength(0);
+  });
+
+  it("供应商切换 notice 行本身不触发 banner,且不吞掉它之后紧跟的真实自主续轮", () => {
+    const { container } = render(
+      <ChatTranscript
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        messages={[
+          msg(1, "user", "后台跑吧，完了叫我"),
+          msg(2, "assistant", "后台任务我先跑着，完了叫你。"),
+          noticeMsg(3),
+          msg(4, "assistant", "后台任务跑完了，结果是……"),
+        ]}
+      />,
+    );
+    // notice 行(msg 3)在判定里透明:它自己不算自主轮 —— 它所在的行里没有 banner。
+    const noticeRow = container.querySelector('[data-message-id="3"]');
+    expect(noticeRow).not.toBeNull();
+    expect(
+      within(noticeRow as HTMLElement).queryByRole("separator"),
+    ).toBeNull();
+    // msg(4) 紧邻的前一条真实消息仍是 assistant(notice 被跳过)→ 真自主续轮的 banner
+    // 必须照常出现在 msg(4) 的行里(决策 3 的反向边界,mockup「R2 的反向边界」)。
+    const realRow = container.querySelector('[data-message-id="4"]');
+    expect(realRow).not.toBeNull();
+    expect(
+      within(realRow as HTMLElement).getByRole("separator"),
+    ).toHaveTextContent(/auto-continued|自动继续/);
+    // 全局也应恰好一条 banner,不多不少。
+    expect(screen.getAllByRole("separator")).toHaveLength(1);
+  });
+
+  it("供应商切换 notice 之后接正常 user→assistant 轮不产生 banner", () => {
+    render(
+      <ChatTranscript
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        messages={[
+          msg(1, "user", "hi"),
+          msg(2, "assistant", "先切个供应商"),
+          noticeMsg(3),
+          msg(4, "user", "继续"),
+          msg(5, "assistant", "好的"),
         ]}
       />,
     );

--- a/frontend/src/components/agentre/__tests__/chat.test.tsx
+++ b/frontend/src/components/agentre/__tests__/chat.test.tsx
@@ -2108,6 +2108,39 @@ describe("ChatTranscript typing indicator", () => {
     expect(screen.getByLabelText("Generating")).toBeInTheDocument();
   });
 
+  it("轮中切换供应商追加的 notice 行不抢走生成指示器", () => {
+    // 供应商 pill 允许在轮中切换,切换成功后 chat-panel 立刻 reloadSession(),把新落库
+    // 的 notice 消息(role=assistant、只有一个 notice 块)拉进 messages —— 它排在在跑
+    // 的 assistant 之后,成了 messages 的末条 assistant。指示器宿主必须仍是真正在流的
+    // 那条,否则三个点会跳到 notice 行上、在跑的那条看着像已经停了。
+    render(
+      <ChatTranscript
+        liveByMessageId={new Map([[2, { liveTail: "streaming chunk" }]])}
+        agentColor="agent-1"
+        agentName="CEO 助手"
+        messages={[
+          userMessage(1, "hi"),
+          assistantMessage(2, []),
+          assistantMessage(3, [
+            {
+              level: "info",
+              noticeKind: "switch",
+              providerKey: "session-key",
+              providerName: "中转 · GLM 5.2",
+              type: "notice",
+            } as ChatBlockData,
+          ]),
+        ]}
+        streaming
+      />,
+    );
+
+    const indicator = screen.getByLabelText("Generating");
+    expect(
+      indicator.closest("[data-message-id]")?.getAttribute("data-message-id"),
+    ).toBe("2");
+  });
+
   it("places the indicator after the live tail text in DOM order", () => {
     render(
       <ChatTranscript

--- a/frontend/src/components/agentre/__tests__/model-pill.test.tsx
+++ b/frontend/src/components/agentre/__tests__/model-pill.test.tsx
@@ -1,10 +1,11 @@
 /**
- * model-pill.test.tsx — 新建会话 LLM 供应商选择器（规格「新建会话供应商选择器」+ 决策 4/5）。
+ * model-pill.test.tsx — LLM 供应商选择器（规格 2026-08-09 决策 4/5 + 2026-08-10 决策 10）。
  *
  * 覆盖：只列兼容供应商（builtin→全部 / claudecode→anthropic / codex→openai-response /
  * piagent→anthropic+openai-chat+openai-response）；未绑 agent（CLI 登录态）也显示；
- * 瞬态选择 / 点击「跟随 agent 绑定」清回；列表加载中 → pill 禁用；拉取失败 → 弹层底部错误行。
- * （openclaw 不渲染 / 已有会话无 pill 是 chat-panel 级门控，见 chat-panel.test.tsx。）
+ * 新建会话瞬态选择 / 点击「跟随 agent 绑定」清回；列表加载中 → pill 禁用；拉取失败 → 弹层
+ * 底部错误行；已有会话（sessionId>0）选择立即持久化（SetChatSessionProvider）；不可切换时
+ * pill 常显但 disabled + tooltip 说明原因（openclaw / 无兼容供应商），不隐藏（决策 10）。
  */
 
 import { act, render, screen, waitFor, within } from "@testing-library/react";
@@ -13,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const appMocks = vi.hoisted(() => ({
   ListLLMProviders: vi.fn(),
+  SetChatSessionProvider: vi.fn(),
 }));
 
 vi.mock("../../../../wailsjs/go/app/App", () => appMocks);
@@ -245,10 +247,164 @@ describe("ProviderPill · 新建会话供应商选择器", () => {
     );
   });
 
-  it("openclaw backend 不拉取供应商（列表为空、不加载）", () => {
+  it("openclaw backend 不拉取供应商；pill 常显但 disabled + tooltip 说明原因（决策 10：禁用而非隐藏）", () => {
     render(<Harness backendType="openclaw" />);
 
-    expect(screen.getByTestId("provider-pill")).not.toBeDisabled();
+    const pill = screen.getByTestId("provider-pill");
+    expect(pill).toBeDisabled();
+    expect(pill).toHaveAttribute(
+      "title",
+      "This backend does not use agentre providers",
+    );
     expect(appMocks.ListLLMProviders).not.toHaveBeenCalled();
+  });
+
+  it("无兼容供应商（列表拉取成功但为空）→ pill disabled + tooltip 说明原因", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: [CHAT_PROVIDER] });
+    render(<Harness backendType="claudecode" />);
+
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).toBeDisabled());
+    expect(pill).toHaveAttribute(
+      "title",
+      "No available provider matches this backend type",
+    );
+  });
+
+  it("弹层底部常显「自下一轮生效」说明（不随轮状态变化）", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: ALL_PROVIDERS });
+    render(<Harness backendType="builtin" />);
+
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    const user = userEvent.setup();
+    await user.click(pill);
+
+    expect(screen.getByTestId("provider-pill-note")).toHaveTextContent(
+      "Switching takes effect from the next turn; the turn in progress is unaffected",
+    );
+  });
+});
+
+describe("ProviderPill · 已有会话（决策 1/9/10：选择立即持久化 + 切换 notice）", () => {
+  it("已有会话水合当前选择：providerKey 显示会话已持久化的供应商", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: ALL_PROVIDERS });
+    render(
+      <Harness
+        backendType="claudecode"
+        sessionId={42}
+        persistedProviderKey="acme-anthropic"
+      />,
+    );
+
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).not.toBeDisabled());
+    expect(pill).toHaveTextContent("Acme Claude");
+  });
+
+  it("选中供应商调用 SetChatSessionProvider 并按响应更新显示，随后触发 onSwitched", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: ALL_PROVIDERS });
+    appMocks.SetChatSessionProvider.mockResolvedValue({
+      providerKey: "acme-anthropic",
+      agentProviderKey: "",
+    });
+    const onSwitched = vi.fn();
+    render(
+      <Harness
+        backendType="claudecode"
+        sessionId={42}
+        persistedProviderKey=""
+        onSwitched={onSwitched}
+      />,
+    );
+
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    const user = userEvent.setup();
+    await user.click(pill);
+    await user.click(
+      within(screen.getByRole("listbox")).getByText("Acme Claude"),
+    );
+
+    expect(appMocks.SetChatSessionProvider).toHaveBeenCalledWith({
+      sessionId: 42,
+      providerKey: "acme-anthropic",
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-pill")).toHaveTextContent(
+        "Acme Claude",
+      ),
+    );
+    await waitFor(() => expect(onSwitched).toHaveBeenCalledTimes(1));
+  });
+
+  it("清回「跟随 agent 绑定」调用 SetChatSessionProvider 传空串，pill 落回绑定供应商名", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: ALL_PROVIDERS });
+    appMocks.SetChatSessionProvider.mockResolvedValue({
+      providerKey: "",
+      agentProviderKey: "acme-anthropic",
+    });
+    render(
+      <Harness
+        backendType="claudecode"
+        sessionId={42}
+        boundProviderKey="acme-anthropic"
+        persistedProviderKey="acme-response"
+      />,
+    );
+
+    // 会话已切到 acme-response（与后端不兼容，但水合只是展示当前持久化值，
+    // 不做二次校验——真实场景下这条会话的 backend 类型本就限定了兼容集合）。
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    const user = userEvent.setup();
+    await user.click(pill);
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: /Follow agent binding/i,
+      }),
+    );
+
+    expect(appMocks.SetChatSessionProvider).toHaveBeenCalledWith({
+      sessionId: 42,
+      providerKey: "",
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-pill")).toHaveTextContent(
+        "Acme Claude",
+      ),
+    );
+  });
+
+  it("切换失败：回滚显示并在弹层底部报错", async () => {
+    appMocks.ListLLMProviders.mockResolvedValue({ items: ALL_PROVIDERS });
+    appMocks.SetChatSessionProvider.mockRejectedValue(new Error("nope"));
+    render(
+      <Harness
+        backendType="claudecode"
+        sessionId={42}
+        persistedProviderKey=""
+      />,
+    );
+
+    const pill = await waitFor(() => screen.getByTestId("provider-pill"));
+    await waitFor(() => expect(pill).not.toBeDisabled());
+
+    const user = userEvent.setup();
+    await user.click(pill);
+    await user.click(
+      within(screen.getByRole("listbox")).getByText("Acme Claude"),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-pill")).toHaveTextContent(
+        "Select provider",
+      ),
+    );
+    await user.click(screen.getByTestId("provider-pill"));
+    expect(screen.getByTestId("provider-pill-error")).toHaveTextContent("nope");
   });
 });

--- a/frontend/src/components/agentre/__tests__/transcript-row-view-notice.test.tsx
+++ b/frontend/src/components/agentre/__tests__/transcript-row-view-notice.test.tsx
@@ -17,6 +17,7 @@ import type { TranscriptRow } from "../transcript-rows";
 type NoticeBlock = {
   text?: string;
   providerKey?: string;
+  noticeKind?: string;
 };
 
 function noticeRow(block: NoticeBlock): TranscriptRow {
@@ -98,6 +99,39 @@ describe("transcript notice block", () => {
           provider: "gone-provider",
         }),
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a provider-switch notice（noticeKind=switch,非空 providerKey）走切换文案（决策 9）", () => {
+    // 用户在会话里切到某个具体供应商：与回退 notice 共用 providerKey 字段,但
+    // noticeKind="switch" 才是判据 —— 文案必须是「切换」而不是「回退」。
+    renderRow(
+      noticeRow({ providerKey: "acme-anthropic", noticeKind: "switch" }),
+    );
+
+    expect(
+      screen.getByText(
+        i18n.t("chat.notice.providerSwitch.sentence", {
+          provider: "acme-anthropic",
+        }),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        i18n.t("chat.notice.providerFallback.sentence", {
+          provider: "acme-anthropic",
+        }),
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a provider-switch notice 清回「跟随 agent 绑定」（noticeKind=switch,providerKey 空串）", () => {
+    // 决策 9：providerKey 空串表示改回跟随 agent 绑定 / CLI 登录态 —— 不能靠
+    // 「providerKey 非空」判定负载有效，必须走 noticeKind。
+    renderRow(noticeRow({ providerKey: "", noticeKind: "switch" }));
+
+    expect(
+      screen.getByText(i18n.t("chat.notice.providerSwitch.followAgentBinding")),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/agentre/__tests__/transcript-row-view-notice.test.tsx
+++ b/frontend/src/components/agentre/__tests__/transcript-row-view-notice.test.tsx
@@ -17,6 +17,7 @@ import type { TranscriptRow } from "../transcript-rows";
 type NoticeBlock = {
   text?: string;
   providerKey?: string;
+  providerName?: string;
   noticeKind?: string;
 };
 
@@ -133,5 +134,44 @@ describe("transcript notice block", () => {
     expect(
       screen.getByText(i18n.t("chat.notice.providerSwitch.followAgentBinding")),
     ).toBeInTheDocument();
+  });
+
+  it("renders a provider-switch notice 优先显示供应商展示名而非裸 key（决策 1）", () => {
+    // 用户在 pill 上选的是供应商名，回看 transcript 应该读到同一个名字，而不是
+    // providerKey 那串 UUID。
+    renderRow(
+      noticeRow({
+        providerKey: "36a04495-dfe9-40ef-a3c5-2b62468db6b1",
+        providerName: "中转 · GLM 5.2",
+        noticeKind: "switch",
+      }),
+    );
+
+    expect(
+      screen.getByText(
+        i18n.t("chat.notice.providerSwitch.sentence", {
+          provider: "中转 · GLM 5.2",
+        }),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/36a04495-dfe9-40ef-a3c5-2b62468db6b1/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a provider-fallback notice 优先显示供应商展示名而非裸 key（决策 2）", () => {
+    // 回退 notice 与切换 notice 同构：供应商实体还在（只是停用/不兼容）时同样有名字。
+    renderRow(
+      noticeRow({ providerKey: "acme-anthropic", providerName: "备用网关" }),
+    );
+
+    expect(
+      screen.getByText(
+        i18n.t("chat.notice.providerFallback.sentence", {
+          provider: "备用网关",
+        }),
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/acme-anthropic/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -95,11 +95,7 @@ import {
 import { computeComposerContextUsage } from "./chat-panel-context-usage";
 import { blockReasonToCta, navigateToTarget } from "./not-chattable";
 import { PermissionModePill, usePermissionMode } from "./permission-mode";
-import {
-  ProviderPill,
-  useProviderPill,
-  isProviderSelectableBackend,
-} from "./model-pill";
+import { ProviderPill, useProviderPill } from "./model-pill";
 import {
   NewSessionExecTargetLine,
   SessionOfflineBanner,
@@ -1337,20 +1333,24 @@ function ChatPanel({
       session?.agentStatus === "running" ||
       session?.agentStatus === "waiting");
 
-  // ProviderPill:新建会话（sessionId===0）的 LLM 供应商选择器,替换原模型 pill。
-  // 只列与后端兼容的供应商（决策 4）,未绑 agent 也显示（决策 5）;已有会话无任何
-  // 切换器（决策 7）。openclaw 不消费 agentre provider,不渲染（决策 4）。
-  // 拉取按 sessionId===0 && 可选项后端 双重门控 —— 否则打开任意已有会话都会白打一次
-  // ListLLMProviders（对每个已绑供应商的真实 HTTP 请求,不是本地目录）。
-  // 可选项后端集合与 use-provider-pill 的 PROVIDER_SELECTABLE_BACKENDS 共用同一判定
-  // （isProviderSelectableBackend），避免两处各自维护一份后端名单漂移 —— 渲染门控与
-  // 拉取门控必须永远一致，否则新增可选项后端时 pill 会拉了列表却不渲染（或反之）。
-  const providerSelectableBackend =
-    isProviderSelectableBackend(activeBackendType);
+  // ProviderPill:composer 里的 LLM 供应商选择器。新建会话（sessionId===0）与已有
+  // 会话共用同一颗 pill（同一组件、同一弹层、同一位置），差异只在数据来源与禁用
+  // 条件（规格 2026-08-10「已有会话切换 LLM 供应商」决策 10，取代 2026-08-09 决策 7
+  // 的「已有会话不渲染任何切换器」）：不可切换（openclaw / 无兼容供应商 / 加载中）
+  // 时 pill 常显但 disabled + tooltip 说明原因，不再隐藏。
+  // 新建会话的绑定供应商来自 newSessionAgent（尚无 session 行）；已有会话来自
+  // ChatSessionDetail.agentProviderKey / providerKey（task 1 已产出）。已有会话选中
+  // 立即持久化（SetChatSessionProvider），成功后 reloadSession() 把新追加的切换
+  // notice 拉进 transcript。
   const providerPill = useProviderPill({
-    backendType:
-      sessionId === 0 && providerSelectableBackend ? activeBackendType : "",
-    boundProviderKey: newSessionAgent?.llmProviderKey,
+    backendType: activeBackendType,
+    boundProviderKey:
+      sessionId > 0
+        ? session?.agentProviderKey
+        : newSessionAgent?.llmProviderKey,
+    sessionId,
+    persistedProviderKey: sessionId > 0 ? session?.providerKey : undefined,
+    onSwitched: () => void reloadSession(),
   });
 
   // prop 优先，无 prop 时降级到内部派生值。
@@ -2845,9 +2845,7 @@ function ChatPanel({
                   ) : null
                 }
                 modelSlot={
-                  sessionId === 0 && providerSelectableBackend ? (
-                    <ProviderPill {...providerPill} />
-                  ) : null
+                  activeBackendType ? <ProviderPill {...providerPill} /> : null
                 }
                 onShiftTab={
                   isModeSwitchable && !modeSwitchingDisabled

--- a/frontend/src/components/agentre/chat-panel.tsx
+++ b/frontend/src/components/agentre/chat-panel.tsx
@@ -46,6 +46,7 @@ import i18n from "@/i18n";
 import { reasonToDisplayStatus } from "@/lib/attention-display";
 import { copyTextWithToast } from "@/lib/clipboard-toast";
 import { splitErrorDetail } from "@/lib/error-detail";
+import { isNoticeOnlyMessage } from "@/lib/notice-message";
 import {
   findProjectColorToken,
   findProjectPath,
@@ -433,8 +434,12 @@ function applyStreamError(
   if (message) return upsertMessage(messages, message);
   if (!error) return messages;
 
+  // 末条**真实** assistant:供应商切换 notice 的旁白行跳过(与 use-chat-session /
+  // ChatTranscript / 后端 lastTurnAssistantIndex 同一口径)。轮中切换供应商会把它排在
+  // 在跑的那条之后,errorText 落到旁白行 = 出错的那一轮看着没出错、旁白行反而红了。
   let idx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
+    if (isNoticeOnlyMessage(messages[i])) continue;
     if (messages[i].role === "assistant") {
       idx = i;
       break;

--- a/frontend/src/components/agentre/chat.tsx
+++ b/frontend/src/components/agentre/chat.tsx
@@ -1315,7 +1315,7 @@ const ChatTranscript = React.forwardRef<
   // 判定:assistant 轮且其在**完整 messages**里紧邻的前一条不是 user —— 正常轮是
   // user→assistant、auto-continue / steer 也是 user→assistant,只有自主续轮是
   // assistant→assistant(无 user 行)。用完整 messages(而非 displayMessages)算,
-  // 避免 compact 折叠把首条 assistant 误判成自主轮。会话首条(永不算,见下方 prevRole
+  // 避免 compact 折叠把首条 assistant 误判成自主轮。会话首条永不算(见下方 prevRole
   // 的 undefined 初值)。
   //
   // 只含 notice 块的消息(供应商切换/回退提示,规格决策 3)在这条判定里透明:它自己

--- a/frontend/src/components/agentre/chat.tsx
+++ b/frontend/src/components/agentre/chat.tsx
@@ -25,6 +25,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { isNoticeOnlyMessage } from "@/lib/notice-message";
 import { cn } from "@/lib/utils";
 
 import type { PlanActionStream } from "./canonical-tool/props";
@@ -1274,12 +1275,21 @@ const ChatTranscript = React.forwardRef<
   },
   ref,
 ) {
-  // 只有当整个序列的「最后一条」就是 assistant 时才挂指示器：
-  // 正常 stream 流程下 doSend 会同时插入 user + assistant 占位，所以末尾一定是 assistant；
-  // 如果末尾是 user（异常态或还没插占位），不应该在更早的 assistant 上挂指示器误导用户。
-  const tail = messages.at(-1);
-  const lastAssistantId =
-    tail && tail.role === "assistant" ? tail.id : undefined;
+  // lastAssistantId:生成指示器(三个点)的宿主。只有当整个序列的「最后一条」就是
+  // assistant 时才挂 —— 正常 stream 流程下 doSend 同时插入 user + assistant 占位,
+  // 所以末尾一定是 assistant;末尾是 user(异常态或还没插占位)时不该在更早的
+  // assistant 上挂指示器误导用户,所以扫到的第一条不是 assistant 就返回 undefined。
+  // 只承载 notice 的旁白行在这里透明:轮中切换供应商会把一条 notice 消息追加在在跑的
+  // assistant 之后(pill 切完立刻 reloadSession),它若被当成末条 assistant,三个点就
+  // 跳到旁白行上、在跑的那条看着像已经停了。
+  const lastAssistantId = React.useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (isNoticeOnlyMessage(m)) continue;
+      return m.role === "assistant" ? m.id : undefined;
+    }
+    return undefined;
+  }, [messages]);
 
   // 折叠"压缩前"的旧消息:扫所有 messages.blocks,找最后一条 compact_boundary 所在的
   // (messageIdx, blockIdx);该位置之前的所有消息默认隐藏,该消息自己的更早 blocks 也
@@ -1326,9 +1336,7 @@ const ChatTranscript = React.forwardRef<
     const ids = new Set<number>();
     let prevRole: string | undefined;
     for (const m of messages) {
-      const isNoticeOnly =
-        m.blocks.length > 0 && m.blocks.every((b) => b.type === "notice");
-      if (isNoticeOnly) continue;
+      if (isNoticeOnlyMessage(m)) continue;
       if (
         prevRole !== undefined &&
         m.role === "assistant" &&

--- a/frontend/src/components/agentre/chat.tsx
+++ b/frontend/src/components/agentre/chat.tsx
@@ -1315,13 +1315,28 @@ const ChatTranscript = React.forwardRef<
   // 判定:assistant 轮且其在**完整 messages**里紧邻的前一条不是 user —— 正常轮是
   // user→assistant、auto-continue / steer 也是 user→assistant,只有自主续轮是
   // assistant→assistant(无 user 行)。用完整 messages(而非 displayMessages)算,
-  // 避免 compact 折叠把首条 assistant 误判成自主轮。会话首条(i===0)永不算。
+  // 避免 compact 折叠把首条 assistant 误判成自主轮。会话首条(永不算,见下方 prevRole
+  // 的 undefined 初值)。
+  //
+  // 只含 notice 块的消息(供应商切换/回退提示,规格决策 3)在这条判定里透明:它自己
+  // 永远不进 ids(单独 continue,连角色都不看),且在寻找「紧邻前一条」时被跳过(不
+  // 推进 prevRole)—— 否则它会插进两条真实 assistant 消息之间把回退提示误判成自主
+  // 续轮,也可能反过来垫在 assistant 与后续真实自主续轮之间把该有的判定拆断。
   const autonomousIds = React.useMemo(() => {
     const ids = new Set<number>();
-    for (let i = 1; i < messages.length; i++) {
-      if (messages[i].role === "assistant" && messages[i - 1].role !== "user") {
-        ids.add(messages[i].id);
+    let prevRole: string | undefined;
+    for (const m of messages) {
+      const isNoticeOnly =
+        m.blocks.length > 0 && m.blocks.every((b) => b.type === "notice");
+      if (isNoticeOnly) continue;
+      if (
+        prevRole !== undefined &&
+        m.role === "assistant" &&
+        prevRole !== "user"
+      ) {
+        ids.add(m.id);
       }
+      prevRole = m.role;
     }
     return ids;
   }, [messages]);

--- a/frontend/src/components/agentre/model-pill/provider-pill.tsx
+++ b/frontend/src/components/agentre/model-pill/provider-pill.tsx
@@ -15,31 +15,41 @@ export type ProviderPillProps = UseProviderPillReturn;
 
 /**
  * ProviderPill: composer 动作行里权限模式旁的 LLM 供应商选择器（规格「新建会话
- * 供应商选择器」+ 决策 4/5）。
+ * 供应商选择器」决策 4/5 + 「已有会话切换 LLM 供应商」决策 10）。
  *
  * 状态机:
  *  - 只列与后端兼容的供应商（isProviderCompatible 过滤,后端 ProviderTypeMatch 对齐）。
  *  - 未绑 agent（CLI 登录态）同样显示:弹层第一项「跟随 agent 绑定」语义为
  *    「不选,走 CLI 登录态」;选具体供应商可接管该会话。
  *  - 未选时 pill 标签:agent 已绑 → 绑定供应商名;未绑 → 「选择供应商」占位。
- *  - 列表加载中 → pill 禁用;拉取失败 → 弹层底部错误行。
- *  - 瞬态选择不发任何 IPC,首发 Send 时随 SendRequest.ProviderKey 透传落库。
+ *  - pill 在所有会话/后端状态下都渲染，不可切换时 disabled 而不是隐藏（决策 10）：
+ *    加载中沿用既有行为；后端不支持 agentre 供应商 / 加载成功但无兼容供应商都在
+ *    disabled 之外通过 title 说明原因；拉取失败保持可用，弹层底部报错（既有行为）。
+ *  - 弹层底部常显一行「自下一轮生效」说明，与轮是否进行中无关（决策 8/切换流程）。
+ *  - 新建会话瞬态选择不发任何 IPC，首发 Send 时随 SendRequest.ProviderKey 透传落库；
+ *    已有会话选中立即调 SetChatSessionProvider 持久化（hook 侧处理）。
  */
 export function ProviderPill({
   providerKey,
   setProviderKey,
   providers,
-  loading,
   error,
   unbound,
   effectiveKey,
+  disabled,
+  disabledReason,
 }: ProviderPillProps) {
   const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
 
   const selected = providers.find((p) => p.providerKey === effectiveKey);
   const label = selected?.name || effectiveKey || t("providerPill.unselected");
-  const disabled = loading;
+  const disabledTitle =
+    disabled && disabledReason === "unsupportedBackend"
+      ? t("providerPill.disabledUnsupportedBackend")
+      : disabled && disabledReason === "noCompatibleProviders"
+        ? t("providerPill.disabledNoCompatibleProviders")
+        : null;
 
   function handleSelect(key: string) {
     setOpen(false);
@@ -53,7 +63,7 @@ export function ProviderPill({
           type="button"
           disabled={disabled}
           aria-label={t("providerPill.aria", { provider: label })}
-          title={t("providerPill.title", { provider: label })}
+          title={disabledTitle ?? t("providerPill.title", { provider: label })}
           data-testid="provider-pill"
           className={cn(
             "inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border px-2 text-2xs font-medium leading-none transition-colors",
@@ -174,6 +184,15 @@ export function ProviderPill({
             );
           })}
         </ul>
+
+        {/* 决策 8/切换流程：弹层底部常显一行说明，不随轮状态变化——轮中允许切、
+            当前轮不受影响。 */}
+        <div
+          data-testid="provider-pill-note"
+          className="border-t border-border px-3.5 py-1.5 text-2xs text-muted-foreground"
+        >
+          {t("providerPill.switchNote")}
+        </div>
 
         {error ? (
           <div

--- a/frontend/src/components/agentre/model-pill/use-provider-pill.ts
+++ b/frontend/src/components/agentre/model-pill/use-provider-pill.ts
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import { ListLLMProviders } from "../../../../wailsjs/go/app/App";
+import {
+  ListLLMProviders,
+  SetChatSessionProvider,
+} from "../../../../wailsjs/go/app/App";
 import { llm_provider_svc } from "../../../../wailsjs/go/models";
 import i18n from "@/i18n";
 
@@ -49,44 +52,80 @@ export function isProviderCompatible(
 }
 
 export interface UseProviderPillOptions {
-  /** agent 后端类型；非可选择的 backend（openclaw 等）不拉取供应商。 */
+  /** agent 后端类型；非可选择的 backend（openclaw 等）不拉取供应商，pill 常显但
+   *  disabled（决策 10：禁用而非隐藏）。 */
   backendType: string;
   /** agent 已绑定的 provider key；空串 = 未绑（CLI 登录态）。 */
   boundProviderKey?: string | null;
+  /**
+   * >0 = 已有会话：选择立即持久化（调用 SetChatSessionProvider）；0 / undefined =
+   * 新建会话：纯瞬态，首发 Send 时随 SendRequest.ProviderKey 透传（决策 2/UI 不变）。
+   */
+  sessionId?: number;
+  /**
+   * 会话当前已持久化的供应商 key（ChatSessionDetail.providerKey）。仅 sessionId>0
+   * 时用于水合初始选择；会话切换 / 切换成功回填后随之更新本地显示。
+   */
+  persistedProviderKey?: string | null;
+  /**
+   * 持久化切换成功后的回调（典型 reloadSession()，把新追加的切换 notice 拉进
+   * transcript；pill 标签本身已由 SetChatSessionProvider 的响应直接更新，不依赖它）。
+   */
+  onSwitched?: () => void;
 }
 
 export interface UseProviderPillReturn {
-  /** 当前瞬态选择的 provider key；空串 = 跟随 agent 绑定。 */
+  /** 当前选择的 provider key；空串 = 跟随 agent 绑定。新建会话是纯瞬态本地值，
+   *  已有会话镜像 chat_sessions.provider_key（乐观更新，失败回滚）。 */
   providerKey: string;
   setProviderKey: (key: string) => void;
   /** 与 backendType 兼容的供应商列表。 */
   providers: llm_provider_svc.ProviderItem[];
   /** 列表加载中 → pill 禁用。 */
   loading: boolean;
-  /** 拉取失败 → 弹层底部错误行。 */
+  /** 拉取失败 或 持久化切换失败 → 弹层底部错误行。 */
   error: string | null;
   /** 未绑 agent（CLI 登录态）。 */
   unbound: boolean;
   /** 生效 key：providerKey || boundProviderKey（用于 pill 标签 / 高亮）。 */
   effectiveKey: string;
+  /** pill 是否禁用（规格「UI 与禁用状态」状态表：加载中 / 后端不可选 / 无兼容供应商）。 */
+  disabled: boolean;
+  /** disabled 的原因，供 tooltip 说明；null = 未禁用或禁用原因是既有的「加载中」
+   *  （沿用既有行为，不需要新增说明）。 */
+  disabledReason: "unsupportedBackend" | "noCompatibleProviders" | null;
 }
 
 /**
- * useProviderPill: 新建会话（sessionId===0）的 LLM 供应商选择器状态。
+ * useProviderPill: composer 里 LLM 供应商选择器的状态（新建会话瞬态选择 + 已有会话
+ * 立即持久化切换，规格 2026-08-10「已有会话切换 LLM 供应商」决策 1/9/10）。
  *
  * 数据流:
- *  - 新建会话还没有 sessionId,瞬态选择只存本地 state,首发 Send 时随
- *    SendRequest.ProviderKey 透传给后端随 Session 一起落库（决策 2/UI）。
- *  - 只拉一次 ListLLMProviders() 并按 isProviderCompatible 过滤出兼容供应商;
- *    未绑 agent（CLI 登录态）同样显示选择器（决策 5）。
+ *  - 新建会话（sessionId<=0）还没有 session 行，瞬态选择只存本地 state，首发 Send
+ *    时随 SendRequest.ProviderKey 透传给后端随 Session 一起落库（决策 2/UI）。
+ *  - 已有会话（sessionId>0）：初始选择水合自 persistedProviderKey；选中一项立即调
+ *    SetChatSessionProvider(sessionId, providerKey) 持久化（乐观更新，失败回滚并把
+ *    错误显示在弹层底部）；成功后按响应更新显示并调 onSwitched()（典型是
+ *    reloadSession()，把后端追加的切换 notice 拉进 transcript）。
+ *  - 供应商列表只随 backendType 变化拉取一次（跨会话、同 backend 类型不重复拉取，
+ *    避免在已有会话之间切换 tab 时反复打 ListLLMProviders）；按 isProviderCompatible
+ *    过滤出兼容供应商；未绑 agent（CLI 登录态）同样显示选择器（决策 5）。
  *  - 已绑 agent:未选时 effectiveKey 落到 boundProviderKey,pill 显示绑定供应商名。
+ *  - pill 在任何会话/后端状态下都渲染（决策 10：禁用而非隐藏）：不可选择的 backend
+ *    （openclaw）与「加载成功但无兼容供应商」都是 disabled + tooltip；拉取失败保持
+ *    可用（既有行为，弹层底部报错）。
  */
 export function useProviderPill({
   backendType,
   boundProviderKey,
+  sessionId,
+  persistedProviderKey,
+  onSwitched,
 }: UseProviderPillOptions): UseProviderPillReturn {
   const selectable = isProviderSelectableBackend(backendType);
-  const [providerKey, setProviderKeyState] = React.useState("");
+  const [providerKey, setProviderKeyState] = React.useState(
+    persistedProviderKey ?? "",
+  );
   const [providers, setProviders] = React.useState<
     llm_provider_svc.ProviderItem[]
   >([]);
@@ -120,18 +159,60 @@ export function useProviderPill({
     }
   }, []);
 
+  // 供应商列表只随 backendType 变化重新拉取：与后端类型强绑定，两条同类型的已有
+  // 会话之间切换不重复请求。
   React.useEffect(() => {
     backendTypeRef.current = backendType;
-    // backend 切换（agent 切换）时重置瞬态选择并重拉列表。
-    setProviderKeyState("");
     setError(null);
     void fetchProviders();
   }, [backendType, fetchProviders]);
 
-  const setProviderKey = React.useCallback((key: string) => {
-    setProviderKeyState(key);
-    setError(null);
-  }, []);
+  // 会话切换（sessionId 变化）、agent 切换（backendType 变化，新建会话场景）、或
+  // 持久化选择被外部改写（切换成功回填 / 另一处 reload）时，把显示值同步回 DB 当前
+  // 值：新建会话固定是空串；已有会话取 persistedProviderKey。
+  React.useEffect(() => {
+    setProviderKeyState(persistedProviderKey ?? "");
+  }, [sessionId, backendType, persistedProviderKey]);
+
+  const setProviderKey = React.useCallback(
+    (key: string) => {
+      // 选中的就是当前已生效的那一项：什么都不做，与后端 SetChatSessionProvider
+      // 的同一处幂等 no-op 语义对齐（避免每点一次已选中项就打一次 IPC）。
+      if (key === providerKey) {
+        return;
+      }
+      const previous = providerKey;
+      setProviderKeyState(key);
+      setError(null);
+
+      if (!sessionId || sessionId <= 0) {
+        // 新建会话：纯瞬态，首发 Send 时随 SendRequest.ProviderKey 透传。
+        return;
+      }
+      void SetChatSessionProvider({ sessionId, providerKey: key } as never)
+        .then((resp) => {
+          setProviderKeyState(resp.providerKey);
+          onSwitched?.();
+        })
+        .catch((e: unknown) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          console.error("[provider-pill] switch failed", e);
+          setProviderKeyState(previous);
+          setError(msg);
+        });
+    },
+    [providerKey, sessionId, onSwitched],
+  );
+
+  // disabledReason 优先级：后端不可选 > 加载中（无专属原因，沿用既有行为）>
+  // 加载成功但无兼容供应商。拉取失败时 providers 也是空数组，但不算「无兼容供应商」
+  // ——失败态本身保持可用，靠弹层底部错误行说明（既有行为），不能被这条规则误判禁用。
+  const disabledReason: "unsupportedBackend" | "noCompatibleProviders" | null =
+    !selectable
+      ? "unsupportedBackend"
+      : !loading && !error && providers.length === 0
+        ? "noCompatibleProviders"
+        : null;
 
   return {
     providerKey,
@@ -141,5 +222,7 @@ export function useProviderPill({
     error,
     unbound: !boundProviderKey,
     effectiveKey: providerKey || boundProviderKey || "",
+    disabled: loading || disabledReason !== null,
+    disabledReason,
   };
 }

--- a/frontend/src/components/agentre/transcript-row-view.tsx
+++ b/frontend/src/components/agentre/transcript-row-view.tsx
@@ -702,22 +702,33 @@ function RenderItemView({
       );
     }
     case "notice": {
-      // notice 块:供应商回退 notice 由后端投影成结构化 providerKey(providerFallbackPayload),
-      // 文案走 t();其它来源/旧数据的非结构化 notice 原样渲染 Text。
+      // notice 块:供应商回退/切换 notice 由后端投影成结构化 providerKey + noticeKind
+      // (providerNoticePayload),文案走 t();其它来源/旧数据的非结构化 notice 原样渲染
+      // Text。noticeKind==="switch" 是用户主动切换（决策 9），其余（含旧数据的空
+      // noticeKind）沿用既有的供应商回退提示——两者共用 providerKey 字段，必须靠
+      // noticeKind 而不是「providerKey 是否非空」区分，因为切换回「跟随 agent 绑定」
+      // 时 providerKey 本就是空串。
       const providerKey = item.block.providerKey;
+      const noticeKind = item.block.noticeKind;
+      const content =
+        noticeKind === "switch"
+          ? providerKey
+            ? t("chat.notice.providerSwitch.sentence", {
+                provider: providerKey,
+              })
+            : t("chat.notice.providerSwitch.followAgentBinding")
+          : providerKey
+            ? t("chat.notice.providerFallback.sentence", {
+                provider: providerKey,
+              })
+            : (item.block.text ?? "");
       return (
         <section
           role="status"
           data-testid="transcript-notice"
           className="flex w-full max-w-measure items-start gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-aux text-muted-foreground"
         >
-          <span className="min-w-0 flex-1 break-words">
-            {providerKey
-              ? t("chat.notice.providerFallback.sentence", {
-                  provider: providerKey,
-                })
-              : (item.block.text ?? "")}
-          </span>
+          <span className="min-w-0 flex-1 break-words">{content}</span>
         </section>
       );
     }

--- a/frontend/src/components/agentre/transcript-row-view.tsx
+++ b/frontend/src/components/agentre/transcript-row-view.tsx
@@ -702,24 +702,27 @@ function RenderItemView({
       );
     }
     case "notice": {
-      // notice 块:供应商回退/切换 notice 由后端投影成结构化 providerKey + noticeKind
-      // (providerNoticePayload),文案走 t();其它来源/旧数据的非结构化 notice 原样渲染
-      // Text。noticeKind==="switch" 是用户主动切换（决策 9），其余（含旧数据的空
-      // noticeKind）沿用既有的供应商回退提示——两者共用 providerKey 字段，必须靠
-      // noticeKind 而不是「providerKey 是否非空」区分，因为切换回「跟随 agent 绑定」
-      // 时 providerKey 本就是空串。
+      // notice 块:供应商回退/切换 notice 由后端投影成结构化 providerKey + providerName
+      // + noticeKind (providerNoticePayload),文案走 t();其它来源/旧数据的非结构化
+      // notice 原样渲染 Text。noticeKind==="switch" 是用户主动切换（决策 9），其余
+      // （含旧数据的空 noticeKind）沿用既有的供应商回退提示——两者共用 providerKey /
+      // providerName 字段，必须靠 noticeKind 而不是「providerKey 是否非空」区分，
+      // 因为切换回「跟随 agent 绑定」时 providerKey 本就是空串。
+      // providerName 非空就优先显示它（2026-08-10 显示缺陷修复决策 1/2）,为空
+      // （供应商已删,后端查不到实体）则回退到裸 providerKey,文案本身不变。
       const providerKey = item.block.providerKey;
+      const providerLabel = item.block.providerName || providerKey;
       const noticeKind = item.block.noticeKind;
       const content =
         noticeKind === "switch"
           ? providerKey
             ? t("chat.notice.providerSwitch.sentence", {
-                provider: providerKey,
+                provider: providerLabel,
               })
             : t("chat.notice.providerSwitch.followAgentBinding")
           : providerKey
             ? t("chat.notice.providerFallback.sentence", {
-                provider: providerKey,
+                provider: providerLabel,
               })
             : (item.block.text ?? "");
       return (

--- a/frontend/src/hooks/use-chat-session.test.ts
+++ b/frontend/src/hooks/use-chat-session.test.ts
@@ -134,6 +134,79 @@ describe("useChatSession", () => {
     });
   });
 
+  // 供应商切换 notice 是一条独立的 assistant 消息(只有一个 notice 块),排在在跑的
+  // assistant 之后。轮中切换供应商 → chat-panel reloadSession() → 这条 notice 成了末条
+  // assistant。若"末条 assistant"按行取,overlay 的 pending 审批就落在 notice 那条空
+  // 消息上找不到 → 既没从 messages 剥离也没搬进 liveBlocks → 用户点批准后 resolved
+  // 事件反扫 liveBlocks 落空 → 卡片永远 pending。找的必须是末条**真实** assistant。
+  it("moves overlay pending tool_approval blocks into liveBlocks even when a provider notice trails", async () => {
+    loadChatSession.mockResolvedValueOnce({
+      session: {
+        id: 9,
+        agentId: 1,
+        agentName: "Eng",
+        title: "x",
+        agentStatus: "running",
+        activeStream: "chat:event:9:42",
+        lastMessageAt: 0,
+        createtime: 0,
+      },
+      messages: [
+        { id: 40, sessionId: 9, role: "user", blocks: [], seq: 1 },
+        {
+          id: 42,
+          sessionId: 9,
+          role: "assistant",
+          blocks: [
+            { type: "text", text: "creating department..." },
+            {
+              type: "tool_approval",
+              toolApproval: {
+                requestId: "org-1",
+                toolName: "org_create_department",
+                toolInput: { name: "研发部" },
+                status: "pending",
+              },
+            },
+          ],
+          seq: 2,
+        },
+        {
+          id: 43,
+          sessionId: 9,
+          role: "assistant",
+          blocks: [
+            {
+              type: "notice",
+              level: "info",
+              noticeKind: "switch",
+              providerKey: "session-key",
+              providerName: "中转 · GLM 5.2",
+            },
+          ],
+          seq: 3,
+        },
+      ],
+    });
+    const { result } = renderHook(() => useChatSession(9));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // ① pending 块从真正持有它的那条消息(42)上剥离,notice 那条不受影响。
+    const owner = result.current.messages.find((m) => m.id === 42)!;
+    expect((owner.blocks ?? []).some((b) => b.type === "tool_approval")).toBe(
+      false,
+    );
+    expect((owner.blocks ?? []).some((b) => b.type === "text")).toBe(true);
+
+    // ② 搬进的是 42 的 liveBlocks —— resolved 事件按 assistantMessageId 反扫才命中。
+    const live = streamForMessage(useChatStreamsStore.getState(), 9, 42);
+    expect(live?.liveBlocks).toHaveLength(1);
+    expect(live?.liveBlocks[0]).toMatchObject({
+      type: "tool_approval",
+      toolApproval: { requestId: "org-1", status: "pending" },
+    });
+  });
+
   // 已决议(resolved)的 tool_approval 块是持久化历史,留在 messages 路径,不搬不剥。
   it("leaves resolved tool_approval blocks in messages untouched on reattach", async () => {
     loadChatSession.mockResolvedValueOnce({

--- a/frontend/src/hooks/use-chat-session.test.ts
+++ b/frontend/src/hooks/use-chat-session.test.ts
@@ -58,6 +58,43 @@ describe("useChatSession", () => {
     expect(live?.assistantMessageId).toBe(42);
   });
 
+  // 「块全是 notice」不足以判定旁白行:回退 notice 是后端追加进**这一轮自己**的
+  // assistant 消息(chat_svc runTurn finalize),零内容收尾时那条消息的块正好只剩它。
+  // 判据必须是「独立落库的切换 notice」(noticeKind==="switch"),与后端
+  // chat.go noticeOnlyMessage 同一口径 —— 否则这一轮被当旁白行跳过,压根不 openStream,
+  // 用户看不到任何流式内容。
+  it("reattaches to a turn whose only block is a provider fallback notice", async () => {
+    loadChatSession.mockResolvedValueOnce({
+      session: {
+        id: 9,
+        agentId: 1,
+        agentName: "Eng",
+        title: "x",
+        agentStatus: "running",
+        activeStream: "chat:event:9:41",
+        lastMessageAt: 0,
+        createtime: 0,
+      },
+      messages: [
+        { id: 40, sessionId: 9, role: "user", blocks: [], seq: 1 },
+        {
+          id: 41,
+          sessionId: 9,
+          role: "assistant",
+          blocks: [
+            { type: "notice", level: "info", providerKey: "gone-provider" },
+          ],
+          seq: 2,
+        },
+      ],
+    });
+    const { result } = renderHook(() => useChatSession(9));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const live = streamForMessage(useChatStreamsStore.getState(), 9, 41);
+    expect(live?.assistantMessageId).toBe(41);
+  });
+
   // Bug: 中途重开运行中的会话时,pending tool_approval 卡来自 LoadSession overlay
   // (后端把内存 pending 块 overlay 进末条 assistant 消息投影 → 渲染走 messages 路径)。
   // 用户点批准/拒绝后 resolved 事件只反扫 liveBlocks → no-op → 卡片永远 pending。

--- a/frontend/src/hooks/use-chat-session.ts
+++ b/frontend/src/hooks/use-chat-session.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { LoadChatSession } from "../../wailsjs/go/app/App";
 import type { chat_svc } from "../../wailsjs/go/models";
 import { clientLog } from "@/lib/client-log";
+import { isNoticeOnlyMessage } from "@/lib/notice-message";
 import {
   hasSessionStream,
   primaryStream,
@@ -130,8 +131,13 @@ export function useChatSession(sessionId: number) {
       // (末条)assistant 消息,StreamDone 经既有路径收口并 reload 回填最终内容。
       if (resp.session.activeStream) {
         const streamsStore = useChatStreamsStore.getState();
+        // 找末条**真实** assistant:只承载 notice 的旁白行(供应商切换 notice)跳过 ——
+        // 它排在在跑的 assistant 之后,若被当成末条 assistant,overlay 的 pending 审批
+        // 就落在这条没有块的旁白行上找不到,既没从 messages 剥离也没搬进 liveBlocks,
+        // 用户点批准后 resolved 事件反扫 liveBlocks 落空 → 卡片永远 pending。
         let lastAssistantIdx = -1;
         for (let i = loadedMessages.length - 1; i >= 0; i--) {
+          if (isNoticeOnlyMessage(loadedMessages[i])) continue;
           if (loadedMessages[i].role === "assistant") {
             lastAssistantIdx = i;
             break;

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -575,6 +575,10 @@
     "notice": {
       "providerFallback": {
         "sentence": "Selected provider {{provider}} is unavailable; fell back to the agent binding"
+      },
+      "providerSwitch": {
+        "followAgentBinding": "Switched back to follow the agent binding / CLI login state from here",
+        "sentence": "Switched to provider {{provider}} from here"
       }
     },
     "meta": {
@@ -2295,11 +2299,14 @@
   "providerPill": {
     "active": "Active",
     "aria": "Provider: {{provider}}",
+    "disabledNoCompatibleProviders": "No available provider matches this backend type",
+    "disabledUnsupportedBackend": "This backend does not use agentre providers",
     "errorFetch": "Failed to load providers. Please try again.",
     "followAgentBinding": "Follow agent binding",
     "followAgentBindingDesc": "Use the provider default bound to this agent",
     "followAgentBindingUnboundDesc": "Leave unselected; use the CLI login state",
     "heading": "Provider",
+    "switchNote": "Switching takes effect from the next turn; the turn in progress is unaffected",
     "title": "Select provider · current {{provider}}",
     "unselected": "Select provider"
   },

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -575,6 +575,10 @@
     "notice": {
       "providerFallback": {
         "sentence": "所选供应商 {{provider}} 不可用，已回退 agent 绑定"
+      },
+      "providerSwitch": {
+        "followAgentBinding": "自此改回跟随 agent 绑定 / CLI 登录态",
+        "sentence": "自此改用供应商 {{provider}}"
       }
     },
     "meta": {
@@ -2295,11 +2299,14 @@
   "providerPill": {
     "active": "生效中",
     "aria": "供应商：{{provider}}",
+    "disabledNoCompatibleProviders": "没有与该后端类型匹配的可用供应商",
+    "disabledUnsupportedBackend": "该后端不使用 agentre 供应商",
     "errorFetch": "供应商列表加载失败，请稍后重试",
     "followAgentBinding": "跟随 agent 绑定",
     "followAgentBindingDesc": "使用 agent 绑定的供应商默认模型",
     "followAgentBindingUnboundDesc": "不选，走 CLI 登录态",
     "heading": "供应商",
+    "switchNote": "切换自下一轮生效，正在进行的回合不受影响",
     "title": "选择供应商 · 当前 {{provider}}",
     "unselected": "选择供应商"
   },

--- a/frontend/src/lib/notice-message.ts
+++ b/frontend/src/lib/notice-message.ts
@@ -1,9 +1,9 @@
 import type { chat_svc } from "../../wailsjs/go/models";
 
 /**
- * isNoticeOnlyMessage 判断一条消息是不是「只承载 notice 的旁白行」。
+ * isNoticeOnlyMessage 判断一条消息是不是「只承载供应商切换 notice 的旁白行」。
  *
- * 供应商切换 notice 是独立落库的一条消息(session_provider.go 的
+ * 切换 notice 是独立落库的一条消息(session_provider.go 的
  * appendProviderSwitchNotice):role 是 assistant、块只有一个 notice,但它不是一轮
  * 对话 —— 它可以在任意时刻插进 transcript(pill 允许轮中切换,切完 chat-panel 立刻
  * reloadSession 把它拉进来),包括插在在跑的 assistant 之后。
@@ -12,10 +12,18 @@ import type { chat_svc } from "../../wailsjs/go/models";
  * 顶替真正那一条:自主续轮横幅错判、生成指示器跳到旁白行、LoadSession 的 pending
  * 审批 overlay 搬不到在跑的那条消息上(卡片永远 pending)。
  *
+ * 判据是 noticeKind==="switch",而不是「块全是 notice」:回退 notice 由后端追加进
+ * **这一轮自己**的 assistant 消息(chat_svc runTurn finalize),零内容收尾时那条消息
+ * 的块正好只剩它 —— 按「块全是 notice」判,一轮真实对话就会被当成旁白行跳过。
+ * 与后端 chat.go 的 noticeOnlyMessage 同一口径,两边必须同时改。
+ *
  * 没有块 ≠ 旁白行:轮刚起时 assistant 行的 blocks 恒为 "[]",那是真实的一轮,
  * 判定必须认到它(横幅/指示器就该在那一刻出现)。
  */
 export function isNoticeOnlyMessage(m: chat_svc.ChatMessage): boolean {
   const blocks = m.blocks ?? [];
-  return blocks.length > 0 && blocks.every((b) => b.type === "notice");
+  return (
+    blocks.length > 0 &&
+    blocks.every((b) => b.type === "notice" && b.noticeKind === "switch")
+  );
 }

--- a/frontend/src/lib/notice-message.ts
+++ b/frontend/src/lib/notice-message.ts
@@ -1,0 +1,21 @@
+import type { chat_svc } from "../../wailsjs/go/models";
+
+/**
+ * isNoticeOnlyMessage 判断一条消息是不是「只承载 notice 的旁白行」。
+ *
+ * 供应商切换 notice 是独立落库的一条消息(session_provider.go 的
+ * appendProviderSwitchNotice):role 是 assistant、块只有一个 notice,但它不是一轮
+ * 对话 —— 它可以在任意时刻插进 transcript(pill 允许轮中切换,切完 chat-panel 立刻
+ * reloadSession 把它拉进来),包括插在在跑的 assistant 之后。
+ *
+ * 所以凡是「找紧邻的前一条 / 末条**真实** assistant」的推导都必须跳过它,否则它会
+ * 顶替真正那一条:自主续轮横幅错判、生成指示器跳到旁白行、LoadSession 的 pending
+ * 审批 overlay 搬不到在跑的那条消息上(卡片永远 pending)。
+ *
+ * 没有块 ≠ 旁白行:轮刚起时 assistant 行的 blocks 恒为 "[]",那是真实的一轮,
+ * 判定必须认到它(横幅/指示器就该在那一刻出现)。
+ */
+export function isNoticeOnlyMessage(m: chat_svc.ChatMessage): boolean {
+  const blocks = m.blocks ?? [];
+  return blocks.length > 0 && blocks.every((b) => b.type === "notice");
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -129,6 +129,13 @@ func (a *App) SetChatPermissionMode(req *chat_svc.SetPermissionModeRequest) (*ch
 	return chat_svc.Chat().SetPermissionMode(a.ctx, req)
 }
 
+// SetChatSessionProvider 切换已有会话的 LLM 供应商（providerKey 空串 = 跟随 agent
+// 绑定，CLI 后端即回到自身登录态）。自下一轮生效，不打断正在进行的轮；所选供应商
+// 缺失 / 停用 / 与后端类型不兼容时拒绝写入并报错，会话保持原供应商。
+func (a *App) SetChatSessionProvider(req *chat_svc.SetSessionProviderRequest) (*chat_svc.SetSessionProviderResponse, error) {
+	return chat_svc.Chat().SetChatSessionProvider(a.ctx, req)
+}
+
 // RegenerateChatMessage 截掉指定 assistant 消息之前的 user 锚点后，用同一段
 // user 文本重新走一遍 turn。Step 1：仅 builtin 后端实际工作；CLI 后端在 runner
 // 接入 Rewinder 之前返回 ChatRegenerateUnsupported。

--- a/internal/daemon/handlers/mock_handlers/mock_ports.go
+++ b/internal/daemon/handlers/mock_handlers/mock_ports.go
@@ -459,6 +459,21 @@ func (mr *MockGatewayPortMockRecorder) IssueToken(ctx, b, ttl any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueToken", reflect.TypeOf((*MockGatewayPort)(nil).IssueToken), ctx, b, ttl)
 }
 
+// IssueTokenFor mocks base method.
+func (m *MockGatewayPort) IssueTokenFor(ctx context.Context, b *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IssueTokenFor", ctx, b, providerKey, ttl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IssueTokenFor indicates an expected call of IssueTokenFor.
+func (mr *MockGatewayPortMockRecorder) IssueTokenFor(ctx, b, providerKey, ttl any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueTokenFor", reflect.TypeOf((*MockGatewayPort)(nil).IssueTokenFor), ctx, b, providerKey, ttl)
+}
+
 // RevokeToken mocks base method.
 func (m *MockGatewayPort) RevokeToken(token string) {
 	m.ctrl.T.Helper()
@@ -469,6 +484,21 @@ func (m *MockGatewayPort) RevokeToken(token string) {
 func (mr *MockGatewayPortMockRecorder) RevokeToken(token any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockGatewayPort)(nil).RevokeToken), token)
+}
+
+// SetTokenProvider mocks base method.
+func (m *MockGatewayPort) SetTokenProvider(token, providerKey string) (string, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTokenProvider", token, providerKey)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// SetTokenProvider indicates an expected call of SetTokenProvider.
+func (mr *MockGatewayPortMockRecorder) SetTokenProvider(token, providerKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTokenProvider", reflect.TypeOf((*MockGatewayPort)(nil).SetTokenProvider), token, providerKey)
 }
 
 // URL mocks base method.

--- a/internal/daemon/handlers/ports.go
+++ b/internal/daemon/handlers/ports.go
@@ -146,9 +146,18 @@ type JournalReaderPort interface {
 // GatewayPort daemon-side LLM gateway 端口：给 CLI 子进程签短 token、查 URL、回收 token。
 // 当前由 cli.* handler 使用；chat.* 走 Runner 内部直拿 *httpgateway.Gateway 没经此端口。
 // 具体实现 *httpgateway.Gateway 自然满足本接口（方法签名一致）。
+//
+// IssueTokenFor / SetTokenProvider 是会话级供应商切换用的两件（spec 决策 3/12）：
+// 按 wire 传来的 effective provider 签发、以及在**不换 token 字符串**的前提下改既有
+// token 的路由目标 —— token 首轮就烤进 daemon 本机 spawn 的 CLI 子进程 env，重签会让
+// 它立刻 401。
 type GatewayPort interface {
 	URL() string
 	IssueToken(ctx context.Context, b *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error)
+	IssueTokenFor(
+		ctx context.Context, b *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration,
+	) (string, error)
+	SetTokenProvider(token, providerKey string) (previous string, ok bool)
 	RevokeToken(token string)
 }
 

--- a/internal/daemon/handlers/runtime.go
+++ b/internal/daemon/handlers/runtime.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	"github.com/cago-frame/agents/agent/blocks"
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
 
 	"github.com/agentre-ai/agentre/internal/daemon/rpc"
 	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
@@ -381,7 +383,9 @@ func (h *RuntimeHandlers) Run(ctx context.Context, p wire.RunParams) (wire.RunAc
 		// 会话级常驻 token:首轮签、后续轮复用同一个,**不在轮末撤销**(见
 		// sessionTokens 注释)。decode/Run 失败也不撤销 —— token 留着给下一轮重试复用,
 		// 没用上的也只是随 daemon 退出释放(有界)。
-		gatewayURL, gatewayToken, terr = h.ensureSessionToken(ctx, em.rid, &be)
+		// 按解析出来的 provider 路由,而不是 be.LLMProviderKey:桌面端中途换了供应商时,
+		// 下一轮 wire 带的是新的 effective key,这条常驻 token 的上游要跟着变(决策 3/12)。
+		gatewayURL, gatewayToken, terr = h.ensureSessionToken(ctx, em.rid, &be, provider.ProviderKey)
 		if terr != nil {
 			return wire.RunAck{}, terr
 		}
@@ -1427,7 +1431,13 @@ func (h *RuntimeHandlers) resolveSession(sid int64) (agentruntime.Runtime, error
 // env,子进程跨轮复用时 env 不重建,所以必须整段会话稳定且永不过期 —— 否则下一轮
 // 复用的子进程手里的 token 失效,PostToolUse hook 撞 401、SteerInbox drain 不到。
 // Gateway 不可用 / URL 为空时返回空串,调用方按"不签"处理。
-func (h *RuntimeHandlers) ensureSessionToken(ctx context.Context, sid int64, be *agent_backend_entity.AgentBackend) (string, string, error) {
+//
+// providerKey 是本轮解析出来的供应商(wire 的 effectiveProviderKey 自解、必要时已回退):
+// 首轮按它签发,之后每轮把既有 token 的路由目标对齐到它 —— 桌面端换供应商后,同一个
+// token 字符串继续有效,只是上游变了(决策 3/12)。
+func (h *RuntimeHandlers) ensureSessionToken(
+	ctx context.Context, sid int64, be *agent_backend_entity.AgentBackend, providerKey string,
+) (string, string, error) {
 	if h.deps.Gateway == nil {
 		return "", "", nil
 	}
@@ -1437,10 +1447,12 @@ func (h *RuntimeHandlers) ensureSessionToken(ctx context.Context, sid int64, be 
 	}
 	if sid > 0 {
 		if v, ok := h.sessionTokens.Load(sid); ok {
-			return url, v.(string), nil
+			tok := v.(string)
+			h.routeSessionToken(ctx, sid, tok, providerKey)
+			return url, tok, nil
 		}
 	}
-	tok, err := h.deps.Gateway.IssueToken(ctx, be, 0)
+	tok, err := h.deps.Gateway.IssueTokenFor(ctx, be, providerKey, 0)
 	if err != nil {
 		return "", "", fmt.Errorf("gateway token: %w", err)
 	}
@@ -1452,6 +1464,25 @@ func (h *RuntimeHandlers) ensureSessionToken(ctx context.Context, sid int64, be 
 		}
 	}
 	return url, tok, nil
+}
+
+// routeSessionToken 把会话常驻 token 的路由目标对齐到本轮的供应商;token 字符串不变,
+// 已烤进子进程 env 的那份继续可用。真的换了才记一条日志;找不到 entry = gateway 重启过
+// (token 表只在内存里),子进程手里那个也已失效,记 warn 供排查。
+func (h *RuntimeHandlers) routeSessionToken(ctx context.Context, sid int64, token, providerKey string) {
+	previous, ok := h.deps.Gateway.SetTokenProvider(token, providerKey)
+	if !ok {
+		logger.Ctx(ctx).Warn("handlers.routeSessionToken: session token missing from gateway",
+			zap.Int64("sessionId", sid),
+			zap.String("providerKey", providerKey))
+		return
+	}
+	if previous != providerKey {
+		logger.Ctx(ctx).Info("handlers.routeSessionToken: gateway token rerouted to new provider",
+			zap.Int64("sessionId", sid),
+			zap.String("previousProviderKey", previous),
+			zap.String("providerKey", providerKey))
+	}
 }
 
 func (h *RuntimeHandlers) lookupSession(sid int64) *runtimeSession {

--- a/internal/daemon/handlers/runtime_test.go
+++ b/internal/daemon/handlers/runtime_test.go
@@ -1290,7 +1290,9 @@ func TestRuntime_Run_WithProvider_ReusesPermanentTokenAcrossTurns(t *testing.T) 
 	gw.EXPECT().URL().Return("http://gw").AnyTimes()
 	// ttl=0 (permanent), minted exactly once; NO RevokeToken EXPECT → gomock
 	// fails if anything revokes it (e.g. a leftover turn-end revoke).
-	gw.EXPECT().IssueToken(ctx, gomock.Any(), time.Duration(0)).Return("sess-token", nil).Times(1)
+	gw.EXPECT().IssueTokenFor(ctx, gomock.Any(), "pk", time.Duration(0)).Return("sess-token", nil).Times(1)
+	// 后续轮只把既有 token 的路由目标对齐到同一家（没换供应商 → 原地不动）。
+	gw.EXPECT().SetTokenProvider("sess-token", "pk").Return("pk", true).Times(1)
 
 	runOnce := func() {
 		_, err := h.Run(ctx, wire.RunParams{Backend: backendJSON(t, be), SessionID: 42, UserText: "hi"})
@@ -1307,6 +1309,57 @@ func TestRuntime_Run_WithProvider_ReusesPermanentTokenAcrossTurns(t *testing.T) 
 	require.Len(t, rt.runReqs, 2)
 	assert.Equal(t, "sess-token", rt.runReqs[0].req.GatewayToken)
 	assert.Equal(t, "sess-token", rt.runReqs[1].req.GatewayToken, "turn 2 must reuse the same permanent token")
+}
+
+// TestRuntime_Run_SessionTokenFollowsEffectiveProvider 钉死决策 3 + 12 的 daemon 侧：
+// daemon 自家网关的会话常驻 token 同样按 effective provider 签发；桌面端中途换了供应商
+// （下一轮 wire 带新的 effectiveProviderKey）时，只改这条既有 token 的路由目标 ——
+// token 字符串必须不变（它已烤进 daemon 本机 spawn 的 CLI 子进程 env）。
+func TestRuntime_Run_SessionTokenFollowsEffectiveProvider(t *testing.T) {
+	rt := &fullRT{}
+	rt.runFn = func(_ context.Context) (<-chan agentruntime.Event, *agentruntime.RunResult, error) {
+		ch := make(chan agentruntime.Event, 1)
+		ch <- agentruntime.Done{}
+		close(ch)
+		return ch, &agentruntime.RunResult{ProviderSessionID: "psid"}, nil
+	}
+	ctx, _, gw, lookup, h := setupRuntimeTest(t, rt)
+	be := agent_backend_entity.AgentBackend{
+		ID:             3,
+		Type:           string(agent_backend_entity.TypeClaudeCode),
+		LLMProviderKey: "agent-bound-key",
+	}
+	activeProvider := func(key string) *llm_provider_entity.LLMProvider {
+		return &llm_provider_entity.LLMProvider{
+			ProviderKey: key, Type: string(llm_provider_entity.TypeAnthropic), Model: "claude-x",
+			Status: consts.ACTIVE,
+		}
+	}
+	lookup.EXPECT().FindByKey(ctx, "first-key").Return(activeProvider("first-key"), nil)
+	lookup.EXPECT().FindByKey(ctx, "switched-key").Return(activeProvider("switched-key"), nil)
+	gw.EXPECT().URL().Return("http://gw").AnyTimes()
+	// 首轮按 effective key 签一个永久 token；换供应商后**不得**再签第二个。
+	gw.EXPECT().IssueTokenFor(ctx, gomock.Any(), "first-key", time.Duration(0)).
+		Return("sess-token", nil).Times(1)
+	gw.EXPECT().SetTokenProvider("sess-token", "switched-key").Return("first-key", true).Times(1)
+
+	runOnce := func(providerKey string) {
+		_, err := h.Run(ctx, wire.RunParams{
+			Backend: backendJSON(t, be), SessionID: 42, UserText: "hi", LLMProviderKey: providerKey,
+		})
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, serr := h.Steer(ctx, wire.SteerParams{SessionID: 42, Text: "x"})
+			assert.ErrorIs(c, serr, agentruntime.ErrNoActiveTurn)
+		}, time.Second, 10*time.Millisecond)
+	}
+	runOnce("first-key")
+	runOnce("switched-key")
+
+	require.Len(t, rt.runReqs, 2)
+	assert.Equal(t, "sess-token", rt.runReqs[0].req.GatewayToken)
+	assert.Equal(t, "sess-token", rt.runReqs[1].req.GatewayToken, "换供应商不换 token 字符串")
+	assert.Equal(t, "switched-key", rt.runReqs[1].req.Provider.ProviderKey)
 }
 
 func TestRuntime_Run_StopErrAborted_RehydratesCode(t *testing.T) {

--- a/internal/model/entity/chat_entity/session.go
+++ b/internal/model/entity/chat_entity/session.go
@@ -71,8 +71,9 @@ type Session struct {
 	PermissionModeAtLaunch string `gorm:"column:permission_mode_at_launch;type:text;not null;default:''"`
 	// ProviderKey 是会话级 LLM 供应商 key（chat_sessions.provider_key）。
 	// 空串 = 跟随 agent 绑定：每轮由 chat_svc 从 be.LLMProviderKey → prov.Model 解析。
-	// 非空时在解析 prov 时优先于 agent 绑定（spec 决策 2/3）。仅新建会话随首条消息落库，
-	// 不可事后修改；所指向供应商缺失/停用时回退 agent 绑定并追加持久 notice（决策 8）。
+	// 非空时在解析 prov 时优先于 agent 绑定（spec 决策 2/3）。新建会话随首条消息落库，
+	// 此后可由 chat_svc.SetChatSessionProvider 单列改写（2026-08-10 决策 1，自下一轮
+	// 生效）；所指向供应商缺失/停用时回退 agent 绑定并追加持久 notice（决策 8）。
 	ProviderKey string `gorm:"column:provider_key;type:text;not null;default:''"`
 	// ExecDeviceID 执行该会话的配对 daemon(paired_agentreds.id)。0 = 本机执行 ——
 	// 也是老数据的默认值，语义与远端执行落地前完全一致。

--- a/internal/pkg/agentruntime/clienv.go
+++ b/internal/pkg/agentruntime/clienv.go
@@ -18,6 +18,21 @@ const (
 type CLIDeps struct {
 	Token      string
 	GatewayURL string
+	// ProviderKey 是本轮 effective provider 的 key（RunRequest.EffectiveProviderKey()
+	// 的同源值：会话 provider_key 覆盖 agent 绑定、经缺失/停用回退后的那家）。空串 =
+	// 调用方没有会话级覆盖信息可报（见下）。
+	//
+	// 只用于 claudecode 的 ANTHROPIC_BASE_URL/AUTH_TOKEN 门控（spec 2026-08-10 决策 6）：
+	// Token/GatewayURL 是否非空只代表「hook 子进程能不能访问 /hook/v1/inbox」——
+	// Claude Code 无论是否绑 provider 都会拿到它俩（PostToolUse hook 需要），不能拿它俩
+	// 当「这一轮要不要把 LLM 流量指向网关」的信号，必须单独看 ProviderKey。
+	//
+	// BuildClaudeCodeEnv 在 ProviderKey 为空时回落 backend.LLMProviderKey：会话级
+	// turn 路径总是显式传 ProviderKey（req.EffectiveProviderKey()，已含 backend 回落，
+	// 决策 2 的唯一口径）；连通性探测类调用点（daemon cli.probe、agent_backend_svc
+	// 的 Test）没有会话概念，只按 backend 自身绑定探测，继续只传 Token/GatewayURL 即可，
+	// 不必每处都重复解析一遍 effective provider。
+	ProviderKey string
 }
 
 // BuildClaudeCodeEnv 装配 claudecode 子进程的环境变量：
@@ -27,10 +42,12 @@ type CLIDeps struct {
 //     /hook/v1/inbox 拉排队消息。不走 ANTHROPIC_*，避免被 claude CLI 当成「替
 //     OAuth 把 LLM 路由到 gateway」的开关（CLI 登录模式下我们没 provider 转
 //     发，会直接挂 LLM）。
-//   - **ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN**：只在 backend 真的绑了 LLM
-//     provider 时设——这种情况下确实希望 claude CLI 把 LLM 请求路由到 gateway，
-//     gateway 按 model_routes 转发到对应 provider。CLI 登录模式留空，让 claude
-//     自身 OAuth 直连 anthropic.com。
+//   - **ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN**：只在本轮有 effective provider 时设
+//     ——deps.ProviderKey 非空（会话 provider_key 覆盖 agent 绑定后的那家）或
+//     b.LLMProviderKey 非空（未传 ProviderKey 的探测类调用点，回落 backend 自身绑定），
+//     二者皆空才是真正的 CLI 登录态。有 effective provider 时确实希望 claude CLI 把
+//     LLM 请求路由到 gateway，gateway 按 model_routes 转发到对应 provider；CLI 登录
+//     模式留空，让 claude 自身 OAuth 直连 anthropic.com。
 //   - 用户自定义 env_json 追加（保留键已被 entity.Check 拒入）；
 //   - 如果 backend.model_routes 含 OPUS/SONNET/HAIKU，注入 ANTHROPIC_DEFAULT_*_MODEL = alias 字符串
 //     （上游识别 alias，gateway 按 alias 路由到对应 provider 后再改写成真实 model id）。
@@ -47,8 +64,10 @@ func BuildClaudeCodeEnv(b *agent_backend_entity.AgentBackend, deps CLIDeps) (map
 		// hook 子进程总能拿到这两个，无论是否 CLI 登录模式。
 		env["AGENTRE_GATEWAY_URL"] = deps.GatewayURL
 		env["AGENTRE_GATEWAY_TOKEN"] = deps.Token
-		// 只有当 backend 绑了 LLM provider 时才让 claude CLI 走 gateway 做 LLM 转发。
-		if b != nil && b.LLMProviderKey != "" {
+		// 只有当本轮有 effective provider 时才让 claude CLI 走 gateway 做 LLM 转发
+		// （决策 6）：deps.ProviderKey 优先（backend 未绑定但会话选了 agentre 供应商时
+		// 也要生效），未传时回落 b.LLMProviderKey，保持无会话概念的探测类调用点行为不变。
+		if strings.TrimSpace(deps.ProviderKey) != "" || (b != nil && strings.TrimSpace(b.LLMProviderKey) != "") {
 			env["ANTHROPIC_BASE_URL"] = deps.GatewayURL
 			env["ANTHROPIC_AUTH_TOKEN"] = deps.Token
 		}

--- a/internal/pkg/agentruntime/clienv_test.go
+++ b/internal/pkg/agentruntime/clienv_test.go
@@ -12,9 +12,9 @@ import (
 // 仅做最小契约测试 — 详细分支已由 agent_backend_svc/prober_test.go 间接覆盖。
 // 这里挡的是包级位置漂移：函数搬到 agentruntime 后仍按预期工作。
 func TestBuildClaudeCodeEnv_Basic(t *testing.T) {
-	t.Run("有 gateway + LLM provider 时同时注入 ANTHROPIC_* 和 AGENTRE_GATEWAY_*", func(t *testing.T) {
+	t.Run("有 gateway + effective provider 时同时注入 ANTHROPIC_* 和 AGENTRE_GATEWAY_*", func(t *testing.T) {
 		b := &agent_backend_entity.AgentBackend{LLMProviderKey: "key-7", ModelRoutes: `{"SONNET":"key-1"}`, EnvJSON: `{"X":"y"}`}
-		env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok", GatewayURL: "http://127.0.0.1:60080"})
+		env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok", GatewayURL: "http://127.0.0.1:60080", ProviderKey: "key-7"})
 		require.NoError(t, err)
 		assert.Equal(t, "http://127.0.0.1:60080", env["ANTHROPIC_BASE_URL"])
 		assert.Equal(t, "tok", env["ANTHROPIC_AUTH_TOKEN"])
@@ -25,7 +25,7 @@ func TestBuildClaudeCodeEnv_Basic(t *testing.T) {
 		_, hasKey := env["ANTHROPIC_API_KEY"]
 		assert.False(t, hasKey, "不写 ANTHROPIC_API_KEY")
 	})
-	t.Run(`CLI 登录模式（LLMProviderKey==""）：只注入 AGENTRE_GATEWAY_*，不动 ANTHROPIC_*`, func(t *testing.T) {
+	t.Run(`CLI 登录模式（deps.ProviderKey==""）：只注入 AGENTRE_GATEWAY_*，不动 ANTHROPIC_*`, func(t *testing.T) {
 		// 这是修复「mid-turn chip 不消除」的核心契约：CLI 登录模式下我们
 		// 仍要让 hook 子进程能访问 /hook/v1/inbox，但不能让 claude CLI 用
 		// Bearer 覆盖 OAuth 走 LLM 转发（gateway 没 provider，会直接挂）。
@@ -39,8 +39,29 @@ func TestBuildClaudeCodeEnv_Basic(t *testing.T) {
 		_, hasAuth := env["ANTHROPIC_AUTH_TOKEN"]
 		assert.False(t, hasAuth, "CLI 登录模式不能设 ANTHROPIC_AUTH_TOKEN")
 	})
+	t.Run("backend 未绑定但会话选了 agentre 供应商（deps.ProviderKey 非空）：仍注入 ANTHROPIC_*", func(t *testing.T) {
+		// spec 2026-08-10 决策 6/问题 3：CLI 登录态后端上，会话级 provider_key 也要
+		// 能接管网关路由 —— 门控必须看本轮 effective provider（deps.ProviderKey），
+		// 不能再看 backend 绑定（b.LLMProviderKey）。
+		b := &agent_backend_entity.AgentBackend{LLMProviderKey: ""}
+		env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok", GatewayURL: "http://127.0.0.1:60080", ProviderKey: "session-picked"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://127.0.0.1:60080", env["ANTHROPIC_BASE_URL"], "会话选了供应商就该走网关,即便 backend 未绑定")
+		assert.Equal(t, "tok", env["ANTHROPIC_AUTH_TOKEN"])
+	})
+	t.Run("backend 绑定了供应商但调用方未传 deps.ProviderKey（探测类调用点）：回落 backend 绑定注入 ANTHROPIC_*", func(t *testing.T) {
+		// daemon cli.probe / agent_backend_svc 的连通性 Test 没有会话 / session_provider
+		// 覆盖概念，只按 backend 自身绑定探测，历来直接传 CLIDeps{Token,GatewayURL}、
+		// 不填 ProviderKey —— 门控必须回落 b.LLMProviderKey，否则这两个既有调用点会
+		// 静默停止走网关（回归成探测 CLI 自身登录态而非目标 provider）。
+		b := &agent_backend_entity.AgentBackend{LLMProviderKey: "key-7"}
+		env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok", GatewayURL: "http://127.0.0.1:60080"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://127.0.0.1:60080", env["ANTHROPIC_BASE_URL"])
+		assert.Equal(t, "tok", env["ANTHROPIC_AUTH_TOKEN"])
+	})
 	t.Run("无 gateway 时既不写 ANTHROPIC_* 也不写 AGENTRE_GATEWAY_*", func(t *testing.T) {
-		env, err := BuildClaudeCodeEnv(&agent_backend_entity.AgentBackend{LLMProviderKey: "key-1"}, CLIDeps{})
+		env, err := BuildClaudeCodeEnv(&agent_backend_entity.AgentBackend{LLMProviderKey: "key-1"}, CLIDeps{ProviderKey: "key-1"})
 		require.NoError(t, err)
 		_, has := env["ANTHROPIC_BASE_URL"]
 		assert.False(t, has)

--- a/internal/pkg/agentruntime/launch_command.go
+++ b/internal/pkg/agentruntime/launch_command.go
@@ -67,9 +67,15 @@ func BuildLaunchCommand(spec LaunchCommandSpec) (string, error) {
 func buildClaudeCodeShellCommand(spec LaunchCommandSpec, cwd string) (string, error) {
 	// 即便 Token 为空，只要 GatewayURL 非空，仍用占位符喂 BuildClaudeCodeEnv，
 	// 让它把 BASE_URL/AUTH_TOKEN 写进 env；真值替换在 assembleShellLine 里做。
+	// ProviderKey 传 spec.Provider 的 key(effective provider，已过回退):backend 未绑定
+	// 但会话选了供应商时，BuildClaudeCodeEnv 的 ANTHROPIC_* 门控只能靠它才知道有
+	// effective provider(spec.Backend.LLMProviderKey 此时为空，回落不到)。
 	deps := CLIDeps{}
 	if spec.GatewayURL != "" {
 		deps = CLIDeps{Token: tokenOrPlaceholder(spec.Token), GatewayURL: spec.GatewayURL}
+		if spec.Provider != nil {
+			deps.ProviderKey = spec.Provider.ProviderKey
+		}
 	}
 	env, err := BuildClaudeCodeEnv(spec.Backend, deps)
 	if err != nil {

--- a/internal/pkg/agentruntime/launch_command_test.go
+++ b/internal/pkg/agentruntime/launch_command_test.go
@@ -34,9 +34,10 @@ func TestBuildLaunchCommand_ClaudeCodeWithTokenAndModel(t *testing.T) {
 			LLMProviderKey: "key-9", // 绑了 provider → 命令里也该带 ANTHROPIC_*
 		},
 		Provider: &llm_provider_entity.LLMProvider{
-			ID:    9,
-			Type:  string(llm_provider_entity.TypeAnthropic),
-			Model: "claude-sonnet-4-6",
+			ID:          9,
+			ProviderKey: "key-9",
+			Type:        string(llm_provider_entity.TypeAnthropic),
+			Model:       "claude-sonnet-4-6",
 		},
 		AgentID:           42,
 		ProviderSessionID: "sess-uuid",
@@ -79,6 +80,7 @@ func TestBuildLaunchCommand_ClaudeCodePlaceholderToken(t *testing.T) {
 			Name:           "cc",
 			LLMProviderKey: "key-1",
 		},
+		Provider:   &llm_provider_entity.LLMProvider{ProviderKey: "key-1"},
 		AgentID:    12,
 		GatewayURL: "http://127.0.0.1:60080",
 	})
@@ -327,6 +329,7 @@ func TestBuildLaunchCommand_ShellEscapes(t *testing.T) {
 			LLMProviderKey: "key-1", // 让 ANTHROPIC_* 入 env，覆盖单引号转义
 			EnvJSON:        `{"WEIRD":"a'b c"}`,
 		},
+		Provider:   &llm_provider_entity.LLMProvider{ProviderKey: "key-1"},
 		AgentID:    11,
 		GatewayURL: "http://127.0.0.1:60080",
 		Token:      "tok",

--- a/internal/pkg/agentruntime/runner.go
+++ b/internal/pkg/agentruntime/runner.go
@@ -448,6 +448,20 @@ type RunRequest struct {
 	LLMProviderKey string
 }
 
+// EffectiveProviderKey 返回本轮 Provider 的 key：Provider==nil（CLI 自身登录态,
+// 无任何 effective provider）返回空串,否则返回 Provider.ProviderKey。
+//
+// 这是 chat_svc.providerKeyOf(prov) 在 runtime 层的同源取值 —— turn 入口已把
+// 「会话 provider_key > agent 绑定」的解析结果（含缺失/停用回退）装进 req.Provider,
+// claudecode / codex 的 CLI env/config 网关门控与 evict 比对键（spec 2026-08-10
+// 决策 4/6）都应读这同一个值,不各自解析一遍导致漂移。
+func (req RunRequest) EffectiveProviderKey() string {
+	if req.Provider == nil {
+		return ""
+	}
+	return req.Provider.ProviderKey
+}
+
 // RunResult 由 runner 在事件流 close 后填充；chat_svc 在 drain 完 channel 后读。
 type RunResult struct {
 	ProviderSessionID string

--- a/internal/pkg/agentruntime/runner_test.go
+++ b/internal/pkg/agentruntime/runner_test.go
@@ -9,8 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/llm_provider_entity"
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/capability"
 )
+
+// TestRunRequest_EffectiveProviderKey 钉死 claudecode/codex 复用的唯一 provider key
+// 取值口径(spec 2026-08-10 决策 4/6 的 interfaces 说明):Provider==nil(CLI 自身登录态)
+// 返回空串,否则返回 Provider.ProviderKey —— env/config 网关门控与 evict 比对键都应读
+// 这同一个值,不各自解析一遍。
+func TestRunRequest_EffectiveProviderKey(t *testing.T) {
+	t.Run("Provider 为 nil 返回空串", func(t *testing.T) {
+		req := RunRequest{}
+		assert.Equal(t, "", req.EffectiveProviderKey())
+	})
+	t.Run("Provider 非 nil 返回其 ProviderKey", func(t *testing.T) {
+		req := RunRequest{Provider: &llm_provider_entity.LLMProvider{ProviderKey: "session-picked"}}
+		assert.Equal(t, "session-picked", req.EffectiveProviderKey())
+	})
+}
 
 type stubRuntime struct{ name string }
 

--- a/internal/pkg/agentruntime/runtimes/claudecode/active.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/active.go
@@ -52,6 +52,12 @@ type claudeActive struct {
 	// DefaultModel)变化时,acquireSession 镜像 launchedEffort 先例强制 evict 重
 	// spawn,否则 LRU 复用的 CLI 子进程一直跑旧模型(镜像 codex 的 modelChanged)。
 	launchedModel string
+	// launchedProviderKey 记录 spawn 时下发给 claude CLI 的 effectiveProviderKey
+	// (RunRequest.EffectiveProviderKey())。ANTHROPIC_BASE_URL/AUTH_TOKEN 同是启动期
+	// env,运行时改不掉;两个不同供应商可以配同一个 model id,只比 launchedModel 会漏掉
+	// 换供应商 —— 下一轮 effectiveProviderKey 变化时同样强制 evict 重 spawn(spec
+	// 2026-08-10 决策 4)。
+	launchedProviderKey string
 
 	// askWaiters 记录当前阻塞中的 AskUserQuestion control_request。
 	askMu      sync.Mutex

--- a/internal/pkg/agentruntime/runtimes/claudecode/env_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/env_test.go
@@ -18,7 +18,7 @@ func TestBuildClaudeCodeEnv_DelegatesToAgentruntime(t *testing.T) {
 		LLMProviderKey: "key-11",
 		ModelRoutes:    `{"OPUS": "key-2"}`,
 	}
-	env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok-abc", GatewayURL: "http://gateway.local"})
+	env, err := BuildClaudeCodeEnv(b, CLIDeps{Token: "tok-abc", GatewayURL: "http://gateway.local", ProviderKey: "key-11"})
 	require.NoError(t, err)
 
 	// 绑 provider + 给 gateway → AUTH_TOKEN + BASE_URL 都出现;

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime.go
@@ -566,6 +566,15 @@ func (r *Runtime) acquireSession(ctx context.Context, req agentruntime.RunReques
 		cur = nil
 	}
 
+	// effectiveProviderKey 同是启动期参数(ANTHROPIC_BASE_URL/AUTH_TOKEN 只在 spawn
+	// 时下发一次):两个不同供应商可以配同一个 model id,只比 launchedModel 会漏掉换
+	// 供应商 —— 会话切换后网关路由虽已改,但复用的旧子进程手里没有指向新供应商的
+	// env,请求仍打旧的(spec 2026-08-10 决策 4)。
+	if cur != nil && cur.launchedProviderKey != req.EffectiveProviderKey() {
+		r.cache.Remove(key)
+		cur = nil
+	}
+
 	if cur != nil {
 		// 复用现有 CLI 子进程:不重新 spawn,因此本轮没有新的 --permission-mode
 		// 下发。回吐当前缓存的 mode 让 chat_svc 写库幂等(值不变即 noop)。
@@ -602,7 +611,9 @@ func (r *Runtime) acquireSession(ctx context.Context, req agentruntime.RunReques
 			return nil, "", err
 		}
 	}
-	env, err := BuildClaudeCodeEnv(req.Backend, CLIDeps{Token: req.GatewayToken, GatewayURL: req.GatewayURL})
+	env, err := BuildClaudeCodeEnv(req.Backend, CLIDeps{
+		Token: req.GatewayToken, GatewayURL: req.GatewayURL, ProviderKey: req.EffectiveProviderKey(),
+	})
 	if err != nil {
 		return nil, "", err
 	}
@@ -641,15 +652,16 @@ func (r *Runtime) acquireSession(ctx context.Context, req agentruntime.RunReques
 		}
 	}
 	cur = &claudeActive{
-		sessionUUID:    inboxKey,
-		handle:         handle,
-		steer:          r.steer,
-		pool:           r.cache,
-		poolKey:        key,
-		launchedEffort: req.Backend.ReasoningEffort,
-		launchedModel:  claudeEffectiveModel(req),
-		permissionMode: runtimeMode,
-		tasks:          newTaskAggregator(),
+		sessionUUID:         inboxKey,
+		handle:              handle,
+		steer:               r.steer,
+		pool:                r.cache,
+		poolKey:             key,
+		launchedEffort:      req.Backend.ReasoningEffort,
+		launchedModel:       claudeEffectiveModel(req),
+		launchedProviderKey: req.EffectiveProviderKey(),
+		permissionMode:      runtimeMode,
+		tasks:               newTaskAggregator(),
 	}
 	if req.SessionID > 0 {
 		r.cache.Put(key, cur)

--- a/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/claudecode/runtime_test.go
@@ -77,6 +77,59 @@ func TestRun_ModelChangeEvictsAndRespawns(t *testing.T) {
 	})
 }
 
+// TestRun_ProviderChangeEvictsAndRespawns 锁住 claudecode 的 evict 比对键扩展
+// （spec 2026-08-10 决策 4）：--model 与 ANTHROPIC_BASE_URL/AUTH_TOKEN 都是启动期
+// 参数，两个不同供应商可以配同一个 model id，只比 model 会漏掉换供应商——必须把
+// effectiveProviderKey 也纳入比对，否则会话切换供应商后 CLI 子进程被 LRU 复用，
+// 请求仍打到旧供应商（网关路由虽已切换，但子进程手里的 ANTHROPIC_BASE_URL 是启动期
+// 烤进去的，运行时改不掉）。
+func TestRun_ProviderChangeEvictsAndRespawns(t *testing.T) {
+	Convey("Given 同一 claudecode 会话两轮 provider.Model 相同但 ProviderKey 不同", t, func() {
+		var spawnCount int32
+		restore := SetSessionFactoryForTest(func(ccLaunchSpec) (ccSessionHandle, error) {
+			atomic.AddInt32(&spawnCount, 1)
+			return &fakeCCHandle{
+				id: "fake-sid",
+				stream: &eventCCStream{events: []claudecode.Event{
+					{Kind: claudecode.EventUsage, Usage: provider.Usage{PromptTokens: 1}},
+					{Kind: claudecode.EventDone},
+				}},
+			}, nil
+		})
+		defer restore()
+
+		r := New()
+		ctx := context.Background()
+		backend := &agent_backend_entity.AgentBackend{
+			Type: string(agent_backend_entity.TypeClaudeCode),
+		}
+		run := func(providerKey string) {
+			events, _, err := r.Run(ctx, agentruntime.RunRequest{
+				Backend:   backend,
+				SessionID: 88,
+				Cwd:       t.TempDir(),
+				UserText:  "hi",
+				Provider:  &llm_provider_entity.LLMProvider{ProviderKey: providerKey, Model: "same-model"},
+			})
+			So(err, ShouldBeNil)
+			for range events { //nolint:revive // drain
+			}
+		}
+
+		Convey("When 同供应商再来一轮, Then 复用不重 spawn", func() {
+			run("provider-a")
+			run("provider-a")
+			So(atomic.LoadInt32(&spawnCount), ShouldEqual, 1)
+		})
+
+		Convey("When ProviderKey 变化但 model 不变, Then evict + 重 spawn", func() {
+			run("provider-a")
+			run("provider-b")
+			So(atomic.LoadInt32(&spawnCount), ShouldEqual, 2)
+		})
+	})
+}
+
 // TestClaudeCodeCapabilities 钉死 claudecode runtime 的能力矩阵 + permission
 // mode 元数据。这些值与 chat_svc / 前端 UI gating 的硬编码 switch 一一对应,
 // 任何一项偏移都意味着 Plan B 切 dispatcher 后会有 UI/dispatch 错乱。

--- a/internal/pkg/agentruntime/runtimes/codex/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/codex/runtime.go
@@ -75,19 +75,29 @@ type Runtime struct {
 	active map[int64]*codexActive
 	pool   *agentruntime.CLISessionPool
 
-	// launchedModel 记录每个 chat 会话(spawn 时)下发的 effectiveModel,
-	// key 与 CLISessionPool 一致(sessionKey)。--model 是启动期 flag(WithModel
-	// 绑定在 Client 创建时),app-server 进程又会被池跨轮复用 —— provider.Model 变了
-	// (换供应商绑定等)必须 evict + 重 spawn(镜像 claudecode 的 launchedEffort 先例),
-	// 否则下一轮复用旧模型进程,新模型不生效(RunResult.Model 仍旧模型)。
+	// launchedModel 记录每个 chat 会话(spawn 时)下发的启动期参数快照
+	// (launchedSpawnKey:effectiveModel + effectiveProviderKey),key 与
+	// CLISessionPool 一致(sessionKey)。--model 与 model_provider/base_url(-c 覆盖项)
+	// 都是启动期 flag(绑定在 Client 创建时),app-server 进程又会被池跨轮复用 ——
+	// provider.Model 或 effectiveProviderKey 任一变化都必须 evict + 重 spawn(镜像
+	// claudecode 的 launchedEffort 先例;决策 4 把比对键从单纯 model 扩展为二者的组合,
+	// 否则两个配同一 model id 的不同供应商换绑定时会漏判,复用旧进程打到旧供应商)。
+	// 否则下一轮复用旧参数进程,新供应商/模型不生效(RunResult.Model 仍旧模型)。
 	//
 	// 池按 LRU 上限(MarkIdle 的 prune)逐出空闲会话时不会回调这里,故条目可能只增不减
 	// (逐出后该 key 再 spawn 会被 recordLaunchedModel 覆盖)。为防长驻进程里 map 随
 	// 会话累积无界增长,recordLaunchedModel 用 FIFO 上限裁剪:被裁掉的 key 若日后回到
-	// 池,modelChanged 只会把它当成「未记录」,最多导致一次无谓重 spawn,绝不产生错误结果。
-	launchedModel map[string]string
+	// 池,spawnKeyChanged 只会把它当成「未记录」,最多导致一次无谓重 spawn,绝不产生错误结果。
+	launchedModel map[string]launchedSpawnKey
 	// launchedModelOrder 是 launchedModel 的 FIFO 插入序,用于容量裁剪。
 	launchedModelOrder []string
+}
+
+// launchedSpawnKey 是 spawn 时下发给 codex CLI 的启动期参数快照,决定 evict 比对
+// (spec 2026-08-10 决策 4)。两个字段任一变化都要求 evict + 重 spawn。
+type launchedSpawnKey struct {
+	model       string
+	providerKey string
 }
 
 // maxTrackedLaunchedModels 是 launchedModel 的上限。池空闲容量 8,同时活跃的 key
@@ -105,29 +115,29 @@ func NewWithPool(pool *agentruntime.CLISessionPool) *Runtime {
 	return &Runtime{
 		active:             map[int64]*codexActive{},
 		pool:               pool,
-		launchedModel:      map[string]string{},
+		launchedModel:      map[string]launchedSpawnKey{},
 		launchedModelOrder: []string{},
 	}
 }
 
-// modelChanged 报告该会话已 spawn 的 effectiveModel 是否与新一轮不同。
-// 新会话(未记录过)视为未变化,正常创建。
-func (r *Runtime) modelChanged(key, effective string) bool {
+// spawnKeyChanged 报告该会话已 spawn 的启动期参数(model + providerKey)是否与新一轮
+// 不同。新会话(未记录过)视为未变化,正常创建。
+func (r *Runtime) spawnKeyChanged(key string, want launchedSpawnKey) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.launchedModel[key] != effective
+	return r.launchedModel[key] != want
 }
 
-// recordLaunchedModel 在 spawn 成功后记录本次下发的 effectiveModel。
+// recordLaunchedModel 在 spawn 成功后记录本次下发的启动期参数快照。
 // 超过 maxTrackedLaunchedModels 时按 FIFO 裁掉最旧条目(池逐出会话不回调本包,
 // 必须在这里兜底防 map 无界增长)。
-func (r *Runtime) recordLaunchedModel(key, effective string) {
+func (r *Runtime) recordLaunchedModel(key string, spawn launchedSpawnKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.launchedModel[key]; !exists {
 		r.launchedModelOrder = append(r.launchedModelOrder, key)
 	}
-	r.launchedModel[key] = effective
+	r.launchedModel[key] = spawn
 	for len(r.launchedModelOrder) > maxTrackedLaunchedModels {
 		oldest := r.launchedModelOrder[0]
 		r.launchedModelOrder = r.launchedModelOrder[1:]
@@ -484,9 +494,11 @@ func (r *Runtime) acquireSession(req agentruntime.RunRequest, env map[string]str
 	if req.SessionID > 0 {
 		key := sessionKey(req.SessionID)
 		if v, ok := r.pool.Get(key); ok {
-			// 模型是启动期 flag:effectiveModel 变化 → evict + 重 spawn(镜像 claudecode
-			// launchedEffort 先例)。模型未变则复用池内 app-server。
-			if r.modelChanged(key, codexEffectiveModel(req)) {
+			// 模型 / effectiveProviderKey 都是启动期参数:任一变化 → evict + 重 spawn
+			// (镜像 claudecode launchedEffort 先例;决策 4)。两者都未变则复用池内
+			// app-server。
+			want := launchedSpawnKey{model: codexEffectiveModel(req), providerKey: req.EffectiveProviderKey()}
+			if r.spawnKeyChanged(key, want) {
 				r.pool.Remove(key)
 				r.forgetLaunchedModel(key)
 			} else {
@@ -503,7 +515,7 @@ func (r *Runtime) acquireSession(req agentruntime.RunRequest, env map[string]str
 		key := sessionKey(req.SessionID)
 		r.pool.Put(key, sess)
 		r.pool.MarkActive(key)
-		r.recordLaunchedModel(key, codexEffectiveModel(req))
+		r.recordLaunchedModel(key, launchedSpawnKey{model: codexEffectiveModel(req), providerKey: req.EffectiveProviderKey()})
 	}
 	return sess, nil
 }
@@ -531,7 +543,7 @@ func (r *Runtime) CloseSession(_ context.Context, sessionID int64) {
 func (r *Runtime) CloseAllSessions(_ context.Context) {
 	r.pool.RemoveAll()
 	r.mu.Lock()
-	r.launchedModel = map[string]string{}
+	r.launchedModel = map[string]launchedSpawnKey{}
 	r.launchedModelOrder = []string{}
 	r.mu.Unlock()
 }

--- a/internal/pkg/agentruntime/runtimes/codex/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/codex/runtime_test.go
@@ -24,14 +24,14 @@ import (
 // CapReportContextWindow=true;PermissionModeMeta 仅 default/plan,SwitchableDuringTurn=false。
 // TestRecordLaunchedModel_Bounded 锁住 launchedModel 的容量裁剪:池按 LRU 上限逐出
 // 空闲会话时不回调本包,若不加上限,map 会随进程内用过的会话数无界增长。裁掉的是
-// 最旧的 key —— 它若日后回池,modelChanged 只会误判一次无谓重 spawn,不产错误结果。
+// 最旧的 key —— 它若日后回池,spawnKeyChanged 只会误判一次无谓重 spawn,不产错误结果。
 func TestRecordLaunchedModel_Bounded(t *testing.T) {
 	Convey("Given 一个 codex runtime", t, func() {
 		r := New()
 
 		Convey("When 记录超过上限的会话数 Then map 被 FIFO 裁剪到上限以内", func() {
 			for i := 0; i < maxTrackedLaunchedModels+64; i++ {
-				r.recordLaunchedModel(fmt.Sprintf("sess-%d", i), "gpt-5.5")
+				r.recordLaunchedModel(fmt.Sprintf("sess-%d", i), launchedSpawnKey{model: "gpt-5.5"})
 			}
 			r.mu.Lock()
 			defer r.mu.Unlock()
@@ -45,8 +45,8 @@ func TestRecordLaunchedModel_Bounded(t *testing.T) {
 		})
 
 		Convey("When forgetLaunchedModel 剔除已记录 key Then map 与 FIFO 序同步删除", func() {
-			r.recordLaunchedModel("a", "m1")
-			r.recordLaunchedModel("b", "m2")
+			r.recordLaunchedModel("a", launchedSpawnKey{model: "m1"})
+			r.recordLaunchedModel("b", launchedSpawnKey{model: "m2"})
 			r.forgetLaunchedModel("a")
 			r.mu.Lock()
 			defer r.mu.Unlock()
@@ -317,6 +317,51 @@ func TestRun_ModelChangeEvictsAndRespawns(t *testing.T) {
 			run("gpt-5.5")
 			second := run("gpt-5.6")
 			So(second.Model, ShouldEqual, "gpt-5.6")
+			So(atomic.LoadInt32(&spawnCount), ShouldEqual, 2)
+		})
+	})
+}
+
+// TestRun_ProviderChangeEvictsAndRespawns 锁住 codex 的 evict 比对键扩展(spec
+// 2026-08-10 决策 4):model_provider/base_url 同是启动期 -c 覆盖项(WithModel 绑定在
+// Client 创建时),两个不同供应商可以配同一个 model id,只比 provider.Model 会漏掉换
+// 供应商 —— 必须把 effectiveProviderKey 也纳入比对,否则会话切换供应商后复用池里的旧
+// app-server 进程,请求仍打旧供应商。
+func TestRun_ProviderChangeEvictsAndRespawns(t *testing.T) {
+	Convey("Given 同一 codex 会话两轮 provider.Model 相同但 ProviderKey 不同", t, func() {
+		var spawnCount int32
+		restore := SetSessionFactoryForTest(func(_ agentruntime.RunRequest, _ map[string]string, _ string) (cxSessionHandle, error) {
+			atomic.AddInt32(&spawnCount, 1)
+			return &fakeRuntimeSession{stream: &emptyRuntimeStream{}, sid: "thread-y", model: "same-model"}, nil
+		})
+		defer restore()
+
+		r := New()
+		run := func(providerKey string) {
+			events, _, err := r.Run(context.Background(), agentruntime.RunRequest{
+				Backend: &agent_backend_entity.AgentBackend{
+					Type:    string(agent_backend_entity.TypeCodex),
+					EnvJSON: "{}",
+				},
+				Provider:  &llm_provider_entity.LLMProvider{ProviderKey: providerKey, Model: "same-model"},
+				SessionID: 78,
+				Cwd:       t.TempDir(),
+				UserText:  "hi",
+			})
+			So(err, ShouldBeNil)
+			for range events {
+			}
+		}
+
+		Convey("When 同供应商再来一轮, Then 复用不重 spawn", func() {
+			run("provider-a")
+			run("provider-a")
+			So(atomic.LoadInt32(&spawnCount), ShouldEqual, 1)
+		})
+
+		Convey("When ProviderKey 变化但 model 不变, Then evict + 重 spawn", func() {
+			run("provider-a")
+			run("provider-b")
 			So(atomic.LoadInt32(&spawnCount), ShouldEqual, 2)
 		})
 	})

--- a/internal/pkg/agentruntime/runtimes/codex/session.go
+++ b/internal/pkg/agentruntime/runtimes/codex/session.go
@@ -338,8 +338,13 @@ type codexLaunchSpec struct {
 	providerSessionID string // codex thread/provider session —— 同上
 }
 
+// gatewayDeps 装配 codex 网关门控(spec 2026-08-10 决策 6):是否给子进程带
+// gateway token/URL 看本轮有没有 effective provider(req.EffectiveProviderKey()，
+// 会话 provider_key 覆盖 agent 绑定后的那家)，不再单看 backend 是否绑定——CLI 登录态
+// 后端(req.Backend.LLMProviderKey=="")上会话选了 agentre 供应商时(req.Provider 非空)
+// 也要装配，否则 chat_svc 签的 token 永远传不到 BuildCodexConfig，登录态无法被接管。
 func gatewayDeps(req agentruntime.RunRequest) CLIDeps {
-	if req.Backend == nil || req.Backend.LLMProviderKey == "" {
+	if req.Backend == nil || req.EffectiveProviderKey() == "" {
 		return CLIDeps{}
 	}
 	return CLIDeps{Token: req.GatewayToken, GatewayURL: req.GatewayURL}

--- a/internal/pkg/agentruntime/runtimes/codex/session_test.go
+++ b/internal/pkg/agentruntime/runtimes/codex/session_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime"
 )
 
+// TestGatewayDeps 锁住 codex 网关门控的唯一口径(spec 2026-08-10 决策 6):是否装配
+// gateway CLIDeps 看本轮有没有 effective provider(req.EffectiveProviderKey()),不再
+// 看 backend 是否绑定(req.Backend.LLMProviderKey)——CLI 登录态后端上会话选了 agentre
+// 供应商时(backend 未绑定但 req.Provider 非空)也要装配,否则 shouldSignChatGateway
+// 签的 token 永远传不到 BuildCodexConfig。
+func TestGatewayDeps(t *testing.T) {
+	Convey("Given backend 未绑定 provider(LLMProviderKey==\"\")", t, func() {
+		backend := &agent_backend_entity.AgentBackend{Type: string(agent_backend_entity.TypeCodex)}
+
+		Convey("When 会话没有 effective provider(req.Provider==nil), Then deps 为空(CLI 登录态不装配)", func() {
+			deps := gatewayDeps(agentruntime.RunRequest{
+				Backend: backend, GatewayToken: "tok", GatewayURL: "http://127.0.0.1:60080",
+			})
+			So(deps, ShouldResemble, CLIDeps{})
+		})
+
+		Convey("When 会话选了 agentre 供应商(req.Provider 非空), Then deps 装配 token/url(登录态可被接管)", func() {
+			deps := gatewayDeps(agentruntime.RunRequest{
+				Backend: backend, GatewayToken: "tok", GatewayURL: "http://127.0.0.1:60080",
+				Provider: &llm_provider_entity.LLMProvider{ProviderKey: "session-picked", Model: "gpt-5.5"},
+			})
+			So(deps.Token, ShouldEqual, "tok")
+			So(deps.GatewayURL, ShouldEqual, "http://127.0.0.1:60080")
+		})
+	})
+
+	Convey("Given backend nil, Then deps 为空", t, func() {
+		deps := gatewayDeps(agentruntime.RunRequest{GatewayToken: "tok", GatewayURL: "http://127.0.0.1:60080"})
+		So(deps, ShouldResemble, CLIDeps{})
+	})
+}
+
 func TestBuildLaunchSpec_MCPServers(t *testing.T) {
 	Convey("Given RunRequest 带一个 http MCP server", t, func() {
 		spec := buildLaunchSpec(agentruntime.RunRequest{

--- a/internal/pkg/httpgateway/gateway.go
+++ b/internal/pkg/httpgateway/gateway.go
@@ -328,16 +328,39 @@ func (g *Gateway) RegisterControl(h http.Handler) {
 	g.ctlMu.Unlock()
 }
 
-// IssueToken 给一个 backend 申请 token；ttl <= 0 视作永久（chat flow 用）。
+// IssueToken 给一个 backend 申请 token，路由到 backend 自身绑定的供应商；
+// ttl <= 0 视作永久（chat flow 用）。
 // State=stopped 时返回 ErrGatewayNotRunning，调用方据此返回软失败给前端。
-func (g *Gateway) IssueToken(_ context.Context, backend *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error) {
+//
+// 会话可能覆盖供应商的场景（chat turn）用 IssueTokenFor 显式传 effective key。
+func (g *Gateway) IssueToken(ctx context.Context, backend *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error) {
+	var key string
+	if backend != nil {
+		key = backend.LLMProviderKey
+	}
+	return g.IssueTokenFor(ctx, backend, key, ttl)
+}
+
+// IssueTokenFor 与 IssueToken 同形，但 token 路由到显式传入的 providerKey：
+// chat flow 传本轮的 effective provider（会话 provider_key > agent 绑定，决策 3），
+// 于是「会话换了供应商」不必换 backend、也不必污染 agent 绑定就能改上游。
+func (g *Gateway) IssueTokenFor(
+	_ context.Context, backend *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration,
+) (string, error) {
 	g.mu.RLock()
 	running := g.state == stateRunning
 	g.mu.RUnlock()
 	if !running {
 		return "", ErrGatewayNotRunning
 	}
-	return g.tokens.Issue(backend, ttl)
+	return g.tokens.Issue(backend, providerKey, ttl)
+}
+
+// SetTokenProvider 改既有 token 的路由目标（token 字符串不变），返回它原来的供应商与
+// 是否命中。会话中途换供应商时由 chat flow / daemon 在下一轮调用 —— 见 TokenRegistry.
+// SetProviderKey 的重签禁忌说明。
+func (g *Gateway) SetTokenProvider(token, providerKey string) (previous string, ok bool) {
+	return g.tokens.SetProviderKey(token, providerKey)
 }
 
 // RevokeToken 立刻删除 token。

--- a/internal/pkg/httpgateway/gateway_test.go
+++ b/internal/pkg/httpgateway/gateway_test.go
@@ -100,6 +100,37 @@ func TestGateway_TokenLifecycle(t *testing.T) {
 	assert.NoError(t, g.Stop(context.Background()))
 }
 
+// TestGateway_IssueTokenForAndSetTokenProvider 钉死 Gateway 这层的会话供应商路由口
+// （决策 3）：签发按传入的 effective key、切换只改路由不换 token 字符串；gateway 没跑
+// 时 IssueTokenFor 与 IssueToken 一样软失败。
+func TestGateway_IssueTokenForAndSetTokenProvider(t *testing.T) {
+	g := New("127.0.0.1", 0, newFakeLookup())
+	be := &agent_backend_entity.AgentBackend{ID: 1, LLMProviderKey: "agent-bound"}
+
+	_, err := g.IssueTokenFor(context.Background(), be, "session-picked", 0)
+	assert.ErrorIs(t, err, ErrGatewayNotRunning)
+
+	assert.NoError(t, g.Start(context.Background()))
+	defer func() { _ = g.Stop(context.Background()) }()
+
+	tok, err := g.IssueTokenFor(context.Background(), be, "session-picked", 0)
+	assert.NoError(t, err)
+	entry, ok := g.tokens.Resolve(tok)
+	if assert.True(t, ok) {
+		assert.Equal(t, "session-picked", entry.MainProviderKey)
+	}
+
+	prev, ok := g.SetTokenProvider(tok, "switched")
+	assert.True(t, ok)
+	assert.Equal(t, "session-picked", prev)
+	assert.Equal(t, 1, g.tokens.Size(), "切换不得多签一条 token")
+	entry, _ = g.tokens.Resolve(tok)
+	assert.Equal(t, "switched", entry.MainProviderKey)
+
+	_, ok = g.SetTokenProvider("never-issued", "switched")
+	assert.False(t, ok)
+}
+
 func TestGateway_BaseURL(t *testing.T) {
 	// 未启动时 BaseURL 为空。
 	g := New("127.0.0.1", 0, newFakeLookup())
@@ -210,7 +241,7 @@ var _ = httptest.NewRecorder
 func TestServeHookInbox(t *testing.T) {
 	g := New("127.0.0.1", 0, newFakeLookup())
 	backend := &agent_backend_entity.AgentBackend{ID: 1, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "key-99"}
-	tok, err := g.tokens.Issue(backend, time.Minute)
+	tok, err := g.tokens.Issue(backend, backend.LLMProviderKey, time.Minute)
 	assert.NoError(t, err)
 
 	g.Steer().Push("abc", "qid-1", "first")

--- a/internal/pkg/httpgateway/llmforward_test.go
+++ b/internal/pkg/httpgateway/llmforward_test.go
@@ -118,7 +118,7 @@ func newRecordingUpstream(t *testing.T, response string) (*httptest.Server, *rec
 // issueAndRequest 帮测试发一条带 token 的请求到 forwarder handler。
 func issueAndRequest(t *testing.T, h http.HandlerFunc, tokens *TokenRegistry, b *agent_backend_entity.AgentBackend, path string, body string) *httptest.ResponseRecorder {
 	t.Helper()
-	tok, err := tokens.Issue(b, time.Minute)
+	tok, err := tokens.Issue(b, b.LLMProviderKey, time.Minute)
 	assert.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
@@ -221,6 +221,74 @@ func TestForwarder_RejectsProviderTypeMismatch(t *testing.T) {
 	var body map[string]string
 	_ = json.Unmarshal(w.Body.Bytes(), &body)
 	assert.Contains(t, body["error"], "type mismatch")
+}
+
+// TestForwarder_SwitchedProviderRoutesSameTokenToNewUpstream 钉死会话切换供应商的转发
+// 侧（规格「网关路由与子进程重启」）：token 字符串整段会话不变（它已烤进 CLI 子进程
+// env），换供应商改的只是它的路由目标 —— 同一个 token 的下一条请求必须打到新供应商的
+// BaseURL、带新供应商的 APIKey、body 的 model 改写成新供应商的 model。
+func TestForwarder_SwitchedProviderRoutesSameTokenToNewUpstream(t *testing.T) {
+	oldUpstream, oldRec := newRecordingUpstream(t, `{"ok":"old"}`)
+	newUpstream, newRec := newRecordingUpstream(t, `{"ok":"new"}`)
+
+	oldProvider := newAnthropicProvider("key-old", oldUpstream.URL)
+	oldProvider.Model = "claude-old"
+	switched := newAnthropicProvider("key-new", newUpstream.URL)
+	switched.Model = "claude-new"
+	switched.APIKey = "k-switched"
+
+	tokens := NewTokenRegistry()
+	f := NewForwarder(tokens, newFakeLookup(oldProvider, switched))
+	be := &agent_backend_entity.AgentBackend{
+		ID: 5, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "key-old",
+	}
+	tok, err := tokens.Issue(be, "key-old", 0)
+	assert.NoError(t, err)
+
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/messages",
+			strings.NewReader(`{"model":"whatever","messages":[]}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rec := httptest.NewRecorder()
+		f.AnthropicHandler()(rec, req)
+		return rec
+	}
+
+	assert.Equal(t, http.StatusOK, send().Code)
+	assert.Equal(t, "/v1/messages", oldRec.Path)
+
+	prev, ok := tokens.SetProviderKey(tok, "key-new")
+	assert.True(t, ok)
+	assert.Equal(t, "key-old", prev)
+
+	assert.Equal(t, http.StatusOK, send().Code, "token 字符串没变，仍然有效")
+	assert.Equal(t, "/v1/messages", newRec.Path, "切换后的请求打到新供应商")
+	assert.Equal(t, "k-switched", newRec.Header.Get("x-api-key"), "用新供应商的 APIKey")
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(newRec.Body, &body))
+	assert.Equal(t, "claude-new", body["model"], "model 改写成新供应商的 model")
+}
+
+// TestForwarder_SwitchedToMissingProviderKeeps502 切换目标在本机缺失/停用时，转发端点
+// 维持既有的 502（规格「网关路由与子进程重启」）：不静默回落旧供应商 —— 那会让用户以为
+// 换成功了、实际还在老那家上跑。
+func TestForwarder_SwitchedToMissingProviderKeeps502(t *testing.T) {
+	upstream, _ := newRecordingUpstream(t, `{"ok":"old"}`)
+	tokens := NewTokenRegistry()
+	f := NewForwarder(tokens, newFakeLookup(newAnthropicProvider("key-old", upstream.URL)))
+
+	tok, err := tokens.Issue(
+		&agent_backend_entity.AgentBackend{ID: 5, Type: string(agent_backend_entity.TypeClaudeCode)},
+		"key-old", 0)
+	assert.NoError(t, err)
+	_, ok := tokens.SetProviderKey(tok, "key-gone")
+	assert.True(t, ok)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"x"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	f.AnthropicHandler()(rec, req)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
 }
 
 func TestForwarder_MissingTokenReturns401(t *testing.T) {

--- a/internal/pkg/httpgateway/token_registry.go
+++ b/internal/pkg/httpgateway/token_registry.go
@@ -69,12 +69,17 @@ var ErrInvalidBackend = errors.New("httpgateway: invalid backend for token issue
 // Issue 把 backend 转成 TokenEntry 并存入表，返回随机 token 字符串。
 // ttl <= 0 时视为永久（chat flow 长 token 用；TestAgentBackend 传 60s）。
 //
-// LLMProviderKey == ""（CLI 登录模式，没绑 provider）也允许发 token：
+// providerKey 是这条 token 的**主供应商**，由调用方按自己的口径给出：chat flow 传本轮
+// 的 effective provider（会话 provider_key > agent 绑定，spec 决策 2/3），backend 自测 /
+// 探针传 backend 自身绑定。registry 不再自己从 backend 派生 —— 各处各读各的正是「会话
+// 选了供应商却打到 agent 绑定那家」的成因。
+//
+// providerKey == ""（CLI 登录模式，没绑 provider）也允许发 token：
 // 这种 token 在 /hook/v1/inbox 上正常用（gateway handler 只 Resolve 不看
 // provider），LLM 转发端点会因 ResolveModel→"" 找不到 provider 自然 502，
 // 互不干扰。**不允许**会让 hook 子进程在 CLI 登录模式下永远拿不到 token，
 // 排队消息没法 mid-turn 注入。
-func (r *TokenRegistry) Issue(b *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error) {
+func (r *TokenRegistry) Issue(b *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration) (string, error) {
 	if b == nil {
 		return "", ErrInvalidBackend
 	}
@@ -94,7 +99,7 @@ func (r *TokenRegistry) Issue(b *agent_backend_entity.AgentBackend, ttl time.Dur
 	entry := TokenEntry{
 		BackendID:       b.ID,
 		BackendType:     agent_backend_entity.BackendType(b.Type),
-		MainProviderKey: b.LLMProviderKey,
+		MainProviderKey: providerKey,
 		Routes:          upper,
 	}
 	if ttl > 0 {
@@ -125,6 +130,25 @@ func (r *TokenRegistry) Resolve(token string) (TokenEntry, bool) {
 		return TokenEntry{}, false
 	}
 	return entry, true
+}
+
+// SetProviderKey 把既有 token 的主供应商改成 providerKey，**token 字符串不变**，
+// 返回它原来的主供应商与是否命中（未签发过 / 已过期 → ("", false)）。
+//
+// 会话中途换供应商走这里而不是重签：token 是会话级常驻、首轮就烤进 CLI 子进程 env 的，
+// 重签会让在跑的子进程手里那个立刻失效（曾经的 401 事故）。tier 路由（Routes）与 backend
+// 身份不动 —— 换的只是主供应商这一件事。
+func (r *TokenRegistry) SetProviderKey(token, providerKey string) (previous string, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, found := r.tokens[token]
+	if !found || entry.IsExpired(r.now()) {
+		return "", false
+	}
+	previous = entry.MainProviderKey
+	entry.MainProviderKey = providerKey
+	r.tokens[token] = entry
+	return previous, true
 }
 
 // Revoke 删除 token；找不到忽略。

--- a/internal/pkg/httpgateway/token_registry_test.go
+++ b/internal/pkg/httpgateway/token_registry_test.go
@@ -18,7 +18,7 @@ func TestTokenRegistry_IssueResolveRevoke(t *testing.T) {
 		LLMProviderKey: "key-3",
 		ModelRoutes:    `{"OPUS":"key-5","sonnet":"key-6"}`,
 	}
-	tok, err := r.Issue(b, 60*time.Second)
+	tok, err := r.Issue(b, b.LLMProviderKey, 60*time.Second)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tok)
 	assert.Equal(t, 1, r.Size())
@@ -50,7 +50,7 @@ func TestTokenRegistry_RejectInvalidBackend(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := r.Issue(tc.b, time.Minute)
+			_, err := r.Issue(tc.b, "key-2", time.Minute)
 			assert.Error(t, err)
 		})
 	}
@@ -66,7 +66,7 @@ func TestTokenRegistry_IssueWithoutProvider(t *testing.T) {
 		ID:             42,
 		Type:           string(agent_backend_entity.TypeClaudeCode),
 		LLMProviderKey: "",
-	}, time.Minute)
+	}, "", time.Minute)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tok)
 
@@ -83,7 +83,7 @@ func TestTokenRegistry_ExpireOnResolve(t *testing.T) {
 	frozen := time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)
 	r.now = func() time.Time { return frozen }
 
-	tok, err := r.Issue(&agent_backend_entity.AgentBackend{ID: 1, LLMProviderKey: "key-1"}, 30*time.Second)
+	tok, err := r.Issue(&agent_backend_entity.AgentBackend{ID: 1}, "key-1", 30*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, r.Size())
 
@@ -100,12 +100,77 @@ func TestTokenRegistry_ExpireOnResolve(t *testing.T) {
 
 func TestTokenRegistry_ZeroTTLNeverExpires(t *testing.T) {
 	r := NewTokenRegistry()
-	tok, err := r.Issue(&agent_backend_entity.AgentBackend{ID: 1, LLMProviderKey: "key-1"}, 0)
+	tok, err := r.Issue(&agent_backend_entity.AgentBackend{ID: 1}, "key-1", 0)
 	assert.NoError(t, err)
 	// 模拟未来：仍命中
 	r.now = func() time.Time { return time.Now().Add(24 * time.Hour) }
 	_, ok := r.Resolve(tok)
 	assert.True(t, ok)
+}
+
+// TestTokenRegistry_IssueUsesEffectiveProviderKey 钉死决策 3 的签发侧：token 的主供应商
+// 来源是**签发时传入的 effective key**（会话 provider_key > agent 绑定），不再由 backend
+// 实体自己派生 —— 会话切了供应商之后，同一条 backend 签出来的 token 必须打到会话选的
+// 那家，否则 `--model` 换了、请求还打在 agent 绑定那家上。
+func TestTokenRegistry_IssueUsesEffectiveProviderKey(t *testing.T) {
+	r := NewTokenRegistry()
+	b := &agent_backend_entity.AgentBackend{
+		ID: 7, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "agent-bound",
+	}
+
+	tok, err := r.Issue(b, "session-picked", time.Minute)
+	assert.NoError(t, err)
+
+	entry, ok := r.Resolve(tok)
+	if assert.True(t, ok) {
+		assert.Equal(t, "session-picked", entry.MainProviderKey, "签发时传入的 effective key 说了算")
+		assert.Equal(t, int64(7), entry.BackendID, "身份仍来自 backend")
+		key, hit := entry.ResolveModel("")
+		assert.Equal(t, "session-picked", key)
+		assert.False(t, hit)
+	}
+}
+
+// TestTokenRegistry_SetProviderKeyKeepsTokenString 钉死决策 3 的切换侧：token 字符串是
+// **会话级常驻**、首轮就烤进 CLI 子进程 env 的，切换供应商只改它在网关里的路由目标，
+// 绝不重签（重签 = 在跑的子进程手里那个立刻失效，正是被修过的 401 事故）。
+func TestTokenRegistry_SetProviderKeyKeepsTokenString(t *testing.T) {
+	r := NewTokenRegistry()
+	b := &agent_backend_entity.AgentBackend{
+		ID: 7, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "agent-bound",
+		ModelRoutes: `{"OPUS":"tier-key"}`,
+	}
+	tok, err := r.Issue(b, "agent-bound", 0)
+	assert.NoError(t, err)
+
+	prev, ok := r.SetProviderKey(tok, "switched")
+	assert.True(t, ok)
+	assert.Equal(t, "agent-bound", prev, "返回旧 key，调用方据此判断是否真的换了")
+	assert.Equal(t, 1, r.Size(), "不得多出一条 token")
+
+	entry, found := r.Resolve(tok)
+	if assert.True(t, found, "token 字符串不变，仍能解出来") {
+		assert.Equal(t, "switched", entry.MainProviderKey)
+		assert.Equal(t, int64(7), entry.BackendID, "身份不变")
+		assert.Equal(t, "tier-key", entry.Routes["OPUS"], "tier 路由来自 backend 配置，不受切换影响")
+	}
+}
+
+// TestTokenRegistry_SetProviderKeyUnknownToken 未知 / 已过期 token 一律 (,,false)：
+// 调用方（会话切换）据此知道这条 token 已经不在表里，不去伪造一条路由记录。
+func TestTokenRegistry_SetProviderKeyUnknownToken(t *testing.T) {
+	r := NewTokenRegistry()
+	_, ok := r.SetProviderKey("never-issued", "x")
+	assert.False(t, ok)
+	assert.Equal(t, 0, r.Size())
+
+	frozen := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	r.now = func() time.Time { return frozen }
+	tok, err := r.Issue(&agent_backend_entity.AgentBackend{ID: 1}, "key-1", 30*time.Second)
+	assert.NoError(t, err)
+	r.now = func() time.Time { return frozen.Add(31 * time.Second) }
+	_, ok = r.SetProviderKey(tok, "key-2")
+	assert.False(t, ok, "过期 token 不可再改路由")
 }
 
 func TestTokenEntry_ResolveModel(t *testing.T) {

--- a/internal/pkg/httpgateway/types.go
+++ b/internal/pkg/httpgateway/types.go
@@ -36,12 +36,28 @@ func DefaultRoutes() []string {
 	return []string{RouteAnthropic, RouteOpenAIResponses, RouteOpenAIChat, RouteHookInbox, RouteMCPPrefix + "*"}
 }
 
-// TokenIssuer 给 Prober 和 chat flow 发临时 token、撤销 token、读 URL。
+// TokenIssuer 给 Prober 和 backend 自测发临时 token、撤销 token、读 URL。
+// 这里签出来的 token 路由到 backend 自身绑定的供应商。
 type TokenIssuer interface {
 	IssueToken(ctx context.Context, backend *agent_backend_entity.AgentBackend, ttl time.Duration) (token string, err error)
 	RevokeToken(token string)
 	URL() string
 	Status() GatewayStatus
+}
+
+// TokenRouter 是 chat flow 用的网关口：在 TokenIssuer 之上多出「按会话有效供应商路由」
+// 的两件能力（决策 3）——
+//   - IssueTokenFor：按本轮的 effective provider（会话 provider_key > agent 绑定）签发；
+//   - SetTokenProvider：**不换 token 字符串**地改既有 token 的路由目标。
+//
+// 之所以是会话切换的唯一手段：token 是会话级常驻、首轮就烤进 CLI 子进程 env 的，重签会
+// 让在跑的子进程立刻 401（被修过的事故）。*Gateway 自然满足本接口。
+type TokenRouter interface {
+	TokenIssuer
+	IssueTokenFor(
+		ctx context.Context, backend *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration,
+	) (token string, err error)
+	SetTokenProvider(token, providerKey string) (previous string, ok bool)
 }
 
 // Lifecycle 给 app_settings_svc 用：查状态、重启、注册 MCP handler。

--- a/internal/repository/chat_repo/mock_chat_repo/mock_session.go
+++ b/internal/repository/chat_repo/mock_chat_repo/mock_session.go
@@ -466,3 +466,17 @@ func (mr *MockSessionRepoMockRecorder) UpdatePermissionModeAtLaunch(ctx, session
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePermissionModeAtLaunch", reflect.TypeOf((*MockSessionRepo)(nil).UpdatePermissionModeAtLaunch), ctx, sessionID, mode)
 }
+
+// UpdateProviderKey mocks base method.
+func (m *MockSessionRepo) UpdateProviderKey(ctx context.Context, sessionID int64, providerKey string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateProviderKey", ctx, sessionID, providerKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateProviderKey indicates an expected call of UpdateProviderKey.
+func (mr *MockSessionRepoMockRecorder) UpdateProviderKey(ctx, sessionID, providerKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProviderKey", reflect.TypeOf((*MockSessionRepo)(nil).UpdateProviderKey), ctx, sessionID, providerKey)
+}

--- a/internal/repository/chat_repo/session.go
+++ b/internal/repository/chat_repo/session.go
@@ -46,6 +46,11 @@ type SessionRepo interface {
 	// invoked through the user-facing SetPermissionMode IPC — that one only
 	// touches permission_mode.
 	UpdatePermissionModeAtLaunch(ctx context.Context, sessionID int64, mode string) error
+	// UpdateProviderKey 改写会话级 LLM 供应商 key（空串 = 跟随 agent 绑定）。
+	// 由 chat_svc.SetChatSessionProvider 调用；切换允许发生在轮中，所以只碰这一列，
+	// 不走整行 Save —— 后者会把并发轮次正在写的状态列一起盖掉。同理 provider_key
+	// 也在 Update 的 Omit 清单里：轮次收尾的整行回写拿的是轮次开始时读出的旧实体。
+	UpdateProviderKey(ctx context.Context, sessionID int64, providerKey string) error
 	// UpdateExecDaemon 记录执行该会话的配对 daemon(paired_agentreds.id)及其实例标识
 	// (sha256:<hex>)、以及这条会话钉住的执行目标档(agentBackendID,R15b / 决策36)。
 	// deviceID=0 + 空标识表示回到本机执行；agentBackendID=0 表示尚未钉住。三列同一条
@@ -397,10 +402,14 @@ func (r *sessionRepo) Update(ctx context.Context, s *chat_entity.Session) error 
 	//     会把「这条会话跑在哪台 daemon 上、钉在哪一档、消费到哪」一起抹成 0 / '' / 0,
 	//     空闲的远端会话从此落在 ListRemoteExecSessions 的取材条件之外,再也进不了
 	//     启动补齐;钉住的档也会被抹回未钉住,下一轮又变成重挑(决策36明确禁止)。
-	// 这四列在服务层没有任何「写实体再 Update」的路径,Omit 不会丢掉谁的写入。
+	//   - provider_key —— 会话级供应商允许在轮中切换(2026-08-10 决策 8),而收尾用的
+	//     实体是轮次开始时读出的、带着旧供应商的那一份,不 Omit 就会把用户刚切好的
+	//     供应商冲回去。新建会话的首次写入走 Create,不经这里。
+	// 这几列在服务层没有任何「写实体再 Update」的路径,Omit 不会丢掉谁的写入。
 	err := db.Ctx(ctx).Omit(
 		"permission_mode", "permission_mode_at_launch",
 		"exec_device_id", "exec_daemon_fingerprint", "exec_agent_backend_id", "event_cursor",
+		"provider_key",
 	).Save(s).Error
 	s.ApplyDerivedFields()
 	return err
@@ -421,6 +430,15 @@ func (r *sessionRepo) UpdatePermissionModeAtLaunch(ctx context.Context, sessionI
 		Updates(map[string]any{
 			"permission_mode_at_launch": mode,
 			"updatetime":                time.Now().UnixMilli(),
+		}).Error
+}
+
+func (r *sessionRepo) UpdateProviderKey(ctx context.Context, sessionID int64, providerKey string) error {
+	return db.Ctx(ctx).Model(&chat_entity.Session{}).
+		Where("id = ? AND status = ?", sessionID, consts.ACTIVE).
+		Updates(map[string]any{
+			"provider_key": providerKey,
+			"updatetime":   time.Now().UnixMilli(),
 		}).Error
 }
 

--- a/internal/repository/chat_repo/session_test.go
+++ b/internal/repository/chat_repo/session_test.go
@@ -653,6 +653,76 @@ func TestSessionRepo_UpdateKeepsExecAgentBackendID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestSessionRepo_UpdateProviderKey 钉死会话级供应商切换的写入 SQL(2026-08-10 决策 1):
+// 只动 provider_key(+ updatetime),不能顺带把并发轮次正在写的状态列一起盖掉 ——
+// 切换允许在轮中发生,整行 Save 在这里是错的。
+func TestSessionRepo_UpdateProviderKey(t *testing.T) {
+	ctx, _, mock := testutils.Database(t)
+	repo := chat_repo.NewSession()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `chat_sessions` SET `provider_key`=\\?,`updatetime`=\\? WHERE id = \\? AND status = \\?").
+		WithArgs("anthropic-main", sqlmock.AnyArg(), int64(42), consts.ACTIVE).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.UpdateProviderKey(ctx, 42, "anthropic-main"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSessionRepo_UpdateProviderKeyClears 空串 = 改回「跟随 agent 绑定」,同一条语句
+// 照常写入(不是 no-op,也不走 gorm 的零值跳过)。
+func TestSessionRepo_UpdateProviderKeyClears(t *testing.T) {
+	ctx, _, mock := testutils.Database(t)
+	repo := chat_repo.NewSession()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `chat_sessions` SET `provider_key`=\\?,`updatetime`=\\? WHERE id = \\? AND status = \\?").
+		WithArgs("", sqlmock.AnyArg(), int64(42), consts.ACTIVE).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.UpdateProviderKey(ctx, 42, ""))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSessionRepo_UpdateKeepsProviderKey 回归(2026-08-10 决策 1/8):供应商切换允许
+// 发生在轮中,而轮次收尾的整行 Save 用的是**轮次开始时**读出的那份实体 —— 那会儿
+// provider_key 还是旧值。provider_key 若不在 Update 的 Omit 清单里,收尾就会把用户
+// 刚切好的供应商悄悄冲回去,下一轮又打回旧供应商(症状与 R12 的执行位置被抹平同形)。
+//
+// 断言落在「这一行最后是什么」,而不是某条语句长什么样:缺陷出在两次写之间的相互作用。
+func TestSessionRepo_UpdateKeepsProviderKey(t *testing.T) {
+	ctx, gdb, mock := testutils.Database(t)
+	repo := chat_repo.NewSession()
+
+	row := map[string]any{
+		"agent_status": "running",
+		"provider_key": "old-provider",
+	}
+	captureUpdatedRow(t, gdb, row)
+
+	// 轮次开始时读出来的实体:带的是切换前的供应商。
+	sess := &chat_entity.Session{ID: 42, AgentStatus: "running", Status: consts.ACTIVE, ProviderKey: "old-provider"}
+
+	// 写 1:轮中用户切到另一个供应商(chat_svc.SetChatSessionProvider)。
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `chat_sessions`").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	require.NoError(t, repo.UpdateProviderKey(ctx, 42, "new-provider"))
+
+	// 写 2:running → idle 收尾,用的是上面那份**没跟着变**的内存实体。
+	sess.AgentStatus = "idle"
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `chat_sessions`").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	require.NoError(t, repo.Update(ctx, sess))
+
+	assert.Equal(t, "new-provider", row["provider_key"], "收尾不得把轮中切好的会话供应商冲回旧值")
+	assert.Equal(t, "idle", row["agent_status"], "收尾本来要写的状态照常落库")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // captureUpdatedRow 把仓储实际发出的 UPDATE 语句应用到 row 上,补出 sqlmock 没有的
 // 行状态。取的是 GORM 生成的 SET 子句本身,不预设哪条语句该写哪些列。
 func captureUpdatedRow(t *testing.T, gdb *gorm.DB, row map[string]any) {

--- a/internal/service/chat_svc/active_stream_internal_test.go
+++ b/internal/service/chat_svc/active_stream_internal_test.go
@@ -3,6 +3,8 @@ package chat_svc
 import (
 	"testing"
 
+	"github.com/cago-frame/agents/agent/blocks"
+
 	"github.com/agentre-ai/agentre/internal/model/entity/chat_entity"
 )
 
@@ -35,4 +37,67 @@ func TestActiveStreamName(t *testing.T) {
 			t.Fatalf("got %q want empty", got)
 		}
 	})
+
+	// 轮中切换供应商会把一条只承载 notice 的旁白行(appendProviderSwitchNotice,
+	// role=assistant、NextSeq 排在在跑那条之后)追加进 transcript。它不是一轮:流名
+	// 若按它算,重挂上来的前端就订到一条**没人 emit** 的流名 —— 这一轮余下的流式内容
+	// 全看不见,也永远等不到终态。
+	t.Run("provider notice row does not steal the in-flight stream name", func(t *testing.T) {
+		withNotice := []*chat_entity.Message{
+			{ID: 1, Role: "user"},
+			{ID: 2, Role: "assistant"},
+			noticeOnlyAssistantMessage(t, 3),
+		}
+		if got, want := activeStreamName(true, 7, withNotice), StreamName(7, 2); got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+
+	// 反向边界:轮刚起、内容还没落地的 assistant 行 BlocksJSON 恒为 "[]" —— 没有块
+	// ≠ 旁白行,流名就该指向它,否则 Send 后立刻重挂的前端反而订不到在跑的那一轮。
+	t.Run("assistant row with no blocks yet is still the in-flight turn", func(t *testing.T) {
+		pending := []*chat_entity.Message{
+			{ID: 1, Role: "user"},
+			{ID: 2, Role: "assistant", BlocksJSON: "[]"},
+		}
+		if got, want := activeStreamName(true, 7, pending), StreamName(7, 2); got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+
+	// 另一条反向边界:回退 notice 不是旁白行 —— 它由 runTurn 追加进**这一轮自己**的
+	// assistant 消息(chat.go finalize),所以「块全是 notice」也可能就是一轮真实对话:
+	// 用户发完立刻点停止、这一轮零内容收尾时,该消息的块正好只剩这条回退 notice。
+	// finalize 写完块到 activeCancels 清掉之间有一个窗口,此刻的 LoadSession 若把它
+	// 当旁白行跳过,流名就会退到更早的 assistant —— 前端重挂到一条已经收尾的流上,
+	// 永远等不到终态。判据必须是「独立落库的切换 notice」,不是「块全是 notice」。
+	t.Run("turn carrying only a fallback notice is still a real turn", func(t *testing.T) {
+		fallback := &chat_entity.Message{ID: 3, Role: "assistant"}
+		if err := fallback.SetBlocks([]blocks.ContentBlock{blocks.NoticeBlock{
+			Level: "info", Text: encodeProviderFallback("gone-provider", ""),
+		}}); err != nil {
+			t.Fatalf("SetBlocks: %v", err)
+		}
+		msgs := []*chat_entity.Message{
+			{ID: 1, Role: "user"},
+			{ID: 2, Role: "assistant"},
+			fallback,
+		}
+		if got, want := activeStreamName(true, 7, msgs), StreamName(7, 3); got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+}
+
+// noticeOnlyAssistantMessage 造一条「只承载供应商切换 notice 的旁白行」,形状与
+// appendProviderSwitchNotice 落库的完全一致(role=assistant + 单个 NoticeBlock)。
+func noticeOnlyAssistantMessage(t *testing.T, id int64) *chat_entity.Message {
+	t.Helper()
+	m := &chat_entity.Message{ID: id, Role: "assistant"}
+	if err := m.SetBlocks([]blocks.ContentBlock{blocks.NoticeBlock{
+		Level: "info", Text: encodeProviderSwitch("session-key", "中转 · GLM 5.2"),
+	}}); err != nil {
+		t.Fatalf("SetBlocks: %v", err)
+	}
+	return m
 }

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -3760,6 +3760,14 @@ func (s *chatSvc) prepareTurnRun(
 		// 覆盖解析出来的那家（缺失/停用已回退过），也正是本轮 `--model` 用的那家 ——
 		// 会话换了供应商，token 的上游随之改变，字符串不变（决策 3）。
 		req.GatewayURL, req.GatewayToken = s.signChatTokenFor(ctx, be, sess.ID, providerKeyOf(prov))
+		// 本轮有 effective provider 却拿不到网关(未注入/未运行)：LLM 本该经本机网关转发
+		// 到所选供应商,此时装不上 ANTHROPIC_* / codex model_provider,子进程会**静默**
+		// 退回 CLI 自身登录态,把这段对话打到用户没选的那家上游。与 resolveAgentBackend
+		// 对「backend 已绑 provider」那半的判定同一口径 —— 那半只看 be.LLMProviderKey,
+		// 覆盖不到「登录态 backend 上会话自己选了供应商」这条新路径(决策 6/7)。
+		if prov != nil && (req.GatewayURL == "" || req.GatewayToken == "") {
+			return fail(i18n.NewError(ctx, code.ChatBackendGatewayUnavailable))
+		}
 	}
 	switch agent_backend_entity.BackendType(be.Type) {
 	case agent_backend_entity.TypeClaudeCode:

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -725,7 +725,7 @@ func (s *chatSvc) GetLaunchCommand(ctx context.Context, req *LaunchCommandReques
 // providerNoticePayload 是供应商相关的持久 notice 写进 blocks.NoticeBlock.Text 的小 JSON。
 // NoticeBlock 是 cago 库的 UI-only 块,只有 Level/Text 两个字段(库类型,不能加字段),所以
 // 把结构化信息编码进 Text;前端投影(noticeBlockToChatBlock)解回 ChatBlock 的
-// ProviderKey / NoticeKind 再用 t() 渲染。该块从不发给 LLM。
+// ProviderKey / ProviderName / NoticeKind 再用 t() 渲染。该块从不发给 LLM。
 // 旧数据 / 非结构化文本的 NoticeBlock 走 Text 原样渲染兜底。
 //
 // 两种 kind:
@@ -734,24 +734,41 @@ func (s *chatSvc) GetLaunchCommand(ctx context.Context, req *LaunchCommandReques
 //   - "switch" = 用户在会话里切换了供应商(2026-08-10 决策 9):ProviderKey 是切换后的
 //     会话级 key,**空串表示改回跟随 agent 绑定 / CLI 登录态** —— 所以这一种不能靠
 //     "ProviderKey 非空" 判定负载有效,kind 字段本身才是判据。
+//
+// ProviderName 是展示名(2026-08-10 显示缺陷修复决策 1/2):后端按当前解析到的供应商
+// 实体填入,查不到(供应商已删)时留空 —— 前端优先渲染它,为空则回退到 key。名字只有
+// 产出 notice 的后端手里有,不能让前端按 key 反查(供应商列表可能未拉/已缺项)。
 type providerNoticePayload struct {
-	ProviderKey string `json:"providerKey,omitempty"`
-	Kind        string `json:"kind,omitempty"`
+	ProviderKey  string `json:"providerKey,omitempty"`
+	ProviderName string `json:"providerName,omitempty"`
+	Kind         string `json:"kind,omitempty"`
 }
 
 // providerNoticeKindSwitch 见 providerNoticePayload 的 kind 说明。回退提示不写 kind,
 // 与旧数据同形。
 const providerNoticeKindSwitch = "switch"
 
-func encodeProviderFallback(providerKey string) string {
-	b, _ := json.Marshal(providerNoticePayload{ProviderKey: providerKey})
+// providerDisplayName 取供应商展示名。prov 为 nil(查不到实体 / 未选任何供应商)时
+// 返回空串,由调用方据此决定 notice 前端渲染时回退到 key 还是「跟随 agent 绑定」的
+// 专用文案(2026-08-10 显示缺陷修复决策 1/2)。
+func providerDisplayName(prov *llm_provider_entity.LLMProvider) string {
+	if prov == nil {
+		return ""
+	}
+	return prov.Name
+}
+
+func encodeProviderFallback(providerKey, providerName string) string {
+	b, _ := json.Marshal(providerNoticePayload{ProviderKey: providerKey, ProviderName: providerName})
 	return string(b)
 }
 
 // encodeProviderSwitch 编码「本会话自此改用某供应商」的持久 notice(2026-08-10 决策 9)。
-// providerKey 为空 = 改回跟随 agent 绑定。
-func encodeProviderSwitch(providerKey string) string {
-	b, _ := json.Marshal(providerNoticePayload{ProviderKey: providerKey, Kind: providerNoticeKindSwitch})
+// providerKey 为空 = 改回跟随 agent 绑定,此时 providerName 恒为空。
+func encodeProviderSwitch(providerKey, providerName string) string {
+	b, _ := json.Marshal(providerNoticePayload{
+		ProviderKey: providerKey, ProviderName: providerName, Kind: providerNoticeKindSwitch,
+	})
 	return string(b)
 }
 
@@ -781,15 +798,16 @@ func firstNonEmpty(values ...string) string {
 }
 
 // noticeBlockToChatBlock 把持久化的 blocks.NoticeBlock 投影成前端 ChatBlock。
-// 供应商回退/切换提示(本功能产出的结构化小 JSON)解回 ProviderKey + NoticeKind、
-// Text 置空 —— 前端走 t() 渲染;非结构化旧数据原样透传 Text。
+// 供应商回退/切换提示(本功能产出的结构化小 JSON)解回 ProviderKey + ProviderName +
+// NoticeKind、Text 置空 —— 前端走 t() 渲染;非结构化旧数据原样透传 Text。
 func noticeBlockToChatBlock(tb blocks.NoticeBlock) ChatBlock {
 	if p, ok := decodeProviderNotice(tb.Text); ok {
 		return ChatBlock{
-			Type:        "notice",
-			Level:       tb.Level,
-			ProviderKey: p.ProviderKey,
-			NoticeKind:  p.Kind,
+			Type:         "notice",
+			Level:        tb.Level,
+			ProviderKey:  p.ProviderKey,
+			ProviderName: p.ProviderName,
+			NoticeKind:   p.Kind,
 		}
 	}
 	return ChatBlock{Type: "notice", Level: tb.Level, Text: tb.Text}
@@ -1817,9 +1835,15 @@ func (s *chatSvc) sessionProviderOverride(
 		kind.ProviderTypeMatch(llm_provider_entity.ProviderType(prov.Type)) {
 		return prov, nil
 	}
+	// 展示名(决策 2):实体查到了(只是停用/类型不兼容)就带上它的名字;查询失败或
+	// 实体本身不存在(供应商已删)则 providerDisplayName 返回空串,notice 保持只显示 key。
+	name := ""
+	if err == nil {
+		name = providerDisplayName(prov)
+	}
 	return baseProv, &blocks.NoticeBlock{
 		Level: "info",
-		Text:  encodeProviderFallback(key),
+		Text:  encodeProviderFallback(key, name),
 	}
 }
 
@@ -4105,11 +4129,12 @@ func (s *chatSvc) runTurn(
 		}
 		// 远端(决策 9):daemon 按 wire 的 effectiveProviderKey 自解失败、回退 agent
 		// 绑定后经 ack 回传被回退的 provider_key,这里据此追加同一条持久 notice(与
-		// 本地 Q3 一致;provider_key 不清除)。
+		// 本地 Q3 一致;provider_key 不清除)。wire 只带 key 不带展示名(远端不在本轮
+		// 范围内,见 spec Out of scope),notice 保持只显示 key。
 		if result.ProviderFallbackKey != "" {
 			finalBlocks = append(finalBlocks, blocks.NoticeBlock{
 				Level: "info",
-				Text:  encodeProviderFallback(result.ProviderFallbackKey),
+				Text:  encodeProviderFallback(result.ProviderFallbackKey, ""),
 			})
 		}
 	}

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -3765,7 +3765,8 @@ func (s *chatSvc) prepareTurnRun(
 		// 退回 CLI 自身登录态,把这段对话打到用户没选的那家上游。与 resolveAgentBackend
 		// 对「backend 已绑 provider」那半的判定同一口径 —— 那半只看 be.LLMProviderKey,
 		// 覆盖不到「登录态 backend 上会话自己选了供应商」这条新路径(决策 6/7)。
-		if prov != nil && (req.GatewayURL == "" || req.GatewayToken == "") {
+		// 只对真正经网关取 LLM 的后端成立,见 gatewayRoutesLLM。
+		if prov != nil && gatewayRoutesLLM(be) && (req.GatewayURL == "" || req.GatewayToken == "") {
 			return fail(i18n.NewError(ctx, code.ChatBackendGatewayUnavailable))
 		}
 	}
@@ -4560,6 +4561,16 @@ func shouldSignChatGateway(be *agent_backend_entity.AgentBackend, prov *llm_prov
 		return true
 	}
 	return prov != nil
+}
+
+// gatewayRoutesLLM 报告这个后端的 LLM 流量是否真的经本机网关：claudecode 靠
+// ANTHROPIC_BASE_URL、codex 靠 model_provider/base_url，两者都是 spawn 时从网关派生的
+// 启动期参数，拿不到网关就会静默退回 CLI 自身登录态。piagent 不在此列 —— 它把
+// provider.APIKey 直接注进子进程 env（agentruntime.BuildPiAgentProviderEnv），整个
+// piagent runtime 没有任何 GatewayURL/GatewayToken 消费点，网关没在跑照样打得到所选
+// 供应商。「有 effective provider 就必须有可用网关」这条门控只对前两者成立。
+func gatewayRoutesLLM(be *agent_backend_entity.AgentBackend) bool {
+	return be != nil && (be.IsClaudeCode() || be.IsCodex())
 }
 
 // remoteProviderKnownMissing returns true only when the watcher cache has a

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -1270,6 +1270,13 @@ func (s *chatSvc) goalSessionContext(ctx context.Context, sessionID int64) (*cha
 	if !be.IsCodex() {
 		return nil, nil, nil, nil, i18n.NewError(ctx, code.ChatGoalUnsupported)
 	}
+	// goal 与 turn 共用同一个 codex app-server 会话池,所以供应商必须同一口径解析
+	// (会话 provider_key > agent 绑定,spec 2026-08-10)。各读各的会让 acquireSession
+	// 的启动期比对键(effectiveModel + effectiveProviderKey,决策 4)在 goal 与 turn 之间
+	// 反复翻转 —— 一次 /goal 就把这条会话正在用的 app-server evict 掉重 spawn,而且这次
+	// goal 本身打在用户没选的那家上游。回退 notice 丢弃:goal 不写 transcript,回退提示
+	// 由真正跑轮的那条路径产出。
+	prov, _ = s.resolveSessionProvider(ctx, sess, be, prov)
 	return sess, a, be, prov, nil
 }
 

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -3751,9 +3751,10 @@ func (s *chatSvc) prepareTurnRun(
 		// 决策 9），daemon 按它从自己的配置解析；无会话 key 时回落 agent 绑定。
 		req.LLMProviderKey = effectiveProviderKey(sess, be)
 		req.Provider = nil
-	} else if shouldSignChatGateway(be) {
+	} else if shouldSignChatGateway(be, prov) {
 		// Claude Code local 需要 gateway token 给 PostToolUse hook；Codex local
-		// 没有 hook，不能覆盖其原生 login 并误打到本地 gateway。
+		// 没有 hook，只有本轮存在 effective provider 时才该走 gateway（决策 6），
+		// 否则会覆盖其原生 login 并误打到本地 gateway。
 		//
 		// 按 prov 路由而不是 be.LLMProviderKey：prov 是 turn 入口按会话 provider_key
 		// 覆盖解析出来的那家（缺失/停用已回退过），也正是本轮 `--model` 用的那家 ——
@@ -4536,14 +4537,21 @@ func chatMessageForEvent(sess *chat_entity.Session, msg *chat_entity.Message) *C
 	return &final
 }
 
-func shouldSignChatGateway(be *agent_backend_entity.AgentBackend) bool {
+// shouldSignChatGateway 决定本轮要不要给 CLI 子进程签一个 gateway token（spec
+// 2026-08-10 决策 6）。Claude Code local 无论是否有 provider 都要签——PostToolUse
+// hook 子进程访问 /hook/v1/inbox 靠它，与 LLM 是否走网关无关（网关路由那半独立由
+// BuildClaudeCodeEnv 按 effective provider 门控）。Codex local 没有 hook，只有本轮
+// 存在 effective provider（prov 非 nil：会话 provider_key 覆盖 agent 绑定后解析出的
+// 那家，已过缺失/停用回退）时才该签，否则会把它自身的 CLI 登录态误打到本地网关
+// ——门控看 prov 而不是 be.LLMProviderKey，是登录态会话能双向切换供应商的前提。
+func shouldSignChatGateway(be *agent_backend_entity.AgentBackend, prov *llm_provider_entity.LLMProvider) bool {
 	if be == nil || be.IsBuiltin() {
 		return false
 	}
 	if be.IsClaudeCode() {
 		return true
 	}
-	return be.LLMProviderKey != ""
+	return prov != nil
 }
 
 // remoteProviderKnownMissing returns true only when the watcher cache has a

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -110,6 +110,9 @@ type ChatSvc interface {
 	Stop(ctx context.Context, req *StopRequest) (*StopResponse, error)
 	StopBackgroundTask(ctx context.Context, req *StopBackgroundTaskRequest) (*StopBackgroundTaskResponse, error)
 	SetPermissionMode(ctx context.Context, req *SetPermissionModeRequest) (*SetPermissionModeResponse, error)
+	// SetChatSessionProvider 切换已有会话的 LLM 供应商（空串 = 跟随 agent 绑定）。
+	// 只写 provider_key 一列，自下一轮生效，不打断正在进行的轮。
+	SetChatSessionProvider(ctx context.Context, req *SetSessionProviderRequest) (*SetSessionProviderResponse, error)
 	Regenerate(ctx context.Context, req *RegenerateRequest) (*SendResponse, error)
 	Edit(ctx context.Context, req *EditRequest) (*SendResponse, error)
 	Rename(ctx context.Context, req *RenameRequest) (*RenameResponse, error)
@@ -520,6 +523,7 @@ func (s *chatSvc) LoadSession(ctx context.Context, req *LoadSessionRequest) (*Lo
 			Createtime:             sess.Createtime,
 			PermissionMode:         sess.PermissionMode,
 			PermissionModeAtLaunch: sess.PermissionModeAtLaunch,
+			ProviderKey:            sess.ProviderKey,
 			ProjectID:              sess.ProjectID,
 		},
 		Messages: make([]ChatMessage, 0, len(msgs)),
@@ -570,9 +574,11 @@ func (s *chatSvc) LoadSession(ctx context.Context, req *LoadSessionRequest) (*Lo
 		if displayBackendID > 0 {
 			if be, _ = agent_backend_repo.AgentBackend().Find(ctx, displayBackendID); be != nil {
 				resp.Session.BackendType = be.Type
-				if be.LLMProviderKey != "" {
-					prov, _ = llm_provider_repo.LLMProvider().FindByKey(ctx, be.LLMProviderKey)
-				}
+				// 展示口径（spec 2026-08-10）：按 effective provider（会话 provider_key >
+				// agent 绑定）解析，与这条会话下一轮真正会用的那家一致；agent 绑定 key
+				// 一并回传，供 composer 的供应商 pill 渲染「跟随绑定」时的标签。
+				prov, _ = s.resolveEffectiveProvider(ctx, sess, be)
+				resp.Session.AgentProviderKey = be.LLMProviderKey
 			}
 		}
 		// ExecTargetCount 给前端聊天头 chip 守卫用（R15 / R20）：多档 Agent 的会话
@@ -671,12 +677,12 @@ func (s *chatSvc) GetLaunchCommand(ctx context.Context, req *LaunchCommandReques
 		return nil, i18n.NewError(ctx, code.ChatLaunchCommandNotAvailable)
 	}
 
-	var prov *llm_provider_entity.LLMProvider
-	if be.LLMProviderKey != "" {
-		prov, err = llm_provider_repo.LLMProvider().FindByKey(ctx, be.LLMProviderKey)
-		if err != nil {
-			return nil, operationFailedWithCause(ctx, err)
-		}
+	// 按 effective provider 解析（会话 provider_key > agent 绑定，spec 2026-08-10）：
+	// 复制出去的命令要与这条会话实际执行的那家供应商一致，否则用户拿到的是 agent
+	// 绑定那家的 BASE_URL / model。
+	prov, err := s.resolveEffectiveProvider(ctx, sess, be)
+	if err != nil {
+		return nil, operationFailedWithCause(ctx, err)
 	}
 
 	// 关联 provider 时拼 gateway URL 并签一个"进程内永久"的 token 内联进命令；
@@ -712,32 +718,51 @@ func (s *chatSvc) GetLaunchCommand(ctx context.Context, req *LaunchCommandReques
 	return &LaunchCommandResponse{Command: cmd, BackendType: be.Type}, nil
 }
 
-// providerFallbackPayload 是供应商回退提示持久化时写进 blocks.NoticeBlock.Text 的小 JSON
-// （spec 决策 8）。NoticeBlock 是 cago 库的 UI-only 块,只有 Level/Text 两个字段(库类型,
-// 不能加字段),所以把会话所选 provider_key 编码进 Text;前端投影(noticeBlockToChatBlock)
-// 解回 ChatBlock.ProviderKey 再用 t() 渲染。该块从不发给 LLM。
+// providerNoticePayload 是供应商相关的持久 notice 写进 blocks.NoticeBlock.Text 的小 JSON。
+// NoticeBlock 是 cago 库的 UI-only 块,只有 Level/Text 两个字段(库类型,不能加字段),所以
+// 把结构化信息编码进 Text;前端投影(noticeBlockToChatBlock)解回 ChatBlock 的
+// ProviderKey / NoticeKind 再用 t() 渲染。该块从不发给 LLM。
 // 旧数据 / 非结构化文本的 NoticeBlock 走 Text 原样渲染兜底。
-type providerFallbackPayload struct {
-	ProviderKey string `json:"providerKey"`
+//
+// 两种 kind:
+//   - ""（无 kind 字段,含全部旧数据）= 供应商回退提示(2026-08-09 决策 8):会话所选
+//     供应商缺失/停用/不兼容,本轮回退 agent 绑定,ProviderKey 是被回退掉的那个 key;
+//   - "switch" = 用户在会话里切换了供应商(2026-08-10 决策 9):ProviderKey 是切换后的
+//     会话级 key,**空串表示改回跟随 agent 绑定 / CLI 登录态** —— 所以这一种不能靠
+//     "ProviderKey 非空" 判定负载有效,kind 字段本身才是判据。
+type providerNoticePayload struct {
+	ProviderKey string `json:"providerKey,omitempty"`
+	Kind        string `json:"kind,omitempty"`
 }
 
+// providerNoticeKindSwitch 见 providerNoticePayload 的 kind 说明。回退提示不写 kind,
+// 与旧数据同形。
+const providerNoticeKindSwitch = "switch"
+
 func encodeProviderFallback(providerKey string) string {
-	b, _ := json.Marshal(providerFallbackPayload{ProviderKey: providerKey})
+	b, _ := json.Marshal(providerNoticePayload{ProviderKey: providerKey})
 	return string(b)
 }
 
-// decodeProviderFallback 把 NoticeBlock.Text 还原成会话所选 provider_key。
+// encodeProviderSwitch 编码「本会话自此改用某供应商」的持久 notice(2026-08-10 决策 9)。
+// providerKey 为空 = 改回跟随 agent 绑定。
+func encodeProviderSwitch(providerKey string) string {
+	b, _ := json.Marshal(providerNoticePayload{ProviderKey: providerKey, Kind: providerNoticeKindSwitch})
+	return string(b)
+}
+
+// decodeProviderNotice 把 NoticeBlock.Text 还原成结构化负载。
 // ok=false 表示文本不是本功能产出的结构化负载(旧数据/其它来源的 notice),调用方应
 // 原样渲染 Text。
-func decodeProviderFallback(text string) (providerKey string, ok bool) {
-	var p providerFallbackPayload
+func decodeProviderNotice(text string) (payload providerNoticePayload, ok bool) {
+	var p providerNoticePayload
 	if err := json.Unmarshal([]byte(text), &p); err != nil {
-		return "", false
+		return providerNoticePayload{}, false
 	}
-	if p.ProviderKey == "" {
-		return "", false
+	if p.ProviderKey == "" && p.Kind == "" {
+		return providerNoticePayload{}, false
 	}
-	return p.ProviderKey, true
+	return p, true
 }
 
 // firstNonEmpty 返回第一个非空白参数(全空白 → "")。会话级 provider_key 优先于
@@ -752,14 +777,15 @@ func firstNonEmpty(values ...string) string {
 }
 
 // noticeBlockToChatBlock 把持久化的 blocks.NoticeBlock 投影成前端 ChatBlock。
-// 供应商回退提示(本功能产出的 {"providerKey":..} 小 JSON)解回 ProviderKey、Text 置空
-// —— 前端走 t() 渲染;非结构化旧数据原样透传 Text。
+// 供应商回退/切换提示(本功能产出的结构化小 JSON)解回 ProviderKey + NoticeKind、
+// Text 置空 —— 前端走 t() 渲染;非结构化旧数据原样透传 Text。
 func noticeBlockToChatBlock(tb blocks.NoticeBlock) ChatBlock {
-	if key, ok := decodeProviderFallback(tb.Text); ok {
+	if p, ok := decodeProviderNotice(tb.Text); ok {
 		return ChatBlock{
 			Type:        "notice",
 			Level:       tb.Level,
-			ProviderKey: key,
+			ProviderKey: p.ProviderKey,
+			NoticeKind:  p.Kind,
 		}
 	}
 	return ChatBlock{Type: "notice", Level: tb.Level, Text: tb.Text}
@@ -3719,7 +3745,7 @@ func (s *chatSvc) prepareTurnRun(
 		// GatewayURL/Token 是 desktop 的 127.0.0.1，Provider 又含明文 APIKey，
 		// 都不跨机器；wire 透传 effectiveProviderKey（会话 provider_key 优先，
 		// 决策 9），daemon 按它从自己的配置解析；无会话 key 时回落 agent 绑定。
-		req.LLMProviderKey = firstNonEmpty(sess.ProviderKey, be.LLMProviderKey)
+		req.LLMProviderKey = effectiveProviderKey(sess, be)
 		req.Provider = nil
 	} else if shouldSignChatGateway(be) {
 		// Claude Code local 需要 gateway token 给 PostToolUse hook；Codex local

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -156,7 +156,7 @@ type ChatSvc interface {
 
 var defaultChat ChatSvc
 
-var defaultGateway httpgateway.TokenIssuer
+var defaultGateway httpgateway.TokenRouter
 
 func Chat() ChatSvc { return defaultChat }
 
@@ -186,7 +186,10 @@ func NewChat(emitter Emitter) ChatSvc {
 
 // RegisterGateway 由 bootstrap 注入 httpgateway 单例；
 // 没有注入时（早期单测、headless 启动）走 CLI 自身 login 路径。
-func RegisterGateway(g httpgateway.TokenIssuer) {
+//
+// 要的是 TokenRouter 而不是 TokenIssuer：chat flow 的 token 按会话 effective provider
+// 路由，且会话中途换供应商时要能在**不换 token 字符串**的前提下改它的路由目标（决策 3）。
+func RegisterGateway(g httpgateway.TokenRouter) {
 	defaultGateway = g
 	if s, ok := defaultChat.(*chatSvc); ok {
 		s.gateway = g
@@ -263,7 +266,7 @@ type chatSvc struct {
 	// tool_use_id 集合」。集合非空 = 该会话有后台 subagent 在跑。后台 subagent 易失
 	// (随 CLI 子进程/重启消失)，故不落库；重启后 map 空 = 0 天然正确。见 bg_running.go。
 	bgRunning sync.Map
-	gateway   httpgateway.TokenIssuer
+	gateway   httpgateway.TokenRouter
 	// chatTokens 缓存每个 chat session 的常驻 gateway token(sessionID int64 → token string)。
 	// 该 token 在 spawn 时烤进 claude 子进程 env 给 PostToolUse hook 用,子进程跨轮复用
 	// 时 env 不重建 —— 所以 token 必须签成永久(ttl=0)并跨轮稳定复用,否则长会话(>15min)
@@ -693,7 +696,8 @@ func (s *chatSvc) GetLaunchCommand(ctx context.Context, req *LaunchCommandReques
 	gatewayURL, gatewayToken := "", ""
 	if prov != nil && s.gateway != nil {
 		gatewayURL = s.gateway.URL()
-		if tok, terr := s.gateway.IssueToken(ctx, be, 0); terr == nil {
+		// 按 effective provider 签：复制出去的命令要打到这条会话实际用的那家。
+		if tok, terr := s.gateway.IssueTokenFor(ctx, be, prov.ProviderKey, 0); terr == nil {
 			gatewayToken = tok
 		}
 	}
@@ -3750,7 +3754,11 @@ func (s *chatSvc) prepareTurnRun(
 	} else if shouldSignChatGateway(be) {
 		// Claude Code local 需要 gateway token 给 PostToolUse hook；Codex local
 		// 没有 hook，不能覆盖其原生 login 并误打到本地 gateway。
-		req.GatewayURL, req.GatewayToken = s.signChatTokenFor(ctx, be, sess.ID)
+		//
+		// 按 prov 路由而不是 be.LLMProviderKey：prov 是 turn 入口按会话 provider_key
+		// 覆盖解析出来的那家（缺失/停用已回退过），也正是本轮 `--model` 用的那家 ——
+		// 会话换了供应商，token 的上游随之改变，字符串不变（决策 3）。
+		req.GatewayURL, req.GatewayToken = s.signChatTokenFor(ctx, be, sess.ID, providerKeyOf(prov))
 	}
 	switch agent_backend_entity.BackendType(be.Type) {
 	case agent_backend_entity.TypeClaudeCode:
@@ -4586,7 +4594,14 @@ func remoteProviderNotConfiguredError(ctx context.Context, providerKey string) e
 // 子进程手里的 token 过期、PostToolUse hook 撞 401、SteerInbox 整轮 drain 不到、
 // steer 被压到轮末 DrainPending。改成 ttl=0 永久 + 跨轮复用,寿命跟随子进程,
 // session 删除时由 Delete→revokeChatToken 撤销。
-func (s *chatSvc) signChatTokenFor(ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64) (string, string) {
+//
+// providerKey 是**本轮真正要跑的那家供应商**(turn 入口按会话 provider_key 覆盖解析后的
+// prov;回退过的话就是回退目标),token 按它路由。会话中途换了供应商时,下一轮走
+// SetTokenProvider 改既有 token 的路由目标而**不重签** —— 见上面那条不变量,重签等于
+// 让在跑的子进程手里那个立刻失效。空串 = CLI 自身登录态(token 只用于 hook inbox)。
+func (s *chatSvc) signChatTokenFor(
+	ctx context.Context, be *agent_backend_entity.AgentBackend, sessionID int64, providerKey string,
+) (string, string) {
 	if be == nil || s.gateway == nil {
 		return "", ""
 	}
@@ -4595,10 +4610,12 @@ func (s *chatSvc) signChatTokenFor(ctx context.Context, be *agent_backend_entity
 	}
 	if sessionID > 0 {
 		if v, ok := s.chatTokens.Load(sessionID); ok {
-			return s.gateway.URL(), v.(string)
+			tok := v.(string)
+			s.routeChatTokenTo(ctx, sessionID, tok, providerKey)
+			return s.gateway.URL(), tok
 		}
 	}
-	tok, err := s.gateway.IssueToken(ctx, be, 0)
+	tok, err := s.gateway.IssueTokenFor(ctx, be, providerKey, 0)
 	if err != nil {
 		return "", ""
 	}
@@ -4610,6 +4627,26 @@ func (s *chatSvc) signChatTokenFor(ctx context.Context, be *agent_backend_entity
 		}
 	}
 	return s.gateway.URL(), tok
+}
+
+// routeChatTokenTo 把会话常驻 token 的路由目标对齐到本轮的供应商(决策 3)。
+// token 字符串不变,所以已经烤进子进程 env 的那份继续可用;真的换了才记一条日志。
+// 找不到 entry = gateway 重启过(token 表只在内存里),此时子进程手里那个也已失效,
+// 记 warn 供排查,不在这里重签 —— 重签也救不回已 spawn 的子进程。
+func (s *chatSvc) routeChatTokenTo(ctx context.Context, sessionID int64, token, providerKey string) {
+	previous, ok := s.gateway.SetTokenProvider(token, providerKey)
+	if !ok {
+		logger.Ctx(ctx).Warn("chat_svc.routeChatTokenTo: session token missing from gateway",
+			zap.Int64("sessionId", sessionID),
+			zap.String("providerKey", providerKey))
+		return
+	}
+	if previous != providerKey {
+		logger.Ctx(ctx).Info("chat_svc.routeChatTokenTo: gateway token rerouted to new provider",
+			zap.Int64("sessionId", sessionID),
+			zap.String("previousProviderKey", previous),
+			zap.String("providerKey", providerKey))
+	}
 }
 
 // revokeChatToken 撤销并清掉某 session 的常驻 token。Delete 关闭常驻子进程后调用,

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -481,18 +481,75 @@ func (s *chatSvc) sessionLiteFromEntity(sess *chat_entity.Session) ChatSessionLi
 	}
 }
 
+// noticeOnlyMessage 报告一条消息是不是「只承载供应商切换 notice 的旁白行」。
+//
+// 切换 notice 是独立落库的一条消息(session_provider.go 的 appendProviderSwitchNotice):
+// role 是 assistant、块只有一个 NoticeBlock,但它不是一轮对话 —— 用户可以在轮中切换
+// 供应商(决策 8),NextSeq 就把它排在**在跑的那条 assistant 之后**。所以凡是「末条
+// assistant = 在跑的那一轮」的推导都必须跳过它。
+//
+// 判据是 kind == switch,而不是「块全是 notice」:回退 notice 由 runTurn 追加进**这一轮
+// 自己**的 assistant 消息,零内容收尾(发完立刻点停止)时那条消息的块正好只剩它 ——
+// 按「块全是 notice」判,一轮真实对话就会被当成旁白行跳过。
+//
+// 没有块 ≠ 旁白行:轮刚起时 assistant 行的 BlocksJSON 恒为 "[]",那是真实的一轮,必须
+// 认到它。解码失败同样不算旁白行 —— 一条读不出块的消息宁可当成真实轮,也不该把在跑的
+// turn 让给它后面的行。
+// 与前端 lib/notice-message.ts 的 isNoticeOnlyMessage 同一口径(那边跳的是同一批行)。
+func noticeOnlyMessage(m *chat_entity.Message) bool {
+	if m == nil {
+		return false
+	}
+	bs, err := m.GetBlocks()
+	if err != nil || len(bs) == 0 {
+		return false
+	}
+	for _, b := range bs {
+		var text string
+		switch tb := b.(type) {
+		case blocks.NoticeBlock:
+			text = tb.Text
+		case *blocks.NoticeBlock:
+			if tb == nil {
+				return false
+			}
+			text = tb.Text
+		default:
+			return false
+		}
+		if p, ok := decodeProviderNotice(text); !ok || p.Kind != providerNoticeKindSwitch {
+			return false
+		}
+	}
+	return true
+}
+
+// lastTurnAssistantIndex 返回最后一条**真实** assistant 消息的下标(没有 → -1)。
+// 供应商切换 notice 那类旁白行跳过,见 noticeOnlyMessage。
+// 先筛 role 再解块:旁白行必是 assistant,user 行不必为此付一次 blocks 解码。
+func lastTurnAssistantIndex(msgs []*chat_entity.Message) int {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i] == nil || msgs[i].Role != "assistant" {
+			continue
+		}
+		if noticeOnlyMessage(msgs[i]) {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
 // activeStreamName 给 LoadSession 用:turn 进行中时,让中途打开该会话的前端能重挂到
 // per-turn 实时流。per-turn 流名只在用户主动 Send 时由响应给出;子 agent 调用轮 / 自主轮等"非
-// 前端发起"的 turn 前端拿不到这个名字 —— 这里按在跑 turn 的(末条)assistant 消息把它重建出来,
-// 前端据此 openStream 续看。无活跃 turn / 还没建出 assistant 消息时返回空串。
+// 前端发起"的 turn 前端拿不到这个名字 —— 这里按在跑 turn 的(末条真实)assistant 消息把它
+// 重建出来,前端据此 openStream 续看。无活跃 turn / 还没建出 assistant 消息时返回空串。
 func activeStreamName(activeTurn bool, sessionID int64, msgs []*chat_entity.Message) string {
 	if !activeTurn {
 		return ""
 	}
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i] != nil && msgs[i].Role == "assistant" {
-			return StreamName(sessionID, msgs[i].ID)
-		}
+	if i := lastTurnAssistantIndex(msgs); i >= 0 {
+		return StreamName(sessionID, msgs[i].ID)
 	}
 	return ""
 }
@@ -629,15 +686,15 @@ func (s *chatSvc) LoadSession(ctx context.Context, req *LoadSessionRequest) (*Lo
 		}
 		resp.Messages = append(resp.Messages, cm)
 	}
-	// 进行中 turn 上挂起/已决的审批 block 还没 finalize 进消息行,overlay 到末条
+	// 进行中 turn 上挂起/已决的审批 block 还没 finalize 进消息行,overlay 到末条**真实**
 	// assistant 消息的投影,中途打开会话也能看到审批卡(finalize 时会真正落库)。
+	// 用 msgs 的下标定位(resp.Messages 与它逐条 1:1 投影),与 ActiveStream 同一口径 ——
+	// 两处若各挑各的行,前端就会把审批卡搬到一条没人 emit 的流上,resolved 反扫落空、
+	// 卡片永远 pending。旁白行(供应商切换 notice)不是一轮,见 lastTurnAssistantIndex。
 	if pend := s.snapshotToolApprovals(sess.ID); len(pend) > 0 {
-		for i := len(resp.Messages) - 1; i >= 0; i-- {
-			if resp.Messages[i].Role == "assistant" {
-				for _, b := range pend {
-					resp.Messages[i].Blocks = append(resp.Messages[i].Blocks, toolApprovalBlockToChatBlock(b))
-				}
-				break
+		if i := lastTurnAssistantIndex(msgs); i >= 0 {
+			for _, b := range pend {
+				resp.Messages[i].Blocks = append(resp.Messages[i].Blocks, toolApprovalBlockToChatBlock(b))
 			}
 		}
 	}

--- a/internal/service/chat_svc/chat_internal_test.go
+++ b/internal/service/chat_svc/chat_internal_test.go
@@ -340,12 +340,13 @@ func TestToChatMessage_NoticeBlockProjectionDecodesStructuredPayload(t *testing.
 // JSON 直接泄漏到界面上。
 func TestToChatMessage_NoticeBlockProjectionDecodesProviderSwitch(t *testing.T) {
 	cases := []struct {
-		name        string
-		text        string
-		providerKey string
+		name         string
+		text         string
+		providerKey  string
+		providerName string
 	}{
-		{name: "切到某个供应商", text: encodeProviderSwitch("key-99"), providerKey: "key-99"},
-		{name: "切回跟随 agent 绑定", text: encodeProviderSwitch(""), providerKey: ""},
+		{name: "切到某个供应商", text: encodeProviderSwitch("key-99", "中转 · GLM 5.2"), providerKey: "key-99", providerName: "中转 · GLM 5.2"},
+		{name: "切回跟随 agent 绑定", text: encodeProviderSwitch("", ""), providerKey: "", providerName: ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -360,6 +361,7 @@ func TestToChatMessage_NoticeBlockProjectionDecodesProviderSwitch(t *testing.T) 
 			assert.Equal(t, "notice", cm.Blocks[0].Type)
 			assert.Equal(t, "switch", cm.Blocks[0].NoticeKind, "前端据此选切换文案而非回退文案")
 			assert.Equal(t, tc.providerKey, cm.Blocks[0].ProviderKey)
+			assert.Equal(t, tc.providerName, cm.Blocks[0].ProviderName, "展示名随投影透传给前端")
 			assert.Empty(t, cm.Blocks[0].Text, "结构化负载不把原始 JSON 泄漏给前端")
 		})
 	}
@@ -370,7 +372,7 @@ func TestToChatMessage_NoticeBlockProjectionDecodesProviderSwitch(t *testing.T) 
 func TestToChatMessage_NoticeBlockProjectionKeepsFallbackKindEmpty(t *testing.T) {
 	m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
 	require.NoError(t, m.SetBlocks([]blocks.ContentBlock{
-		blocks.NoticeBlock{Level: "info", Text: encodeProviderFallback("gone-provider")},
+		blocks.NoticeBlock{Level: "info", Text: encodeProviderFallback("gone-provider", "")},
 	}))
 
 	cm, err := toChatMessage(m)

--- a/internal/service/chat_svc/chat_internal_test.go
+++ b/internal/service/chat_svc/chat_internal_test.go
@@ -334,6 +334,52 @@ func TestToChatMessage_NoticeBlockProjectionDecodesStructuredPayload(t *testing.
 	assert.Empty(t, cm.Blocks[0].Text)
 }
 
+// TestToChatMessage_NoticeBlockProjectionDecodesProviderSwitch 钉死切换 notice 的投影
+// (2026-08-10 决策 9):切回「跟随 agent 绑定」时负载里没有 providerKey,只有 kind ——
+// 投影必须靠 kind 认出它是结构化负载,否则会掉进「原样渲染 Text」的兜底分支,把原始
+// JSON 直接泄漏到界面上。
+func TestToChatMessage_NoticeBlockProjectionDecodesProviderSwitch(t *testing.T) {
+	cases := []struct {
+		name        string
+		text        string
+		providerKey string
+	}{
+		{name: "切到某个供应商", text: encodeProviderSwitch("key-99"), providerKey: "key-99"},
+		{name: "切回跟随 agent 绑定", text: encodeProviderSwitch(""), providerKey: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
+			require.NoError(t, m.SetBlocks([]blocks.ContentBlock{
+				blocks.NoticeBlock{Level: "info", Text: tc.text},
+			}))
+
+			cm, err := toChatMessage(m)
+			require.NoError(t, err)
+			require.Len(t, cm.Blocks, 1)
+			assert.Equal(t, "notice", cm.Blocks[0].Type)
+			assert.Equal(t, "switch", cm.Blocks[0].NoticeKind, "前端据此选切换文案而非回退文案")
+			assert.Equal(t, tc.providerKey, cm.Blocks[0].ProviderKey)
+			assert.Empty(t, cm.Blocks[0].Text, "结构化负载不把原始 JSON 泄漏给前端")
+		})
+	}
+}
+
+// TestToChatMessage_NoticeBlockProjectionKeepsFallbackKindEmpty 既有回退 notice(含全部
+// 旧数据)不带 kind:前端按空 kind 走回退文案,这一路不能被切换 notice 的新字段带偏。
+func TestToChatMessage_NoticeBlockProjectionKeepsFallbackKindEmpty(t *testing.T) {
+	m := &chat_entity.Message{ID: 1, SessionID: 9, Role: "assistant"}
+	require.NoError(t, m.SetBlocks([]blocks.ContentBlock{
+		blocks.NoticeBlock{Level: "info", Text: encodeProviderFallback("gone-provider")},
+	}))
+
+	cm, err := toChatMessage(m)
+	require.NoError(t, err)
+	require.Len(t, cm.Blocks, 1)
+	assert.Equal(t, "gone-provider", cm.Blocks[0].ProviderKey)
+	assert.Empty(t, cm.Blocks[0].NoticeKind)
+}
+
 func TestAskQuestionsToDTO_PreservesRequestUserInputMetadata(t *testing.T) {
 	got := chatblocks.QuestionsFromRuntime([]agentruntime.AskQuestion{{
 		ID:          "target",

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -88,6 +88,16 @@ func (f *fakeChatGateway) IssueToken(context.Context, *agent_backend_entity.Agen
 	return "chat-token", nil
 }
 
+func (f *fakeChatGateway) IssueTokenFor(
+	ctx context.Context, be *agent_backend_entity.AgentBackend, _ string, ttl time.Duration,
+) (string, error) {
+	return f.IssueToken(ctx, be, ttl)
+}
+
+func (f *fakeChatGateway) SetTokenProvider(_, providerKey string) (string, bool) {
+	return providerKey, true
+}
+
 func (f *fakeChatGateway) RevokeToken(string) {}
 
 func (f *fakeChatGateway) URL() string {

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -3004,6 +3004,43 @@ func TestGoal_CodexRoutesToGoalController(t *testing.T) {
 	})
 }
 
+// TestGoal_UsesSessionEffectiveProvider 钉死 /goal 入口的供应商口径：goal 与 turn 必须
+// 落在同一家供应商上（会话 provider_key > agent 绑定，spec 2026-08-10「有效供应商解析
+// （唯一口径）」）。
+//
+// goal 与 turn 共用同一个 codex app-server 会话池：acquireSession 的启动期比对键是
+// (effectiveModel, effectiveProviderKey)（决策 4），goal 侧若还按 agent 绑定解析
+// Provider，两边比对键就不一致 —— 一次 /goal 会把这条会话正在用的 app-server evict 掉
+// 重 spawn（下一轮 turn 再 evict 一次），而且这次 goal 本身就打在用户没选的那家上游。
+// 登录态后端（backend 未绑定、会话自己选了一家）是最直接的形态：Provider 会整个丢成 nil。
+func TestGoal_UsesSessionEffectiveProvider(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := m.ctx
+	runner := &goalRecordingRunner{recordingRunner: &recordingRunner{requests: make(chan agentruntime.RunRequest, 1)}}
+	t.Cleanup(agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeCodex, runner))
+
+	m.session.EXPECT().Find(gomock.Any(), int64(100)).Return(&chat_entity.Session{
+		ID: 100, AgentID: 7, AgentStatus: "idle", Status: consts.ACTIVE,
+		ProviderSessionID: "codex-thread-123", ProviderKey: "session-picked",
+	}, nil)
+	m.agent.EXPECT().Find(gomock.Any(), int64(7)).Return(&agent_entity.Agent{
+		ID: 7, Name: "Codex", AgentBackendID: 12, Status: consts.ACTIVE, PromptJSON: `[]`,
+	}, nil)
+	// 登录态 codex 后端：这一档没绑供应商，会话自己选了一家接管。
+	m.backend.EXPECT().Find(gomock.Any(), int64(12)).Return(&agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeCodex), LLMProviderKey: "", Status: consts.ACTIVE,
+	}, nil)
+	m.provider.EXPECT().FindByKey(gomock.Any(), "session-picked").Return(&llm_provider_entity.LLMProvider{
+		ID: 34, ProviderKey: "session-picked", Type: string(llm_provider_entity.TypeOpenAIResponse),
+		Model: "gpt-session", Status: consts.ACTIVE,
+	}, nil)
+
+	_, err := m.svc.GetGoal(ctx, &chat_svc.GoalRequest{SessionID: 100})
+	require.NoError(t, err)
+	require.NotNil(t, runner.getReq.Provider, "goal 必须带上本会话的 effective provider，而不是 agent 绑定")
+	assert.Equal(t, "session-picked", runner.getReq.Provider.ProviderKey)
+}
+
 func TestStartGoal_CreatesCodexSessionAndSetsGoalBeforeFirstTurn(t *testing.T) {
 	convey.Convey("Given a new Codex chat, when setting /goal before the first message, then a provider thread is created and stored without creating chat messages", t, func() {
 		m := setupChatTest(t)

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -2471,6 +2471,73 @@ func TestSend_CodexLocalDoesNotInjectGatewayDeps(t *testing.T) {
 	}
 }
 
+// TestSend_CodexLoginStateWithSessionProviderInjectsGatewayDeps 钉死 spec 2026-08-10
+// 决策 6/问题 3:CLI 登录态 codex 后端(agent 未绑 LLM provider)上,会话选了一个
+// agentre 供应商(sess.ProviderKey)时也要签网关 token、把 GatewayURL/Token 装进
+// RunRequest —— shouldSignChatGateway 的门控必须看本轮 effective provider(prov),
+// 不能只看 be.LLMProviderKey,否则决策 7(登录态双向可切)在 codex 上从未兑现。
+// 与 TestSend_CodexLocalDoesNotInjectGatewayDeps(无 effective provider 时不装配)
+// 互为正反例。
+func TestSend_CodexLoginStateWithSessionProviderInjectsGatewayDeps(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := m.ctx
+	chat_svc.RegisterGateway(&fakeChatGateway{
+		status: httpgateway.GatewayStatus{State: "running", URL: "http://127.0.0.1:60080"},
+		token:  "chat-token",
+	})
+	t.Cleanup(func() { chat_svc.RegisterGateway(nil) })
+
+	runner := &recordingRunner{requests: make(chan agentruntime.RunRequest, 1)}
+	restore := agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeCodex, runner)
+	t.Cleanup(restore)
+
+	sess := &chat_entity.Session{
+		ID: 100, AgentID: 7, AgentStatus: "idle", Status: consts.ACTIVE, ProviderKey: "session-picked",
+	}
+	m.session.EXPECT().Find(gomock.Any(), int64(100)).Return(sess, nil)
+	m.agent.EXPECT().Find(gomock.Any(), int64(7)).Return(&agent_entity.Agent{
+		ID: 7, Name: "Codex Local", AgentBackendID: 12, Status: consts.ACTIVE, PromptJSON: `[]`,
+	}, nil)
+	m.backend.EXPECT().Find(gomock.Any(), int64(12)).Return(&agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeCodex), LLMProviderKey: "", Status: consts.ACTIVE,
+	}, nil)
+	m.provider.EXPECT().FindByKey(gomock.Any(), "session-picked").
+		Return(newActiveProvider("session-picked", string(llm_provider_entity.TypeOpenAIResponse)), nil)
+	m.session.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
+
+	m.dbMock.ExpectBegin()
+	m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(3, nil)
+	m.message.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, msg *chat_entity.Message) error {
+			if msg.Role == "user" {
+				msg.ID = 1000
+			} else {
+				msg.ID = 1001
+			}
+			return nil
+		}).Times(2)
+	m.dbMock.ExpectCommit()
+	m.message.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
+
+	resp, err := m.svc.Send(ctx, &chat_svc.SendRequest{
+		SessionID: 100,
+		AgentID:   7,
+		Text:      "hi",
+	})
+	assert.NoError(t, err)
+	chat_svc.WaitForStreamForTest(m.svc, resp.AssistantMessageID)
+
+	select {
+	case req := <-runner.requests:
+		assert.NotEmpty(t, req.GatewayURL, "登录态后端上会话选了供应商也要装配网关 URL")
+		assert.NotEmpty(t, req.GatewayToken, "登录态后端上会话选了供应商也要签网关 token")
+		require.NotNil(t, req.Provider)
+		assert.Equal(t, "session-picked", req.Provider.ProviderKey)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runtime request")
+	}
+}
+
 func TestCompact_CodexStartsCompactTurnWithoutUserMessage(t *testing.T) {
 	m := setupChatTest(t)
 	ctx := m.ctx

--- a/internal/service/chat_svc/chat_token_test.go
+++ b/internal/service/chat_svc/chat_token_test.go
@@ -7,7 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cago-frame/cago/pkg/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/agent_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/chat_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/llm_provider_entity"
+	"github.com/agentre-ai/agentre/internal/pkg/agentruntime"
 	"github.com/agentre-ai/agentre/internal/pkg/httpgateway"
 )
 
@@ -15,10 +23,13 @@ import (
 // with, hands back a distinct token per call, and records revocations — enough
 // to assert the chat hook token is permanent + stable per session.
 type recordingGateway struct {
-	mu      sync.Mutex
-	issued  int
-	ttls    []time.Duration
-	revoked []string
+	mu        sync.Mutex
+	issued    int
+	ttls      []time.Duration
+	revoked   []string
+	issuedFor []string          // 每次签发时传入的 provider key
+	rerouted  []string          // 每次「改路由不换 token」的调用
+	routes    map[string]string // token → 当前路由到的 provider key
 }
 
 func (g *recordingGateway) IssueToken(_ context.Context, _ *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error) {
@@ -27,6 +38,40 @@ func (g *recordingGateway) IssueToken(_ context.Context, _ *agent_backend_entity
 	g.issued++
 	g.ttls = append(g.ttls, ttl)
 	return fmt.Sprintf("tok-%d", g.issued), nil
+}
+
+func (g *recordingGateway) IssueTokenFor(_ context.Context, _ *agent_backend_entity.AgentBackend, providerKey string, ttl time.Duration) (string, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.issued++
+	g.ttls = append(g.ttls, ttl)
+	g.issuedFor = append(g.issuedFor, providerKey)
+	tok := fmt.Sprintf("tok-%d", g.issued)
+	g.routes[tok] = providerKey
+	return tok, nil
+}
+
+func (g *recordingGateway) SetTokenProvider(token, providerKey string) (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	prev, ok := g.routes[token]
+	if !ok {
+		return "", false
+	}
+	g.routes[token] = providerKey
+	g.rerouted = append(g.rerouted, token+"→"+providerKey)
+	return prev, true
+}
+
+// routeOf 返回该 token 当前的路由目标（测试断言用）。
+func (g *recordingGateway) routeOf(token string) string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.routes[token]
+}
+
+func newRecordingGateway() *recordingGateway {
+	return &recordingGateway{routes: map[string]string{}}
 }
 func (g *recordingGateway) RevokeToken(t string) {
 	g.mu.Lock()
@@ -50,12 +95,12 @@ func claudeBackendFixture() *agent_backend_entity.AgentBackend {
 // PostToolUse hook gets 401 on /hook/v1/inbox → the SteerInbox is never drained
 // mid-turn.
 func TestSignChatTokenFor_PermanentAndStablePerSession(t *testing.T) {
-	gw := &recordingGateway{}
+	gw := newRecordingGateway()
 	s := &chatSvc{gateway: gw}
 	be := claudeBackendFixture()
 
-	url1, tok1 := s.signChatTokenFor(context.Background(), be, 42)
-	_, tok2 := s.signChatTokenFor(context.Background(), be, 42) // next turn, same session
+	url1, tok1 := s.signChatTokenFor(context.Background(), be, 42, "")
+	_, tok2 := s.signChatTokenFor(context.Background(), be, 42, "") // next turn, same session
 
 	if url1 == "" || tok1 == "" {
 		t.Fatalf("expected signed url+token, got url=%q tok=%q", url1, tok1)
@@ -76,12 +121,12 @@ func TestSignChatTokenFor_PermanentAndStablePerSession(t *testing.T) {
 // TestSignChatTokenFor_DistinctPerSession guards that the per-session cache keys
 // correctly — different sessions must not share a token.
 func TestSignChatTokenFor_DistinctPerSession(t *testing.T) {
-	gw := &recordingGateway{}
+	gw := newRecordingGateway()
 	s := &chatSvc{gateway: gw}
 	be := claudeBackendFixture()
 
-	_, a := s.signChatTokenFor(context.Background(), be, 1)
-	_, b := s.signChatTokenFor(context.Background(), be, 2)
+	_, a := s.signChatTokenFor(context.Background(), be, 1, "")
+	_, b := s.signChatTokenFor(context.Background(), be, 2, "")
 	if a == b {
 		t.Fatalf("distinct sessions must get distinct tokens: s1=%q s2=%q", a, b)
 	}
@@ -91,21 +136,106 @@ func TestSignChatTokenFor_DistinctPerSession(t *testing.T) {
 // CloseSession) revokes its permanent token and drops the cache entry, so a
 // future same-id session re-mints a fresh one (no stale-token reuse, no leak).
 func TestRevokeChatToken_RevokesAndEvicts(t *testing.T) {
-	gw := &recordingGateway{}
+	gw := newRecordingGateway()
 	s := &chatSvc{gateway: gw}
 	be := claudeBackendFixture()
 
-	_, tok := s.signChatTokenFor(context.Background(), be, 42)
+	_, tok := s.signChatTokenFor(context.Background(), be, 42, "")
 	s.revokeChatToken(42)
 
 	if len(gw.revoked) != 1 || gw.revoked[0] != tok {
 		t.Fatalf("revokeChatToken must revoke session token %q; revoked=%v", tok, gw.revoked)
 	}
-	_, tok2 := s.signChatTokenFor(context.Background(), be, 42)
+	_, tok2 := s.signChatTokenFor(context.Background(), be, 42, "")
 	if tok2 == tok {
 		t.Fatalf("after revoke the re-signed token must be fresh; got same %q", tok2)
 	}
 	if gw.issued != 2 {
 		t.Fatalf("expected a re-mint after revoke; issued=%d", gw.issued)
 	}
+}
+
+// TestSignChatTokenFor_IssuesForEffectiveProvider 钉死决策 3 的签发侧：首轮就按本轮的
+// effective provider（会话 provider_key > agent 绑定）签 token，而不是按 agent 绑定 ——
+// 否则会话选了 X、CLI 的请求还是打到 agent 绑定那家。
+func TestSignChatTokenFor_IssuesForEffectiveProvider(t *testing.T) {
+	gw := newRecordingGateway()
+	s := &chatSvc{gateway: gw}
+	be := claudeBackendFixture()
+	be.LLMProviderKey = "agent-bound"
+
+	_, tok := s.signChatTokenFor(context.Background(), be, 42, "session-picked")
+
+	if got := gw.routeOf(tok); got != "session-picked" {
+		t.Fatalf("token must route to the effective provider; routed to %q", got)
+	}
+	if len(gw.issuedFor) != 1 || gw.issuedFor[0] != "session-picked" {
+		t.Fatalf("expected exactly one issue for the effective provider; issuedFor=%v", gw.issuedFor)
+	}
+}
+
+// TestSignChatTokenFor_SwitchReroutesWithoutReissuing 钉死决策 3 的切换侧：会话换了供应
+// 商后的下一轮，token **字符串必须不变**（它首轮就烤进了 CLI 子进程 env，重签 = 在跑的
+// 子进程立刻 401，正是被修过的那次事故），改的只是它在网关里的路由目标。
+func TestSignChatTokenFor_SwitchReroutesWithoutReissuing(t *testing.T) {
+	gw := newRecordingGateway()
+	s := &chatSvc{gateway: gw}
+	be := claudeBackendFixture()
+	be.LLMProviderKey = "agent-bound"
+
+	_, tok1 := s.signChatTokenFor(context.Background(), be, 42, "agent-bound")
+	_, tok2 := s.signChatTokenFor(context.Background(), be, 42, "session-picked") // 切换后的下一轮
+
+	if tok1 != tok2 {
+		t.Fatalf("provider switch must NOT change the session token: before=%q after=%q", tok1, tok2)
+	}
+	if gw.issued != 1 {
+		t.Fatalf("provider switch must not re-issue a token; issued=%d", gw.issued)
+	}
+	if got := gw.routeOf(tok2); got != "session-picked" {
+		t.Fatalf("existing token must be re-routed to the new provider; routed to %q", got)
+	}
+	if len(gw.rerouted) != 1 {
+		t.Fatalf("expected exactly one re-route call; got %v", gw.rerouted)
+	}
+
+	// 同一供应商的续轮不再重复改路由（避免每轮都写一次 + 刷日志）。
+	_, tok3 := s.signChatTokenFor(context.Background(), be, 42, "session-picked")
+	if tok3 != tok1 {
+		t.Fatalf("unchanged provider must keep the same token; got %q", tok3)
+	}
+	if got := gw.routeOf(tok3); got != "session-picked" {
+		t.Fatalf("route must stay on the switched provider; routed to %q", got)
+	}
+}
+
+// TestPrepareTurnRun_LocalTokenRoutesToTurnProvider 钉死桌面 turn 路径这一端：本地 CLI
+// 后端组装 RunRequest 时，交给子进程的那个 gateway token 必须路由到**本轮真正要跑的那家
+// 供应商**（turn 入口已按会话 provider_key 覆盖解析过的 prov），而不是 agent 绑定。
+func TestPrepareTurnRun_LocalTokenRoutesToTurnProvider(t *testing.T) {
+	gw := newRecordingGateway()
+	s := &chatSvc{gateway: gw}
+	runner := &directRunRunner{request: make(chan agentruntime.RunRequest, 1)}
+	t.Cleanup(agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner))
+	prevCwd := resolveCwdFn
+	t.Cleanup(func() { resolveCwdFn = prevCwd })
+	dir := t.TempDir()
+	resolveCwdFn = func(context.Context, *chat_entity.Session) (string, error) { return dir, nil }
+
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, ProviderKey: "session-picked"}
+	a := &agent_entity.Agent{ID: 7, AgentBackendID: 12}
+	be := &agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "agent-bound",
+	}
+	prov := &llm_provider_entity.LLMProvider{
+		ProviderKey: "session-picked", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-x", Status: consts.ACTIVE,
+	}
+
+	prepared, err := s.prepareTurnRun(context.Background(), sess, a, be, prov, nil, nil, "", false, false)
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	require.NotEmpty(t, prepared.req.GatewayToken, "本地 claudecode 仍要签 token")
+	assert.Equal(t, "session-picked", gw.routeOf(prepared.req.GatewayToken),
+		"token 必须路由到本轮的 provider，而不是 agent 绑定")
 }

--- a/internal/service/chat_svc/chat_token_test.go
+++ b/internal/service/chat_svc/chat_token_test.go
@@ -258,7 +258,7 @@ func TestPrepareTurnRun_LocalTokenRoutesToTurnProvider(t *testing.T) {
 // 反向那一半是硬不变量 1：整轮压根没有 effective provider（真·CLI 登录态）时行为完全不变
 // —— 照常起轮，只是不带网关参数。
 func TestPrepareTurnRun_SessionProviderNeedsRunningGateway(t *testing.T) {
-	newTurn := func(t *testing.T, prov *llm_provider_entity.LLMProvider) (*chatSvc, *chat_entity.Session, *agent_entity.Agent, *agent_backend_entity.AgentBackend) {
+	newTurn := func(t *testing.T) (*chatSvc, *chat_entity.Session, *agent_entity.Agent, *agent_backend_entity.AgentBackend) {
 		t.Helper()
 		runner := &directRunRunner{request: make(chan agentruntime.RunRequest, 1)}
 		t.Cleanup(agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner))
@@ -279,7 +279,7 @@ func TestPrepareTurnRun_SessionProviderNeedsRunningGateway(t *testing.T) {
 			ProviderKey: "session-picked", Type: string(llm_provider_entity.TypeAnthropic),
 			Model: "claude-x", Status: consts.ACTIVE,
 		}
-		s, sess, a, be := newTurn(t, prov)
+		s, sess, a, be := newTurn(t)
 		sess.ProviderKey = "session-picked"
 
 		_, err := s.prepareTurnRun(context.Background(), sess, a, be, prov, nil, nil, "", false, false)
@@ -287,7 +287,7 @@ func TestPrepareTurnRun_SessionProviderNeedsRunningGateway(t *testing.T) {
 	})
 
 	t.Run("真·CLI 登录态（无任何供应商）不受影响：照常起轮、不带网关参数", func(t *testing.T) {
-		s, sess, a, be := newTurn(t, nil)
+		s, sess, a, be := newTurn(t)
 
 		prepared, err := s.prepareTurnRun(context.Background(), sess, a, be, nil, nil, nil, "", false, false)
 		require.NoError(t, err)
@@ -295,4 +295,37 @@ func TestPrepareTurnRun_SessionProviderNeedsRunningGateway(t *testing.T) {
 		assert.Empty(t, prepared.req.GatewayToken)
 		assert.Empty(t, prepared.req.GatewayURL)
 	})
+}
+
+// TestPrepareTurnRun_PiAgentSessionProviderRunsWithoutGateway 是上面那条门控的边界：
+// 「有 effective provider 就必须有网关」只对**把 LLM 流量指向本机网关**的后端成立
+// （claudecode 的 ANTHROPIC_BASE_URL / codex 的 model_provider 都是启动期从网关派生的）。
+// pi-agent 不走网关 —— 它把 provider.APIKey 直接注进子进程 env
+// （agentruntime.BuildPiAgentProviderEnv），GatewayURL/Token 在整个 piagent runtime 里
+// 没有任何消费点。所以网关没在跑时这一轮照样能正常执行，把它打成
+// ChatBackendGatewayUnavailable 等于凭空失败一条本来跑得通的会话。
+func TestPrepareTurnRun_PiAgentSessionProviderRunsWithoutGateway(t *testing.T) {
+	runner := &directRunRunner{request: make(chan agentruntime.RunRequest, 1)}
+	t.Cleanup(agentruntime.SwapRuntimeForTest(agent_backend_entity.TypePiAgent, runner))
+	prevCwd := resolveCwdFn
+	t.Cleanup(func() { resolveCwdFn = prevCwd })
+	dir := t.TempDir()
+	resolveCwdFn = func(context.Context, *chat_entity.Session) (string, error) { return dir, nil }
+
+	s := &chatSvc{gateway: newStoppedGateway()}
+	// 登录态 pi 后端（这一档没绑供应商）+ 会话自己选了一个 agentre 供应商。
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, ProviderKey: "session-picked"}
+	a := &agent_entity.Agent{ID: 7, AgentBackendID: 12}
+	be := &agent_backend_entity.AgentBackend{ID: 12, Type: string(agent_backend_entity.TypePiAgent)}
+	prov := &llm_provider_entity.LLMProvider{
+		ProviderKey: "session-picked", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-x", APIKey: "sk-x", Status: consts.ACTIVE,
+	}
+
+	prepared, err := s.prepareTurnRun(context.Background(), sess, a, be, prov, nil, nil, "", false, false)
+	require.NoError(t, err, "pi 不经网关取 LLM，网关没在跑不该把这一轮打成失败")
+	require.NotNil(t, prepared)
+	require.NotNil(t, prepared.req.Provider)
+	assert.Equal(t, "session-picked", prepared.req.Provider.ProviderKey,
+		"所选供应商仍随 RunRequest 下发 —— pi 从它取 APIKey")
 }

--- a/internal/service/chat_svc/chat_token_test.go
+++ b/internal/service/chat_svc/chat_token_test.go
@@ -207,10 +207,17 @@ func TestSignChatTokenFor_SwitchReroutesWithoutReissuing(t *testing.T) {
 		t.Fatalf("expected exactly one re-route call; got %v", gw.rerouted)
 	}
 
-	// 同一供应商的续轮不再重复改路由（避免每轮都写一次 + 刷日志）。
+	// 同一供应商的续轮照样把路由重申一遍（幂等，且 gateway 重启丢表时能立刻被
+	// SetTokenProvider 的 ok=false 探到并告警）；变的只有日志——只有真换了才记一条。
 	_, tok3 := s.signChatTokenFor(context.Background(), be, 42, "session-picked")
 	if tok3 != tok1 {
 		t.Fatalf("unchanged provider must keep the same token; got %q", tok3)
+	}
+	if len(gw.rerouted) != 2 {
+		t.Fatalf("每轮都要重申一次路由（幂等）；got %v", gw.rerouted)
+	}
+	if gw.issued != 1 {
+		t.Fatalf("续轮不得再签一个 token; issued=%d", gw.issued)
 	}
 	if got := gw.routeOf(tok3); got != "session-picked" {
 		t.Fatalf("route must stay on the switched provider; routed to %q", got)

--- a/internal/service/chat_svc/chat_token_test.go
+++ b/internal/service/chat_svc/chat_token_test.go
@@ -30,6 +30,7 @@ type recordingGateway struct {
 	issuedFor []string          // 每次签发时传入的 provider key
 	rerouted  []string          // 每次「改路由不换 token」的调用
 	routes    map[string]string // token → 当前路由到的 provider key
+	state     string            // GatewayStatus.State；newRecordingGateway 默认 running
 }
 
 func (g *recordingGateway) IssueToken(_ context.Context, _ *agent_backend_entity.AgentBackend, ttl time.Duration) (string, error) {
@@ -71,7 +72,14 @@ func (g *recordingGateway) routeOf(token string) string {
 }
 
 func newRecordingGateway() *recordingGateway {
-	return &recordingGateway{routes: map[string]string{}}
+	return &recordingGateway{routes: map[string]string{}, state: "running"}
+}
+
+// newStoppedGateway 是「网关已注入但没在跑」（用户在设置里停了本机网关 / 端口占用起不来）。
+func newStoppedGateway() *recordingGateway {
+	g := newRecordingGateway()
+	g.state = "stopped"
+	return g
 }
 func (g *recordingGateway) RevokeToken(t string) {
 	g.mu.Lock()
@@ -80,7 +88,7 @@ func (g *recordingGateway) RevokeToken(t string) {
 }
 func (g *recordingGateway) URL() string { return "http://gw" }
 func (g *recordingGateway) Status() httpgateway.GatewayStatus {
-	return httpgateway.GatewayStatus{State: "running"}
+	return httpgateway.GatewayStatus{State: g.state}
 }
 
 func claudeBackendFixture() *agent_backend_entity.AgentBackend {
@@ -238,4 +246,53 @@ func TestPrepareTurnRun_LocalTokenRoutesToTurnProvider(t *testing.T) {
 	require.NotEmpty(t, prepared.req.GatewayToken, "本地 claudecode 仍要签 token")
 	assert.Equal(t, "session-picked", gw.routeOf(prepared.req.GatewayToken),
 		"token 必须路由到本轮的 provider，而不是 agent 绑定")
+}
+
+// TestPrepareTurnRun_SessionProviderNeedsRunningGateway 钉死规格「登录态与后端可用性」：
+// 未绑供应商的 CLI 登录态会话选了一个 agentre 供应商接管时，「该轮起签发网关 token、装配
+// 网关 env / config，请求经本机网关转发到所选供应商」—— 网关没在跑就装不上 ANTHROPIC_*
+// / codex model_provider，子进程会**静默**退回 CLI 自身登录态、把这段对话打到用户没选的
+// 那家上游。这一轮存在 effective provider 却拿不到网关，必须与「backend 已绑 provider 时
+// resolveAgentBackend 直接报 ChatBackendGatewayUnavailable」同一口径地报错，不静默降级。
+//
+// 反向那一半是硬不变量 1：整轮压根没有 effective provider（真·CLI 登录态）时行为完全不变
+// —— 照常起轮，只是不带网关参数。
+func TestPrepareTurnRun_SessionProviderNeedsRunningGateway(t *testing.T) {
+	newTurn := func(t *testing.T, prov *llm_provider_entity.LLMProvider) (*chatSvc, *chat_entity.Session, *agent_entity.Agent, *agent_backend_entity.AgentBackend) {
+		t.Helper()
+		runner := &directRunRunner{request: make(chan agentruntime.RunRequest, 1)}
+		t.Cleanup(agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner))
+		prevCwd := resolveCwdFn
+		t.Cleanup(func() { resolveCwdFn = prevCwd })
+		dir := t.TempDir()
+		resolveCwdFn = func(context.Context, *chat_entity.Session) (string, error) { return dir, nil }
+
+		return &chatSvc{gateway: newStoppedGateway()},
+			&chat_entity.Session{ID: 100, AgentID: 7},
+			&agent_entity.Agent{ID: 7, AgentBackendID: 12},
+			// 登录态：agent 这一档没绑任何供应商。
+			&agent_backend_entity.AgentBackend{ID: 12, Type: string(agent_backend_entity.TypeClaudeCode)}
+	}
+
+	t.Run("会话选了供应商但网关没在跑 → 报错而不是退回 CLI 登录态", func(t *testing.T) {
+		prov := &llm_provider_entity.LLMProvider{
+			ProviderKey: "session-picked", Type: string(llm_provider_entity.TypeAnthropic),
+			Model: "claude-x", Status: consts.ACTIVE,
+		}
+		s, sess, a, be := newTurn(t, prov)
+		sess.ProviderKey = "session-picked"
+
+		_, err := s.prepareTurnRun(context.Background(), sess, a, be, prov, nil, nil, "", false, false)
+		require.Error(t, err, "本轮有 effective provider 却没有网关，必须报错")
+	})
+
+	t.Run("真·CLI 登录态（无任何供应商）不受影响：照常起轮、不带网关参数", func(t *testing.T) {
+		s, sess, a, be := newTurn(t, nil)
+
+		prepared, err := s.prepareTurnRun(context.Background(), sess, a, be, nil, nil, nil, "", false, false)
+		require.NoError(t, err)
+		require.NotNil(t, prepared)
+		assert.Empty(t, prepared.req.GatewayToken)
+		assert.Empty(t, prepared.req.GatewayURL)
+	})
 }

--- a/internal/service/chat_svc/provider_key_internal_test.go
+++ b/internal/service/chat_svc/provider_key_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/agentre-ai/agentre/internal/repository/chat_repo/mock_chat_repo"
 	"github.com/agentre-ai/agentre/internal/repository/llm_provider_repo"
 	"github.com/agentre-ai/agentre/internal/repository/llm_provider_repo/mock_llm_provider_repo"
+	chatblocks "github.com/agentre-ai/agentre/internal/service/chat_svc/blocks"
 )
 
 // directRunRunner 记录下发的 RunRequest 并回一个固定实际模型，供 runTurn 直连测试用。
@@ -292,4 +293,61 @@ func TestSessionProviderOverride_FallbackNoticeOmitsNameWhenProviderGone(t *test
 
 	require.NotNil(t, notice)
 	assert.JSONEq(t, `{"providerKey":"gone-key"}`, notice.Text)
+}
+
+// TestLoadSession_OverlaysApprovalOntoInFlightTurnNotNoticeRow 钉死:轮中切换供应商会把
+// 一条只承载 notice 的旁白行(appendProviderSwitchNotice,role=assistant,NextSeq 排在
+// 在跑的 assistant 之后)追加进 transcript。LoadSession 里两处「末条 assistant」推导都
+// 必须跳过它:
+//   - ActiveStream 指到旁白行 → 重挂的前端订上一条没人 emit 的流名,余下的流式内容全
+//     看不见、也等不到终态;
+//   - 待决审批 overlay 挂到旁白行 → 前端把 pending 卡搬到那一行,resolved 事件按在跑
+//     那条的 id 反扫 liveBlocks 落空 → 卡片永远 pending。
+//
+// producer 侧钉死:前端跳过旁白行的那一半(use-chat-session)单独修不好这个 —— 后端
+// 一旦把审批块塞进旁白行,那行就不再「只有 notice」,前端反而正好挑中它。
+func TestLoadSession_OverlaysApprovalOntoInFlightTurnNotNoticeRow(t *testing.T) {
+	m, ctx := setupDirectRunTest(t)
+	s := NewChat(NoopEmitter{}).(*chatSvc)
+
+	noticeRow := &chat_entity.Message{ID: 43, SessionID: 9, Role: "assistant", Seq: 3}
+	require.NoError(t, noticeRow.SetBlocks([]blocks.ContentBlock{blocks.NoticeBlock{
+		Level: "info", Text: encodeProviderSwitch("session-key", "中转 · GLM 5.2"),
+	}}))
+
+	m.session.EXPECT().Find(ctx, int64(9)).Return(&chat_entity.Session{
+		ID: 9, AgentID: 7, AgentStatus: "running", Status: consts.ACTIVE,
+	}, nil)
+	m.agent.EXPECT().Find(ctx, int64(7)).Return(nil, nil)
+	m.message.EXPECT().List(ctx, int64(9)).Return([]*chat_entity.Message{
+		{ID: 41, SessionID: 9, Role: "user", BlocksJSON: "[]", Seq: 1},
+		{ID: 42, SessionID: 9, Role: "assistant", BlocksJSON: "[]", Seq: 2},
+		noticeRow,
+	}, nil)
+
+	// 活跃 turn + 一条挂起审批:LoadSession 的 overlay 分支的两个前提。
+	s.activeCancels.Store(int64(9), &activeTurnControl{})
+	s.toolApprovals[9] = []*chatblocks.ToolApprovalBlock{
+		{RequestID: "org-1", ToolName: "org_create_department", Status: "pending"},
+	}
+
+	resp, err := s.LoadSession(ctx, &LoadSessionRequest{SessionID: 9})
+	require.NoError(t, err)
+
+	assert.Equal(t, StreamName(9, 42), resp.Session.ActiveStream,
+		"重挂的流名要指向在跑的那一轮,不是切换 notice 的旁白行")
+	require.Len(t, resp.Messages, 3)
+	assert.True(t, hasToolApprovalBlock(resp.Messages[1]),
+		"待决审批 overlay 挂在在跑的 assistant(42)上")
+	assert.False(t, hasToolApprovalBlock(resp.Messages[2]),
+		"旁白行不该被塞进审批卡 —— 塞了它就不再『只有 notice』,前端的跳过也就跟着失效")
+}
+
+func hasToolApprovalBlock(cm ChatMessage) bool {
+	for _, b := range cm.Blocks {
+		if b.Type == "tool_approval" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/chat_svc/provider_key_internal_test.go
+++ b/internal/service/chat_svc/provider_key_internal_test.go
@@ -115,7 +115,7 @@ func TestRunTurn_ProviderFallbackAppendsPersistentNotice(t *testing.T) {
 		}).AnyTimes()
 
 	s.runTurn(ctx, sess, a, be, prov, nil, assistant, "stream", "", false, nil, turnExtras{
-		providerFallbackNotice: &blocks.NoticeBlock{Level: "info", Text: encodeProviderFallback("gone-provider")},
+		providerFallbackNotice: &blocks.NoticeBlock{Level: "info", Text: encodeProviderFallback("gone-provider", "")},
 	})
 
 	select {
@@ -255,4 +255,41 @@ func TestRunTurn_RemoteFallbackSignalAppendsPersistentNotice(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(notice.Text), &payload))
 	assert.Equal(t, "gone-provider", payload.ProviderKey, "持久 notice 携带被回退的会话 provider_key")
+}
+
+// TestSessionProviderOverride_FallbackNoticeCarriesProviderName 钉死设计决策 2：会话
+// 所选供应商还在(只是停用/类型不兼容)时,回退 notice 一并带上它的展示名 —— 与切换
+// notice 同源同形,同一次改动覆盖。
+func TestSessionProviderOverride_FallbackNoticeCarriesProviderName(t *testing.T) {
+	m, ctx := setupDirectRunTest(t)
+	s := NewChat(NoopEmitter{}).(*chatSvc)
+	be := &agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), Status: consts.ACTIVE,
+	}
+	m.provider.EXPECT().FindByKey(ctx, "stale-key").Return(&llm_provider_entity.LLMProvider{
+		ProviderKey: "stale-key", Name: "中转 · GLM 5.2",
+		Type: string(llm_provider_entity.TypeAnthropic), Status: consts.DELETE,
+	}, nil)
+
+	_, notice := s.sessionProviderOverride(ctx, be, "stale-key", nil)
+
+	require.NotNil(t, notice)
+	assert.JSONEq(t, `{"providerKey":"stale-key","providerName":"中转 · GLM 5.2"}`, notice.Text)
+}
+
+// TestSessionProviderOverride_FallbackNoticeOmitsNameWhenProviderGone 钉死设计决策 2
+// 的边界：供应商已被删(查不到实体)时没有名字可给,notice 保持只显示 key —— 前端据此
+// 回退渲染,不能出现「有时有名有时是 UUID」的不稳定文案。
+func TestSessionProviderOverride_FallbackNoticeOmitsNameWhenProviderGone(t *testing.T) {
+	m, ctx := setupDirectRunTest(t)
+	s := NewChat(NoopEmitter{}).(*chatSvc)
+	be := &agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), Status: consts.ACTIVE,
+	}
+	m.provider.EXPECT().FindByKey(ctx, "gone-key").Return(nil, nil)
+
+	_, notice := s.sessionProviderOverride(ctx, be, "gone-key", nil)
+
+	require.NotNil(t, notice)
+	assert.JSONEq(t, `{"providerKey":"gone-key"}`, notice.Text)
 }

--- a/internal/service/chat_svc/session_provider.go
+++ b/internal/service/chat_svc/session_provider.go
@@ -40,6 +40,17 @@ func effectiveProviderKey(sess *chat_entity.Session, be *agent_backend_entity.Ag
 	return firstNonEmpty(sessKey, agentKey)
 }
 
+// providerKeyOf 是「本轮解析出来的这家供应商的 key」，nil（CLI 自身登录态，没有任何
+// 供应商）返回空串。turn 侧把它交给网关 token 用：解析后的 prov 才是真正会被请求打到的
+// 那家（会话所选缺失/停用时已回退过），拿 effectiveProviderKey 的原始值反而会让回退的
+// 那一轮在网关上 502。
+func providerKeyOf(prov *llm_provider_entity.LLMProvider) string {
+	if prov == nil {
+		return ""
+	}
+	return prov.ProviderKey
+}
+
 // resolveEffectiveProvider 把 effectiveProviderKey 解析成 provider 实体，供**展示侧**
 // 消费点（LoadSession 的供应商类型/上下文窗口、复制启动命令）使用。
 //

--- a/internal/service/chat_svc/session_provider.go
+++ b/internal/service/chat_svc/session_provider.go
@@ -26,9 +26,15 @@ import (
 // 「有效供应商解析（唯一口径）」）：会话级 provider_key 非空取它，否则取 agent 绑定；
 // 两者皆空表示无供应商，即 CLI 自身登录态。
 //
-// 任何消费点（turn 解析、网关 token、CLI env/config 门控、LoadSession 展示、复制启动
-// 命令、远端 wire）都必须走这里，不得再各自直接读 be.LLMProviderKey —— 各读各的正是
-// 「会话选了供应商却打到 agent 绑定那家」的成因。
+// 任何消费点（turn 解析、网关 token、CLI env/config 门控、goal 入口、LoadSession 展示、
+// 复制启动命令、远端 wire）都必须走这里，不得再各自直接读 be.LLMProviderKey —— 各读各的
+// 正是「会话选了供应商却打到 agent 绑定那家」的成因。goal 尤其不能漏：它与 turn 共用同
+// 一个 CLI 会话池，两边解析不一致会让启动期比对键（决策 4）反复翻转、把在用的子进程
+// evict 掉重 spawn。
+//
+// 已知残留（本地已收口，远端未）：远端 goal 的 wire.GoalParams 不带 provider key，daemon
+// 的 hydrateGoalProvider 仍按 agent 绑定自解 —— 补齐需要给该 RPC 加 wire 字段（与
+// RunParams.LLMProviderKey 同形），属协议改动。
 func effectiveProviderKey(sess *chat_entity.Session, be *agent_backend_entity.AgentBackend) string {
 	var sessKey, agentKey string
 	if sess != nil {

--- a/internal/service/chat_svc/session_provider.go
+++ b/internal/service/chat_svc/session_provider.go
@@ -1,0 +1,191 @@
+package chat_svc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cago-frame/agents/agent/blocks"
+	"github.com/cago-frame/cago/pkg/i18n"
+	"github.com/cago-frame/cago/pkg/logger"
+	"go.uber.org/zap"
+
+	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/chat_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/llm_provider_entity"
+	"github.com/agentre-ai/agentre/internal/pkg/code"
+	"github.com/agentre-ai/agentre/internal/repository/agent_backend_repo"
+	"github.com/agentre-ai/agentre/internal/repository/agent_repo"
+	"github.com/agentre-ai/agentre/internal/repository/chat_repo"
+	"github.com/agentre-ai/agentre/internal/repository/llm_provider_repo"
+)
+
+// 会话级 LLM 供应商：切换入口 + 有效供应商解析的唯一口径。
+// 规格：docs/specs/2026-08-10-session-provider-switch.md
+
+// effectiveProviderKey 是「这条会话下一轮用哪个供应商」的**唯一**解析口（spec
+// 「有效供应商解析（唯一口径）」）：会话级 provider_key 非空取它，否则取 agent 绑定；
+// 两者皆空表示无供应商，即 CLI 自身登录态。
+//
+// 任何消费点（turn 解析、网关 token、CLI env/config 门控、LoadSession 展示、复制启动
+// 命令、远端 wire）都必须走这里，不得再各自直接读 be.LLMProviderKey —— 各读各的正是
+// 「会话选了供应商却打到 agent 绑定那家」的成因。
+func effectiveProviderKey(sess *chat_entity.Session, be *agent_backend_entity.AgentBackend) string {
+	var sessKey, agentKey string
+	if sess != nil {
+		sessKey = sess.ProviderKey
+	}
+	if be != nil {
+		agentKey = be.LLMProviderKey
+	}
+	return firstNonEmpty(sessKey, agentKey)
+}
+
+// resolveEffectiveProvider 把 effectiveProviderKey 解析成 provider 实体，供**展示侧**
+// 消费点（LoadSession 的供应商类型/上下文窗口、复制启动命令）使用。
+//
+// 会话所选供应商缺失/停用/与后端 kind 不兼容时回落 agent 绑定 —— 与 turn 侧
+// sessionProviderOverride 同一段代码、同一套回退语义，展示因此不会与真正会执行的那家
+// 供应商说两套话（回退 notice 只在真正跑轮时产出，展示侧丢弃）。
+//
+// 返回的 error 只来自 agent 绑定那一次查询：调用方（复制启动命令）沿用既有的「查询
+// 失败即报错」；会话所选 key 的查询失败按回退处理，不把展示整块打挂。
+func (s *chatSvc) resolveEffectiveProvider(
+	ctx context.Context,
+	sess *chat_entity.Session,
+	be *agent_backend_entity.AgentBackend,
+) (*llm_provider_entity.LLMProvider, error) {
+	if be == nil {
+		return nil, nil
+	}
+	var base *llm_provider_entity.LLMProvider
+	if be.LLMProviderKey != "" {
+		var err error
+		base, err = llm_provider_repo.LLMProvider().FindByKey(ctx, be.LLMProviderKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if sess == nil || strings.TrimSpace(sess.ProviderKey) == "" {
+		return base, nil
+	}
+	prov, _ := s.sessionProviderOverride(ctx, be, sess.ProviderKey, base)
+	return prov, nil
+}
+
+// SetChatSessionProvider 切换已有会话的 LLM 供应商（spec 决策 1）。
+//
+// 只写 chat_sessions.provider_key 一列：agent / backend / cli_path / reasoning_effort /
+// permission mode / cwd / 钉住的执行目标一律不动（硬不变量 2），也不写回 agent 绑定。
+// 允许在轮中调用：本轮已 spawn 的子进程不受影响，新供应商自下一轮生效（决策 8），
+// 所以这里不加 turn 锁、也不 evict 任何东西。
+//
+// 校验复用新建会话那一套（存在 / IsActive / ProviderTypeMatch，决策 11）：不通过一律
+// 拒绝写库并原样报错，会话保持原供应商 —— 不产生「写进去了但下一轮必然失败」的会话。
+//
+// 错误码：
+//   - SessionID <= 0 → InvalidParameter
+//   - 会话不存在 → ChatSessionNotFound
+//   - agent/backend 解析不出来 → AgentNotFound / ChatAgentNoBackend
+//   - 所选供应商缺失/停用/与后端 kind 不兼容 → ChatAgentNotChattable
+func (s *chatSvc) SetChatSessionProvider(ctx context.Context, req *SetSessionProviderRequest) (*SetSessionProviderResponse, error) {
+	if req == nil || req.SessionID <= 0 {
+		return nil, i18n.NewError(ctx, code.InvalidParameter)
+	}
+	key := strings.TrimSpace(req.ProviderKey)
+
+	sess, err := chat_repo.Session().Find(ctx, req.SessionID)
+	if err != nil {
+		return nil, operationFailedWithCause(ctx, err, zap.Int64("sessionId", req.SessionID))
+	}
+	if sess == nil {
+		return nil, i18n.NewError(ctx, code.ChatSessionNotFound)
+	}
+	be, err := sessionProviderBackend(ctx, sess)
+	if err != nil {
+		return nil, err
+	}
+	// 选中的就是当前生效的那一项（弹层里点已选中的行）：什么都没变，不写库也不追加
+	// notice —— 否则每点一次就往 transcript 里塞一条「已改用 X」。
+	if key == sess.ProviderKey {
+		return &SetSessionProviderResponse{ProviderKey: key, AgentProviderKey: be.LLMProviderKey}, nil
+	}
+	// 决策 11：与 validateNewSessionProvider 同一口径（空串跳过校验 = 跟随 agent 绑定）。
+	if _, err := s.validateNewSessionProvider(ctx, be, key); err != nil {
+		return nil, err
+	}
+	if err := chat_repo.Session().UpdateProviderKey(ctx, sess.ID, key); err != nil {
+		return nil, operationFailedWithCause(ctx, err, zap.Int64("sessionId", sess.ID))
+	}
+	sess.ProviderKey = key
+	logger.Ctx(ctx).Info("chat_svc.SetChatSessionProvider: session provider switched",
+		zap.Int64("sessionId", sess.ID),
+		zap.String("providerKey", key),
+		zap.String("agentProviderKey", be.LLMProviderKey),
+		zap.String("backendType", be.Type))
+	s.appendProviderSwitchNotice(ctx, sess, be, key)
+	return &SetSessionProviderResponse{ProviderKey: key, AgentProviderKey: be.LLMProviderKey}, nil
+}
+
+// sessionProviderBackend 解析这条会话「下一轮落在哪一档」的 backend：钉住的那一档优先
+// （R15b / 决策36），否则 Agent 的默认档 —— 与 GetLaunchCommand / LoadSession 展示取的
+// 是同一档，切换校验因此对的是用户真正会跑的那个后端 kind。只读仓储，无副作用。
+func sessionProviderBackend(ctx context.Context, sess *chat_entity.Session) (*agent_backend_entity.AgentBackend, error) {
+	a, err := agent_repo.Agent().Find(ctx, sess.AgentID)
+	if err != nil {
+		return nil, operationFailedWithCause(ctx, err, zap.Int64("agentId", sess.AgentID))
+	}
+	if a == nil {
+		return nil, i18n.NewError(ctx, code.AgentNotFound)
+	}
+	backendID := sessionBackendID(sess, a)
+	if backendID <= 0 {
+		return nil, i18n.NewError(ctx, code.ChatAgentNoBackend)
+	}
+	be, err := agent_backend_repo.AgentBackend().Find(ctx, backendID)
+	if err != nil {
+		return nil, operationFailedWithCause(ctx, err, zap.Int64("agentBackendId", backendID))
+	}
+	if be == nil {
+		return nil, i18n.NewError(ctx, code.ChatAgentNoBackend)
+	}
+	return be, nil
+}
+
+// appendProviderSwitchNotice 在 transcript 追加一条持久 notice，标出「从这里起换了供应商」
+// （决策 9）：两家供应商配同一个 model 时，逐条消息的 model 字段看不出分界。
+// 负载与既有回退 notice 同构（结构化 JSON + 前端 t() 渲染，不把原始 JSON 泄漏给前端）。
+//
+// 落库失败只记日志：供应商切换本身已经成功落库，为了一条提示把整个切换报成失败，会让
+// 用户以为没切成（实际下一轮已经换了）——这里的降级方向必须是「少一条提示」。
+func (s *chatSvc) appendProviderSwitchNotice(
+	ctx context.Context,
+	sess *chat_entity.Session,
+	be *agent_backend_entity.AgentBackend,
+	providerKey string,
+) {
+	msg := &chat_entity.Message{
+		SessionID:  sess.ID,
+		DeviceID:   be.DeviceID,
+		Role:       "assistant",
+		BlocksJSON: "[]",
+	}
+	if err := msg.SetBlocks([]blocks.ContentBlock{blocks.NoticeBlock{
+		Level: "info",
+		Text:  encodeProviderSwitch(providerKey),
+	}}); err != nil {
+		logger.Ctx(ctx).Warn("chat_svc.appendProviderSwitchNotice: encode notice failed",
+			zap.Int64("sessionId", sess.ID), zap.Error(err))
+		return
+	}
+	seq, err := chat_repo.Message().NextSeq(ctx, sess.ID)
+	if err != nil {
+		logger.Ctx(ctx).Warn("chat_svc.appendProviderSwitchNotice: next seq failed",
+			zap.Int64("sessionId", sess.ID), zap.Error(err))
+		return
+	}
+	msg.Seq = seq
+	if err := chat_repo.Message().Create(ctx, msg); err != nil {
+		logger.Ctx(ctx).Warn("chat_svc.appendProviderSwitchNotice: persist notice failed",
+			zap.Int64("sessionId", sess.ID), zap.Error(err))
+	}
+}

--- a/internal/service/chat_svc/session_provider.go
+++ b/internal/service/chat_svc/session_provider.go
@@ -127,7 +127,10 @@ func (s *chatSvc) SetChatSessionProvider(ctx context.Context, req *SetSessionPro
 		return &SetSessionProviderResponse{ProviderKey: key, AgentProviderKey: be.LLMProviderKey}, nil
 	}
 	// 决策 11：与 validateNewSessionProvider 同一口径（空串跳过校验 = 跟随 agent 绑定）。
-	if _, err := s.validateNewSessionProvider(ctx, be, key); err != nil {
+	// 校验顺带解析出的实体留着给 notice 当展示名(2026-08-10 显示缺陷修复决策 1):
+	// 校验已经查过一次,不再为取名字重复查询。
+	prov, err := s.validateNewSessionProvider(ctx, be, key)
+	if err != nil {
 		return nil, err
 	}
 	if err := chat_repo.Session().UpdateProviderKey(ctx, sess.ID, key); err != nil {
@@ -139,7 +142,7 @@ func (s *chatSvc) SetChatSessionProvider(ctx context.Context, req *SetSessionPro
 		zap.String("providerKey", key),
 		zap.String("agentProviderKey", be.LLMProviderKey),
 		zap.String("backendType", be.Type))
-	s.appendProviderSwitchNotice(ctx, sess, be, key)
+	s.appendProviderSwitchNotice(ctx, sess, be, key, providerDisplayName(prov))
 	return &SetSessionProviderResponse{ProviderKey: key, AgentProviderKey: be.LLMProviderKey}, nil
 }
 
@@ -179,6 +182,7 @@ func (s *chatSvc) appendProviderSwitchNotice(
 	sess *chat_entity.Session,
 	be *agent_backend_entity.AgentBackend,
 	providerKey string,
+	providerName string,
 ) {
 	msg := &chat_entity.Message{
 		SessionID:  sess.ID,
@@ -188,7 +192,7 @@ func (s *chatSvc) appendProviderSwitchNotice(
 	}
 	if err := msg.SetBlocks([]blocks.ContentBlock{blocks.NoticeBlock{
 		Level: "info",
-		Text:  encodeProviderSwitch(providerKey),
+		Text:  encodeProviderSwitch(providerKey, providerName),
 	}}); err != nil {
 		logger.Ctx(ctx).Warn("chat_svc.appendProviderSwitchNotice: encode notice failed",
 			zap.Int64("sessionId", sess.ID), zap.Error(err))

--- a/internal/service/chat_svc/session_provider_test.go
+++ b/internal/service/chat_svc/session_provider_test.go
@@ -84,6 +84,37 @@ func TestSetChatSessionProvider_PersistsAndAppendsNotice(t *testing.T) {
 	assert.Equal(t, `{"providerKey":"session-key","kind":"switch"}`, noticeTextOf(t, created))
 }
 
+// TestSetChatSessionProvider_NoticeCarriesProviderDisplayName 钉死设计决策 1：切换
+// notice 负载带上供应商显示名（后端产出时已解析到的实体，非前端按 key 查表）——
+// transcript 要读得懂「改用了哪个供应商」，而不是一串 UUID。
+func TestSetChatSessionProvider_NoticeCarriesProviderDisplayName(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, AgentStatus: "running", Status: consts.ACTIVE}
+	expectSwitchBackend(m, ctx, sess, agent_backend_entity.TypeClaudeCode, "agent-bound")
+	m.provider.EXPECT().FindByKey(ctx, "session-key").Return(&llm_provider_entity.LLMProvider{
+		ID: 33, ProviderKey: "session-key", Name: "中转 · GLM 5.2", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-sonnet-4-6", Status: consts.ACTIVE,
+	}, nil)
+	m.session.EXPECT().UpdateProviderKey(ctx, int64(100), "session-key").Return(nil)
+	m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(7, nil)
+	var created *chat_entity.Message
+	m.message.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, msg *chat_entity.Message) error {
+			created = msg
+			return nil
+		})
+
+	_, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{
+		SessionID: 100, ProviderKey: "session-key",
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		`{"providerKey":"session-key","providerName":"中转 · GLM 5.2","kind":"switch"}`,
+		noticeTextOf(t, created))
+}
+
 // TestSetChatSessionProvider_ClearsBackToAgentBinding：空串 = 改回跟随 agent 绑定
 // （CLI 登录态双向可切，决策 7）；不查供应商，notice 说明的是「跟随绑定」。
 func TestSetChatSessionProvider_ClearsBackToAgentBinding(t *testing.T) {

--- a/internal/service/chat_svc/session_provider_test.go
+++ b/internal/service/chat_svc/session_provider_test.go
@@ -1,0 +1,276 @@
+package chat_svc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cago-frame/agents/agent/blocks"
+	"github.com/cago-frame/cago/pkg/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/agent_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/chat_entity"
+	"github.com/agentre-ai/agentre/internal/model/entity/llm_provider_entity"
+	"github.com/agentre-ai/agentre/internal/pkg/httpgateway"
+	"github.com/agentre-ai/agentre/internal/service/chat_svc"
+)
+
+// 本文件覆盖 docs/specs/2026-08-10-session-provider-switch.md 的会话级供应商切换
+// （决策 1 / 11、「切换流程与生效时机」的写入与校验半边）与「有效供应商解析（唯一
+// 口径）」在展示侧的两个消费点（LoadSession 展示字段、复制启动命令）。
+
+// expectSwitchBackend 搭一条「会话 → agent → backend」的解析链：切换入口按会话钉住
+// 的那一档（没钉住则 agent 默认档）校验供应商与后端 kind 是否匹配。
+func expectSwitchBackend(
+	m *chatMocks,
+	ctx context.Context,
+	sess *chat_entity.Session,
+	backendType agent_backend_entity.BackendType,
+	agentProviderKey string,
+) {
+	m.session.EXPECT().Find(ctx, sess.ID).Return(sess, nil)
+	m.agent.EXPECT().Find(ctx, sess.AgentID).Return(&agent_entity.Agent{
+		ID: sess.AgentID, AgentBackendID: 12, Status: consts.ACTIVE,
+	}, nil)
+	m.backend.EXPECT().Find(ctx, int64(12)).Return(&agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(backendType), LLMProviderKey: agentProviderKey, Status: consts.ACTIVE,
+	}, nil)
+}
+
+// noticeTextOf 取出一条消息里唯一那个 notice 块的 Text（持久化的结构化负载原文）。
+func noticeTextOf(t *testing.T, msg *chat_entity.Message) string {
+	t.Helper()
+	require.NotNil(t, msg, "应该新建了一条承载 notice 的消息")
+	bs, err := msg.GetBlocks()
+	require.NoError(t, err)
+	require.Len(t, bs, 1, "切换 notice 消息只带一个 notice 块")
+	nb, ok := bs[0].(blocks.NoticeBlock)
+	require.True(t, ok, "块类型应为 NoticeBlock")
+	return nb.Text
+}
+
+// TestSetChatSessionProvider_PersistsAndAppendsNotice：切换成功 → 单列写 provider_key
+// （决策 1）+ 向 transcript 追加一条持久 notice（决策 9），notice 是结构化负载而不是
+// 现成文案（前端走 t() 渲染）。
+func TestSetChatSessionProvider_PersistsAndAppendsNotice(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, AgentStatus: "running", Status: consts.ACTIVE}
+	expectSwitchBackend(m, ctx, sess, agent_backend_entity.TypeClaudeCode, "agent-bound")
+	m.provider.EXPECT().FindByKey(ctx, "session-key").Return(&llm_provider_entity.LLMProvider{
+		ID: 33, ProviderKey: "session-key", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-sonnet-4-6", Status: consts.ACTIVE,
+	}, nil)
+	m.session.EXPECT().UpdateProviderKey(ctx, int64(100), "session-key").Return(nil)
+	m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(7, nil)
+	var created *chat_entity.Message
+	m.message.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, msg *chat_entity.Message) error {
+			created = msg
+			return nil
+		})
+
+	resp, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{
+		SessionID: 100, ProviderKey: "session-key",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "session-key", resp.ProviderKey)
+	assert.Equal(t, "agent-bound", resp.AgentProviderKey, "回传 agent 绑定 key 供 pill 渲染回落标签")
+	assert.Equal(t, 7, created.Seq)
+	assert.Equal(t, `{"providerKey":"session-key","kind":"switch"}`, noticeTextOf(t, created))
+}
+
+// TestSetChatSessionProvider_ClearsBackToAgentBinding：空串 = 改回跟随 agent 绑定
+// （CLI 登录态双向可切，决策 7）；不查供应商，notice 说明的是「跟随绑定」。
+func TestSetChatSessionProvider_ClearsBackToAgentBinding(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, Status: consts.ACTIVE, ProviderKey: "session-key"}
+	expectSwitchBackend(m, ctx, sess, agent_backend_entity.TypeClaudeCode, "")
+	m.session.EXPECT().UpdateProviderKey(ctx, int64(100), "").Return(nil)
+	m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(3, nil)
+	var created *chat_entity.Message
+	m.message.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, msg *chat_entity.Message) error {
+			created = msg
+			return nil
+		})
+
+	resp, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{
+		SessionID: 100, ProviderKey: "",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.ProviderKey)
+	assert.Equal(t, `{"kind":"switch"}`, noticeTextOf(t, created))
+}
+
+// TestSetChatSessionProvider_NoOpWhenUnchanged：选中当前已生效的那一项（弹层里点已选中
+// 的行）不写库、也不追加 notice —— 否则每点一次就往 transcript 里塞一条「已改用 X」，
+// 而实际上什么都没变。mock 上没有 UpdateProviderKey / NextSeq / Create 期望。
+func TestSetChatSessionProvider_NoOpWhenUnchanged(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	sess := &chat_entity.Session{ID: 100, AgentID: 7, Status: consts.ACTIVE, ProviderKey: "session-key"}
+	expectSwitchBackend(m, ctx, sess, agent_backend_entity.TypeClaudeCode, "agent-bound")
+
+	resp, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{
+		SessionID: 100, ProviderKey: "session-key",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "session-key", resp.ProviderKey)
+	assert.Equal(t, "agent-bound", resp.AgentProviderKey)
+}
+
+// TestSetChatSessionProvider_RejectsUnusableProvider：决策 11 —— 复用新建会话那套校验，
+// 不通过一律拒绝写库（会话保持原供应商），也不产出 notice。mock 上没有 UpdateProviderKey
+// / Create 期望，真写了就会失败。
+func TestSetChatSessionProvider_RejectsUnusableProvider(t *testing.T) {
+	cases := []struct {
+		name     string
+		backend  agent_backend_entity.BackendType
+		provider *llm_provider_entity.LLMProvider
+	}{
+		{name: "供应商不存在", backend: agent_backend_entity.TypeClaudeCode, provider: nil},
+		{
+			name:    "供应商已停用",
+			backend: agent_backend_entity.TypeClaudeCode,
+			provider: &llm_provider_entity.LLMProvider{
+				ID: 33, ProviderKey: "session-key", Type: string(llm_provider_entity.TypeAnthropic),
+				Status: consts.DELETE,
+			},
+		},
+		{
+			name:    "供应商类型与后端 kind 不兼容",
+			backend: agent_backend_entity.TypeClaudeCode,
+			provider: &llm_provider_entity.LLMProvider{
+				ID: 34, ProviderKey: "session-key", Type: string(llm_provider_entity.TypeOpenAIResponse),
+				Status: consts.ACTIVE,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := setupChatTest(t)
+			ctx := context.Background()
+
+			sess := &chat_entity.Session{ID: 100, AgentID: 7, Status: consts.ACTIVE, ProviderKey: "old-key"}
+			expectSwitchBackend(m, ctx, sess, tc.backend, "agent-bound")
+			m.provider.EXPECT().FindByKey(ctx, "session-key").Return(tc.provider, nil)
+
+			_, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{
+				SessionID: 100, ProviderKey: "session-key",
+			})
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestSetChatSessionProvider_SessionNotFound / InvalidParameter：边界。
+func TestSetChatSessionProvider_Boundaries(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	_, err := m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{SessionID: 0})
+	assert.Error(t, err, "SessionID <= 0 → InvalidParameter")
+
+	m.session.EXPECT().Find(ctx, int64(404)).Return(nil, nil)
+	_, err = m.svc.SetChatSessionProvider(ctx, &chat_svc.SetSessionProviderRequest{SessionID: 404})
+	assert.Error(t, err, "会话不存在 → ChatSessionNotFound")
+}
+
+// TestLoadSession_DisplaysEffectiveProvider：展示口径 —— 会话选了供应商时，供应商类型
+// 与上下文窗口按 effective provider（会话 > agent 绑定）算，而不是 agent 绑定；同时把
+// 会话 key 与 agent 绑定 key 一并回传给前端渲染 pill。
+func TestLoadSession_DisplaysEffectiveProvider(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	m.session.EXPECT().Find(ctx, int64(100)).Return(&chat_entity.Session{
+		ID: 100, AgentID: 7, Status: consts.ACTIVE, ProviderKey: "session-key",
+	}, nil)
+	m.agent.EXPECT().Find(ctx, int64(7)).Return(&agent_entity.Agent{
+		ID: 7, AgentBackendID: 12, Status: consts.ACTIVE,
+	}, nil)
+	m.backend.EXPECT().Find(ctx, int64(12)).Return(&agent_backend_entity.AgentBackend{
+		ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "agent-bound", Status: consts.ACTIVE,
+	}, nil)
+	m.provider.EXPECT().FindByKey(ctx, "agent-bound").Return(&llm_provider_entity.LLMProvider{
+		ID: 33, ProviderKey: "agent-bound", Type: string(llm_provider_entity.TypeOpenAIChat),
+		Model: "gpt-5", ContextWindow: 111_000, Status: consts.ACTIVE,
+	}, nil).AnyTimes()
+	m.provider.EXPECT().FindByKey(ctx, "session-key").Return(&llm_provider_entity.LLMProvider{
+		ID: 34, ProviderKey: "session-key", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-sonnet-4-6", ContextWindow: 222_000, Status: consts.ACTIVE,
+	}, nil)
+	m.message.EXPECT().List(ctx, int64(100)).Return(nil, nil)
+
+	resp, err := m.svc.LoadSession(ctx, &chat_svc.LoadSessionRequest{SessionID: 100})
+	require.NoError(t, err)
+	assert.Equal(t, string(llm_provider_entity.TypeAnthropic), resp.Session.LLMProviderType,
+		"用量口径必须按会话实际会用的供应商算")
+	assert.Equal(t, 222_000, resp.Session.ContextWindow, "上下文窗口同样按 effective provider 算")
+	assert.Equal(t, "session-key", resp.Session.ProviderKey)
+	assert.Equal(t, "agent-bound", resp.Session.AgentProviderKey)
+}
+
+// TestLoadSession_FallsBackToAgentBindingForDisplay：会话 provider_key 为空时展示完全
+// 不变（硬不变量 1）—— 仍按 agent 绑定解析。
+func TestLoadSession_FallsBackToAgentBindingForDisplay(t *testing.T) {
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	expectLoadSessionBackend(m, ctx, 100, 7, 12, agent_backend_entity.TypeClaudeCode,
+		&llm_provider_entity.LLMProvider{
+			ID: 33, ProviderKey: "agent-bound", Type: string(llm_provider_entity.TypeAnthropic),
+			Model: "claude-sonnet-4-6", ContextWindow: 111_000, Status: consts.ACTIVE,
+		})
+
+	resp, err := m.svc.LoadSession(ctx, &chat_svc.LoadSessionRequest{SessionID: 100})
+	require.NoError(t, err)
+	assert.Equal(t, string(llm_provider_entity.TypeAnthropic), resp.Session.LLMProviderType)
+	assert.Equal(t, 111_000, resp.Session.ContextWindow)
+	assert.Empty(t, resp.Session.ProviderKey, "未选具体供应商 → 会话 key 为空，前端显示 agent 绑定名")
+	assert.Equal(t, "agent-bound", resp.Session.AgentProviderKey)
+}
+
+// TestGetLaunchCommand_UsesEffectiveProvider：复制启动命令按 effective provider 解析，
+// 复制出的命令与该会话实际执行一致（问题 5）。
+func TestGetLaunchCommand_UsesEffectiveProvider(t *testing.T) {
+	t.Setenv("AGENTRE_DATA_DIR", t.TempDir())
+	chat_svc.RegisterGateway(&fakeChatGateway{
+		status: httpgateway.GatewayStatus{State: "running", URL: "http://127.0.0.1:60080"},
+	})
+	t.Cleanup(func() { chat_svc.RegisterGateway(nil) })
+
+	m := setupChatTest(t)
+	ctx := context.Background()
+
+	m.session.EXPECT().Find(ctx, int64(3)).Return(&chat_entity.Session{
+		ID: 3, AgentID: 7, ProviderSessionID: "sess-uuid", Status: consts.ACTIVE, ProviderKey: "session-key",
+	}, nil)
+	m.agent.EXPECT().Find(ctx, int64(7)).Return(&agent_entity.Agent{
+		ID: 7, AgentBackendID: 22, Status: consts.ACTIVE,
+	}, nil)
+	m.backend.EXPECT().Find(ctx, int64(22)).Return(&agent_backend_entity.AgentBackend{
+		ID: 22, Type: string(agent_backend_entity.TypeClaudeCode), LLMProviderKey: "agent-bound", Status: consts.ACTIVE,
+	}, nil)
+	m.provider.EXPECT().FindByKey(ctx, "agent-bound").Return(&llm_provider_entity.LLMProvider{
+		ID: 33, ProviderKey: "agent-bound", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-opus-4-1", Status: consts.ACTIVE,
+	}, nil).AnyTimes()
+	m.provider.EXPECT().FindByKey(ctx, "session-key").Return(&llm_provider_entity.LLMProvider{
+		ID: 34, ProviderKey: "session-key", Type: string(llm_provider_entity.TypeAnthropic),
+		Model: "claude-sonnet-4-6", Status: consts.ACTIVE,
+	}, nil)
+
+	resp, err := m.svc.GetLaunchCommand(ctx, &chat_svc.LaunchCommandRequest{SessionID: 3})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Command, "--model claude-sonnet-4-6", "命令要用会话所选供应商的模型")
+	assert.NotContains(t, resp.Command, "claude-opus-4-1")
+}

--- a/internal/service/chat_svc/types.go
+++ b/internal/service/chat_svc/types.go
@@ -285,11 +285,16 @@ type ChatBlock struct {
 	Text  string `json:"text,omitempty"`  // text / thinking / tool_result / notice 文本
 	Level string `json:"level,omitempty"` // notice 级别
 
-	// notice 块专用:供应商回退提示的会话所选 provider_key（spec 决策 8）。
+	// notice 块专用:供应商回退提示的会话所选 provider_key（spec 2026-08-09 决策 8）,
+	// 或供应商切换提示切换后的会话级 key（2026-08-10 决策 9,空串 = 改回跟随 agent 绑定）。
 	// 持久化时编码进 cago blocks.NoticeBlock.Text 的小 JSON,投影(noticeBlockToChatBlock)
 	// 解回这里;非结构化旧 notice 无此字段,前端回退到 Text 原样渲染。
-	ProviderKey string          `json:"providerKey,omitempty"`
-	Image       *ChatBlockImage `json:"image,omitempty"`
+	ProviderKey string `json:"providerKey,omitempty"`
+	// NoticeKind 区分 notice 的来源:""=供应商回退提示(含全部旧数据),"switch"=用户
+	// 切换了会话供应商。前端据它选 t() 文案 —— 切回「跟随 agent 绑定」时 ProviderKey
+	// 为空,只有这个字段能把它与「无结构化负载的旧 notice」区分开。
+	NoticeKind string          `json:"noticeKind,omitempty"`
+	Image      *ChatBlockImage `json:"image,omitempty"`
 
 	// tool_use:
 	ToolUseID string         `json:"toolUseId,omitempty"`
@@ -491,9 +496,19 @@ type ChatSessionDetail struct {
 	// openai-response）。前端用它和 BackendType 一起判定 Usage 字段语义：Anthropic 系
 	// 的 PromptTokens 只含未缓存输入，要叠加 CachedTokens + CacheCreationTokens 才是
 	// 总上下文；OpenAI 系的 PromptTokens 已是总数。空串表示后端未绑定 provider（CLI 登录态）。
+	//
+	// 按 **effective provider**（会话 provider_key > agent 绑定，spec 2026-08-10
+	// 「有效供应商解析（唯一口径）」）解析，不再单看 agent 绑定 —— 否则会话换了个不同
+	// 类型 / 不同上下文窗口的供应商后，用量条与上下文占比会按另一个供应商算错。
 	LLMProviderType string `json:"llmProviderType"`
-	Title           string `json:"title"`
-	AgentStatus     string `json:"agentStatus"`
+	// ProviderKey 是这条会话自己选的 LLM 供应商 key；空串 = 跟随 agent 绑定。
+	// AgentProviderKey 是该会话所用那一档 backend 绑定的 key；两者都空 = CLI 登录态。
+	// 前端 composer 的供应商 pill 用这两个值渲染标签（已选 → 供应商名；未选 → agent
+	// 绑定供应商名；皆无 → 「选择供应商」占位）。
+	ProviderKey      string `json:"providerKey"`
+	AgentProviderKey string `json:"agentProviderKey"`
+	Title            string `json:"title"`
+	AgentStatus      string `json:"agentStatus"`
 	// ActiveStream 仅在 LoadSession 时填:该会话有正在跑的 turn 时,给出其 per-turn
 	// wails 事件名("chat:event:<sessionID>:<assistantMessageID>"),让中途打开本会话的
 	// 前端 openStream 重挂到实时流。子 agent 调用轮 / 自主轮等"非前端发起"的 turn 没有 Send
@@ -734,9 +749,9 @@ type SendRequest struct {
 	// （SessionID>0）忽略这个字段：会话早已按 R15b 钉在它落到的那一档上，不可能再改。
 	ExecTargetOverride int64 `json:"execTargetOverride,omitempty"`
 	// ProviderKey 仅新建会话（SessionID=0）生效：所选 LLM 供应商 key，随首条消息与
-	// Session 一同 Create 落库（spec 决策 2）。空串 = 跟随 agent 绑定。已有会话忽略
-	// （B 不允许事后改，无 Setter）。非空时校验：供应商必须存在、IsActive 且与后端
-	// kind 兼容（ProviderTypeMatch），否则 Send 报错。
+	// Session 一同 Create 落库（spec 决策 2）。空串 = 跟随 agent 绑定。已有会话在这里
+	// 忽略——改供应商走 SetChatSessionProvider（2026-08-10 决策 1）。非空时校验：
+	// 供应商必须存在、IsActive 且与后端 kind 兼容（ProviderTypeMatch），否则 Send 报错。
 	ProviderKey string `json:"providerKey,omitempty"`
 	// EmitTurnStartedBypass 表示本轮由"非查看者"发起(子 agent 调用经 subagent_svc
 	// 阻塞起轮),需经会话级旁路 chat:autonomous:<sessionId> 把 per-turn 流名推给该会话
@@ -949,6 +964,21 @@ type SetPermissionModeRequest struct {
 type SetPermissionModeResponse struct {
 	Applied bool   `json:"applied"`
 	Mode    string `json:"mode"`
+}
+
+// SetSessionProviderRequest 切换已有会话的 LLM 供应商（spec 2026-08-10 决策 1）。
+// ProviderKey 空串 = 改回「跟随 agent 绑定」（CLI 后端即回到自身登录态，决策 7）。
+type SetSessionProviderRequest struct {
+	SessionID   int64  `json:"sessionId"`
+	ProviderKey string `json:"providerKey"`
+}
+
+// SetSessionProviderResponse 回传落库后的会话级 key 与该会话所用那一档 backend 的
+// 绑定 key，前端据此立刻更新 pill 标签，不必再拉一次 LoadSession。
+// 新供应商自下一轮生效：正在进行的轮不受影响（决策 8）。
+type SetSessionProviderResponse struct {
+	ProviderKey      string `json:"providerKey"`
+	AgentProviderKey string `json:"agentProviderKey"`
 }
 
 // LaunchCommandRequest / Response 用于「复制启动命令」菜单：

--- a/internal/service/chat_svc/types.go
+++ b/internal/service/chat_svc/types.go
@@ -290,6 +290,11 @@ type ChatBlock struct {
 	// 持久化时编码进 cago blocks.NoticeBlock.Text 的小 JSON,投影(noticeBlockToChatBlock)
 	// 解回这里;非结构化旧 notice 无此字段,前端回退到 Text 原样渲染。
 	ProviderKey string `json:"providerKey,omitempty"`
+	// ProviderName 是 ProviderKey 对应供应商的展示名(2026-08-10 显示缺陷修复决策 1/2):
+	// 后端产出 notice 时按当前解析到的供应商实体填入,查不到(供应商已删)时留空。前端
+	// 渲染时优先用它,空则回退到 ProviderKey —— transcript 要读得懂"改用了哪个供应商"
+	// 而不是一串 UUID。
+	ProviderName string `json:"providerName,omitempty"`
 	// NoticeKind 区分 notice 的来源:""=供应商回退提示(含全部旧数据),"switch"=用户
 	// 切换了会话供应商。前端据它选 t() 文案 —— 切回「跟随 agent 绑定」时 ProviderKey
 	// 为空,只有这个字段能把它与「无结构化负载的旧 notice」区分开。


### PR DESCRIPTION
## 变更说明 / Summary

**已有会话可以换 LLM 供应商了**，自下一轮生效、不打断正在跑的轮。起因是用户报告「在对话输出时，选择供应商怎么没了」——供应商选择器此前只在 `sessionId === 0` 渲染，首条消息一发就消失。

调查中发现一个更要紧的问题：**会话级 `provider_key` 在 claudecode / codex 上从来没真正生效过**。网关 token 的路由信息取自 agent 绑定（`token_registry.go` 的 `MainProviderKey = b.LLMProviderKey`），转发时按它取 `BaseURL` / `APIKey` 并把请求体的 model 重写回去；会话选的供应商只走到 CLI 的 `--model`，随后被网关改掉。更彻底的一处是 `BuildClaudeCodeEnv` 只在 backend 已绑供应商时才设 `ANTHROPIC_BASE_URL`，所以上一份规格承诺的「未绑 agent 的新建会话也能选供应商接管」在这两个后端上是空头支票。

因此本 PR 一并修了这条根因：引入唯一的 effective provider 解析口（会话 `provider_key` > agent 绑定），turn 解析、网关 token 路由、CLI env/config 门控、`LoadSession` 展示、复制启动命令、远端 wire 全部改读它。

两份规格：
- `docs/specs/2026-08-10-session-provider-switch.md` — 切换能力 + 上述根因
- `docs/specs/2026-08-10-provider-notice-fixes.md` — 真机验证暴露的两个显示缺陷

主要改动：
- 会话 `provider_key` 从「落库后不可改」放开为可改（单列更新 + `SetChatSessionProvider` + Wails 绑定），切换走与新建同一套校验
- 网关 token **身份不变、路由可变**：token 是会话级常驻且首轮就烤进子进程 env，重签会复现之前修过的 401 事故，所以切换时改的是 entry 的路由目标
- claudecode / codex 的 evict 比对键从 `model` 扩为 `(effectiveProviderKey, model)`——两个不同供应商可以配同一个 model id，只比 model 会漏掉换供应商
- 选择器改为常显 + 不可切时禁用并给 tooltip（不再隐藏），切换在 transcript 留一条持久 notice
- notice 显示供应商名而非 UUID；notice 行在自主续轮判定里透明，不再误报「后台任务完成 · 已自动续跑」

## 关联 Issue / Related Issue

Closes #

## 截图 / Screenshots

真机验证证据在 `e2e/scratch/2026-08-10-session-provider-switch/`（gitignored，本地）：

- `screenshots/v5-disabled-no-compatible.png` — 无兼容供应商时禁用而非隐藏
- `screenshots/v4-switch-notice.png` — 修复前：notice 显示 UUID + 误报横幅
- `screenshots/r1r2-named-notice-no-banner.png` — 修复后：显示供应商名、无横幅

## 验证结论 / Verification

真 app 驱动，两组 harness：fake 组（`make e2e-scratch`）覆盖 UI/IPC/落库；真环境组（**不带 `-tags e2e`**，真 claude 2.1.224 / codex 0.147.0 + 真中转供应商）覆盖上游路由。

**holds**：已有会话渲染选择器 · `provider_key` 落库 / 清回 · 切换 notice 落库并渲染 · 无兼容供应商时禁用 · 展示口径跟着会话走 · 非法 key 被拒且不写库 · **会话供应商真正决定 claudecode/codex 的上游** · **登录态后端被接管** · **换供应商 evict 重 spawn 且 `--resume` 续上** · 自下一轮生效 · notice 显示供应商名 · 不再误报自主续轮横幅

上游那条的决定性证据是同一条会话里 `chat_messages.model` 三段变化：`claude-opus-5[1m]`（登录态）→ `glm-5.2` → `glm-4.5-air`，而该后端全程没绑供应商；claude 官方 API 不存在 `glm-*`，请求没打到中转站就会是 model_not_found。codex 侧同构：`gpt-5.6-sol` → `gpt-5.3-codex-spark` → `gpt-5-mini`。

**未观察到（合并即接受）**：
- 远端 agentred 的切换生效 — 本机没有配对的 daemon
- 「轮进行中切换不打断当前轮」— 三次切换都落在轮结束后；「自下一轮生效」已被上面的 model 变化链证明
- 真实自主续轮仍出横幅 — 需要一次真的后台任务自主续轮；由 vitest 接缝覆盖，且该守卫经过变异验证
- 供应商被删时回退显示 key — 未构造该场景；由 chat_svc 单元覆盖
- openclaw 后端的禁用态 — e2e 未 seed openclaw 后端

**已知遗留**：远端 daemon 的回退 notice 仍编码空显示名（渲染成 key）。规格 Out of scope 明列「远端 agentred」，把名字穿过 wire ack 属协议改动，两轮复审均独立确认这是本轮的合规终态。

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

`make test-backend` 全绿 · `make test-frontend` 239 文件 / 2432 测试 · `tsc -b --noEmit` 干净 · `make lint` 0 errors（唯一 warning 在本分支未触及的 `org-chart-page.tsx`）
