### PR TITLE
🐛 系统 Agent 不再强制置顶，CEO 助手可正常取消置顶

### DIFF
--- a/frontend/src/components/agentre/chat-page.tsx
+++ b/frontend/src/components/agentre/chat-page.tsx
@@ -436,7 +436,7 @@ function ChatPage() {
       ),
     [agents, filterValue, filterStatuses, attentionReasons],
   );
-  // 列表：agent 按最近活跃倒序;pinned（系统 agent + 用户置顶的 agent）浮顶。
+  // 列表：agent 按最近活跃倒序；pinned（DB 置顶的 agent）浮顶。
   // agent 活跃度取 sessionIds 在 meta-store 的 max(lastMessageAt)，确保 turn
   // 结束后实时反映。无活跃的项 ts=0 沉到底部。
   const agentRows = React.useMemo<AgentRow[]>(() => {

--- a/internal/service/agent_svc/agent.go
+++ b/internal/service/agent_svc/agent.go
@@ -337,7 +337,9 @@ func (s *agentSvc) DeleteAvatar(ctx context.Context, req *DeleteAvatarRequest) (
 	return &DeleteAvatarResponse{Item: toItem(existing, targets)}, nil
 }
 
-// SetPinned 切换 Agent 用户置顶。系统 agent 也允许置顶（虽然恒置顶），不特判。
+// SetPinned 切换 Agent 用户置顶。系统 agent 与普通 Agent 同一条路径，不特判：
+// 置顶与否完全由 DB 的 pinned 列承载，侧栏读口不再用 IsSystem() 强制浮顶
+// （R: ceo-unpin）。
 func (s *agentSvc) SetPinned(ctx context.Context, req *SetPinnedRequest) (*SetPinnedResponse, error) {
 	existing, err := agent_repo.Agent().Find(ctx, req.ID)
 	if err != nil {

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -368,7 +368,9 @@ func (s *chatSvc) ListAgents(ctx context.Context, _ *ListAgentsRequest) (*ListAg
 			AvatarColor:   a.AvatarColor,
 			AvatarIcon:    a.AvatarIcon,
 			AvatarDataURL: a.AvatarDataURL,
-			Pinned:        a.IsSystem() || a.Pinned,
+			// 置顶完全由 DB 的 pinned 列承载（含系统 Agent/CEO）：系统 Agent 不再被
+			// IsSystem() 强制浮顶，用户置顶/取消后这里透传 DB 值（R: ceo-unpin）。
+			Pinned:        a.Pinned,
 			ActiveCount:   counts[a.ID],
 			TotalSessions: totals[a.ID],
 			SessionIDs:    ids,

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -596,9 +596,9 @@ func TestListAgents(t *testing.T) {
 			}
 		})
 
-		convey.Convey("CEO 默认 Pinned，但无后端时 Chattable=false", func() {
+		convey.Convey("CEO 未置顶（DB pinned=0，无默认置顶回填），无后端时 Chattable=false", func() {
 			m.agent.EXPECT().List(ctx).Return([]*agent_entity.Agent{
-				{ID: 1, Name: "CEO 助手", SystemBadge: agent_entity.SystemBadgeDefault, AgentBackendID: 0, Status: consts.ACTIVE},
+				{ID: 1, Name: "CEO 助手", SystemBadge: agent_entity.SystemBadgeDefault, Pinned: false, AgentBackendID: 0, Status: consts.ACTIVE},
 				{ID: 2, Name: "工程师", AgentBackendID: 7, Status: consts.ACTIVE},
 			}, nil)
 			m.backend.EXPECT().BatchFind(ctx, []int64{7}).Return(map[int64]*agent_backend_entity.AgentBackend{
@@ -624,7 +624,7 @@ func TestListAgents(t *testing.T) {
 			resp, err := m.svc.ListAgents(ctx, &chat_svc.ListAgentsRequest{})
 			assert.NoError(t, err)
 			assert.Len(t, resp.Agents, 2)
-			assert.True(t, resp.Agents[0].Pinned)
+			assert.False(t, resp.Agents[0].Pinned)
 			assert.False(t, resp.Agents[0].Chattable)
 			assert.True(t, resp.Agents[1].Chattable)
 			assert.Equal(t, 3, resp.Agents[1].ActiveCount)

--- a/internal/service/chat_svc/pinned_test.go
+++ b/internal/service/chat_svc/pinned_test.go
@@ -13,22 +13,25 @@ import (
 	"github.com/agentre-ai/agentre/internal/service/chat_svc"
 )
 
-// TestListAgents_PinnedDerivation: ChatAgentItem.Pinned = IsSystem() || a.Pinned。
-// 系统 agent 恒置顶; 用户置顶的普通 agent 也置顶; 未置顶的普通 agent 不置顶。
+// TestListAgents_PinnedDerivation: ChatAgentItem.Pinned = a.Pinned（DB 列直读）。
+// 系统 agent 不再被 IsSystem() 强制浮顶（R: ceo-unpin）：置顶与否完全由 DB 的
+// pinned 列承载，系统 agent 同样可以置顶或取消。用户置顶的普通 agent 置顶；
+// 未置顶的普通 agent 不置顶。
 func TestListAgents_PinnedDerivation(t *testing.T) {
 	m := setupChatTest(t)
 	ctx := context.Background()
 
 	m.agent.EXPECT().List(ctx).Return([]*agent_entity.Agent{
-		{ID: 1, Name: "Sys", SystemBadge: agent_entity.SystemBadgeDefault, AgentBackendID: 9, Pinned: false, Status: consts.ACTIVE},
+		{ID: 1, Name: "SysUnpinned", SystemBadge: agent_entity.SystemBadgeDefault, AgentBackendID: 9, Pinned: false, Status: consts.ACTIVE},
 		{ID: 2, Name: "PinnedUser", AgentBackendID: 9, Pinned: true, Status: consts.ACTIVE},
 		{ID: 3, Name: "Plain", AgentBackendID: 9, Pinned: false, Status: consts.ACTIVE},
+		{ID: 4, Name: "SysPinned", SystemBadge: agent_entity.SystemBadgeDefault, AgentBackendID: 9, Pinned: true, Status: consts.ACTIVE},
 	}, nil)
 	m.backend.EXPECT().BatchFind(ctx, []int64{9}).Return(map[int64]*agent_backend_entity.AgentBackend{
 		9: {ID: 9, Type: string(agent_backend_entity.TypeBuiltin), Status: consts.ACTIVE},
 	}, nil)
 	m.provider.EXPECT().BatchFindByKey(ctx, []string{}).Return(map[string]*llm_provider_entity.LLMProvider{}, nil)
-	ids := []int64{1, 2, 3}
+	ids := []int64{1, 2, 3, 4}
 	m.session.EXPECT().CountRunningByAgents(ctx, ids).Return(map[int64]int{}, nil)
 	m.session.EXPECT().CountByAgentsIncludingGroups(ctx, ids).Return(map[int64]int64{}, nil)
 	m.session.EXPECT().ListIDsByAgentsIncludingGroups(ctx, ids).Return(map[int64][]int64{}, nil)
@@ -43,7 +46,8 @@ func TestListAgents_PinnedDerivation(t *testing.T) {
 	for _, a := range resp.Agents {
 		byID[a.ID] = a.Pinned
 	}
-	assert.True(t, byID[1], "system agent stays pinned")
+	assert.False(t, byID[1], "system agent with DB pinned=false is unpinned (unpin respected)")
 	assert.True(t, byID[2], "user-pinned agent is pinned")
 	assert.False(t, byID[3], "plain agent not pinned")
+	assert.True(t, byID[4], "system agent default pinned via DB pinned=true")
 }


### PR DESCRIPTION
## 变更说明 / Summary

**Bug**：CEO 助手（系统 Agent，`system_badge='DEFAULT'`）在侧栏恒置顶，点「取消置顶」无效。

**根因**：`chat_svc.ListAgents` 用 `Pinned: a.IsSystem() || a.Pinned` 把系统 Agent 强制算成置顶。用户点「取消置顶」时 `SetAgentPinned(pinned=false)` 确实写库成功，但刷新后 `IsSystem() || false` 又被强制算回 `true`，所以永远取消不掉。

**修复**：改为 `Pinned: a.Pinned`（直接透传 DB 的 `pinned` 列）。系统 Agent 与普通 Agent 同一条路径——置顶与否完全由 DB 承载，不再被 `IsSystem()` 强制浮顶。CEO 默认不置顶（seed 未回填 pinned），手动置顶/取消均可正常生效。

**改动文件**：
- `internal/service/chat_svc/chat.go` — 读口透传 DB pinned（核心修复）
- `internal/service/chat_svc/pinned_test.go` — 派生矩阵：系统 Agent pinned=false → 不置顶；pinned=true → 置顶
- `internal/service/chat_svc/chat_test.go` — CEO 默认不置顶断言
- `internal/service/agent_svc/agent.go`、`frontend/.../chat-page.tsx` — 更新过时的「恒置顶」注释

## 关联 Issue / Related Issue

无（用户反馈：ceo助手固定置顶无法取消）

## 截图 / Screenshots

行为修复，无视觉样式改动，不附截图。

## 自检 / Checklist

- [x]  Fixes mentioned issues / 修复已提及的问题
- [x]  Code reviewed by human / 代码通过人工检查
- [x]  Changes tested / 已完成测试（`make test-backend` 全绿 exit 0；`golangci-lint` v2.12.2 0 issues；前端 eslint 改动文件干净）
