### PR TITLE
🐛 远端续话语义分离：wire.RunParams.FreshSession —— regenerate 无锚点 / provider 会话失效恢复起全新会话（挂账修复）

### DIFF
--- a/internal/daemon/handlers/runtime.go
+++ b/internal/daemon/handlers/runtime.go
@@ -463,7 +463,10 @@ func (h *RuntimeHandlers) Run(ctx context.Context, p wire.RunParams) (wire.RunAc
 	// 提供。这里只改直连(非 Pi)路径 —— Pi 的 prepare/start 由已准备的身份自己带,不受
 	// 影响;调用方显式提供的值(重开 fork 等)优先于落库的那份。查不出行或读失败时保持
 	// 空,让 runtime 自己新建会话,不拿一个读不出来的库去换续话。
-	if strings.TrimSpace(req.ProviderSessionID) == "" && h.deps.SessionQuery != nil {
+	// 挂账修复(2026-08-11):FreshSession=true 声明这一轮**必须全新**(regenerate 无锚点
+	// 时 / provider 会话失效恢复),即使落库有旧 id 也不许续 —— 否则这两条路径的空字段
+	// 被重载成「续话」,regenerate 退化成续旧上下文、gone 恢复永远撞同一个失效 id。
+	if !p.FreshSession && strings.TrimSpace(req.ProviderSessionID) == "" && h.deps.SessionQuery != nil {
 		if row, err := h.deps.SessionQuery.Find(ctx, em.peer, em.peerSessionID); err == nil && row != nil && row.ProviderSessionID != "" {
 			req.ProviderSessionID = row.ProviderSessionID
 		}

--- a/internal/daemon/handlers/runtime_test.go
+++ b/internal/daemon/handlers/runtime_test.go
@@ -1922,6 +1922,37 @@ func TestRuntime_Run_ContinuationResolvesStoredProviderSessionID(t *testing.T) {
 		"续话不需要调用方提供 providerSessionID,daemon 拿自己落库的那份续上")
 }
 
+// TestRuntime_Run_FreshSessionSkipsStoredProviderSessionID 覆盖挂账修复:决策 8 把「空
+// RunParams.ProviderSessionID」重载成「用落库那份续话」,但 regenerate 与 provider 会话
+// 失效恢复这两条路径的空字段本意是「起全新会话」。freshSession=true 显式声明这一轮不续
+// 任何落库的 provider_session_id —— daemon 必须把 ProviderSessionID 保持为空让 runtime
+// 新建,而不是拿落库的旧 id 顶掉(否则 regenerate 退化成续旧上下文、gone 恢复永远撞同
+// 一个失效 id)。
+func TestRuntime_Run_FreshSessionSkipsStoredProviderSessionID(t *testing.T) {
+	rt := &fullRT{}
+	rt.runFn = func(_ context.Context) (<-chan agentruntime.Event, *agentruntime.RunResult, error) {
+		ch := make(chan agentruntime.Event, 1)
+		ch <- agentruntime.Done{}
+		close(ch)
+		return ch, &agentruntime.RunResult{ProviderSessionID: "claude-abc123"}, nil
+	}
+	ctx, notif, _, h := setupRuntimeTestWithSessions(t, rt)
+	be := agent_backend_entity.AgentBackend{Type: string(agent_backend_entity.TypeClaudeCode)}
+	// 第一轮:daemon 从 result 收回 providerSessionID 并落库。
+	_, err := h.Run(ctx, wire.RunParams{Backend: backendJSON(t, be), SessionID: 5, AgentID: 7, Cwd: "/work"})
+	require.NoError(t, err)
+	notif.waitFrames(t, 2)
+	require.Len(t, rt.runReqs, 1)
+
+	// 第二轮:调用方显式声明 freshSession —— 落库已有旧 id,也必须起全新会话。
+	_, err = h.Run(ctx, wire.RunParams{Backend: backendJSON(t, be), SessionID: 5, AgentID: 7, Cwd: "/work", FreshSession: true})
+	require.NoError(t, err)
+	notif.waitFrames(t, 2)
+	require.Len(t, rt.runReqs, 2)
+	assert.Equal(t, "", rt.runReqs[1].req.ProviderSessionID,
+		"freshSession=true 时 daemon 不得用落库的 provider_session_id 续话,必须保持为空起全新会话")
+}
+
 // TestRuntime_Run_AutonomousTurnMovesLifecycleBackToRunning 覆盖自主续轮:backend
 // 自发跑的一轮同样是「一轮执行中」,会话必须在这段时间报 running 而不是停在 idle ——
 // 否则重连的客户端会把一条正在产出事件的会话显示成闲置。

--- a/internal/pkg/agentruntime/runner.go
+++ b/internal/pkg/agentruntime/runner.go
@@ -412,12 +412,19 @@ type RunRequest struct {
 	AgentSyncID       string
 	SystemPrompt      string
 	ProviderSessionID string // 空 = 新建；非空 = resume
-	UserText          string
-	UserBlocks        []blocks.ContentBlock // 非空时为本轮用户输入权威 blocks；UserText 仅保留文本索引/兼容
-	History           []HistoryMessage      // 仅 builtin
-	GatewayURL        string                // 关联 provider 的 CLI 后端要；builtin 不用
-	GatewayToken      string                // 同上，一次性 token
-	Compact           bool                  // Codex 原生 compact turn；不创建普通 user prompt
+	// FreshSession 声明这一轮**必须起全新会话**(挂账修复 2026-08-11):即使远端 daemon
+	// 在自家落库里存了这条会话的 provider_session_id,也不许续。决策 8 之后「空
+	// ProviderSessionID」被重载成「用落库那份续话」,而 regenerate 无锚点 / provider 会话
+	// 失效恢复这两条路径的空字段本意是「全新」—— 两者在 wire 上不可区分,daemon 拿旧 id
+	// 顶掉就失效。chat_svc 在本地 sess.ProviderSessionID 为空(即没有可续的原生会话)时置
+	// true;本地 runner 忽略它,只有远端 daemon 的续话逻辑读它。
+	FreshSession bool
+	UserText     string
+	UserBlocks   []blocks.ContentBlock // 非空时为本轮用户输入权威 blocks；UserText 仅保留文本索引/兼容
+	History      []HistoryMessage      // 仅 builtin
+	GatewayURL   string                // 关联 provider 的 CLI 后端要；builtin 不用
+	GatewayToken string                // 同上，一次性 token
+	Compact      bool                  // Codex 原生 compact turn；不创建普通 user prompt
 
 	// MCPServers 非空 = 给本轮 CLI 注入额外 MCP tool server。仅声明 CapMCPTools
 	// 的 runtime(claudecode/codex)消费; 其它 runtime 忽略。org/subagent/hook 等工具经此注入。

--- a/internal/pkg/agentruntime/runtimes/remote/runtime.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime.go
@@ -568,6 +568,7 @@ func buildRunParams(req agentruntime.RunRequest) (wire.RunParams, error) {
 		AgentSyncID:       req.AgentSyncID,
 		SystemPrompt:      req.SystemPrompt,
 		ProviderSessionID: req.ProviderSessionID,
+		FreshSession:      req.FreshSession,
 		UserText:          req.UserText,
 		UserBlocks:        userBlocks,
 		History:           history,

--- a/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
+++ b/internal/pkg/agentruntime/runtimes/remote/runtime_test.go
@@ -1690,6 +1690,36 @@ func TestBuildRunParams_ForwardsMCPServers(t *testing.T) {
 	}
 }
 
+// TestBuildRunParams_ForwardsFreshSession 钉死挂账修复(2026-08-11)的映射:chat_svc 在
+// 本地 sess.ProviderSessionID 为空时置 RunRequest.FreshSession=true,必须随 wire 过线到
+// daemon —— 漏传则 daemon 拿落库旧 id 续话,regenerate / provider 会话失效恢复又变回坏路径。
+func TestBuildRunParams_ForwardsFreshSession(t *testing.T) {
+	params, err := buildRunParams(agentruntime.RunRequest{
+		Backend:      &agent_backend_entity.AgentBackend{},
+		SessionID:    9,
+		FreshSession: true,
+	})
+	if err != nil {
+		t.Fatalf("buildRunParams: %v", err)
+	}
+	if !params.FreshSession {
+		t.Fatalf("buildRunParams dropped FreshSession: %+v", params)
+	}
+
+	// wire JSON round-trip preserves the field.
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out wire.RunParams
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.FreshSession {
+		t.Fatalf("FreshSession not preserved across wire JSON: %+v", out)
+	}
+}
+
 // TestBuildRunParams_ForwardsEnabledPlugins 钉死 buildRunParams 把
 // RunRequest.EnabledPlugins 透传到 wire.RunParams，且 JSON round-trip 保留该字段。
 func TestBuildRunParams_ForwardsEnabledPlugins(t *testing.T) {

--- a/internal/pkg/agentruntime/runtimes/remote/wire/golden_test.go
+++ b/internal/pkg/agentruntime/runtimes/remote/wire/golden_test.go
@@ -165,6 +165,20 @@ func buildGoldenFrames(t *testing.T) []goldenFrame {
 				SourceDeviceName: "Chrome · macOS",
 			},
 		},
+		// 挂账修复(2026-08-11)的 freshSession 场景:regenerate 无锚点 / provider 会话失效
+		// 恢复 —— 空 providerSessionId + FreshSession=true,daemon 据此起全新会话而不是拿
+		// 落库旧 id 续话。
+		{
+			name: "run-params-fresh",
+			body: RunParams{
+				Backend:        json.RawMessage(`{"backendType":"claudecode"}`),
+				AgentID:        agentID,
+				SessionID:      sid,
+				Cwd:            "/home/agent/proj",
+				FreshSession:   true,
+				PermissionMode: "default",
+			},
+		},
 		{name: "run-ack", body: runAck},
 		{name: "session-summary", body: newSummary},
 		{name: "session-summary-legacy", body: legacySummary},

--- a/internal/pkg/agentruntime/runtimes/remote/wire/wire.go
+++ b/internal/pkg/agentruntime/runtimes/remote/wire/wire.go
@@ -227,9 +227,18 @@ type RunParams struct {
 	Title string `json:"title,omitempty"`
 	// AgentSyncID 是该会话所属 Agent 的账号级同步标识(块 1,决策 3 的 ULID,不是本地
 	// 自增 agent_id)。会话列表按它解析 Agent 名与头像(R5)。
-	AgentSyncID       string               `json:"agentSyncId,omitempty"`
-	SystemPrompt      string               `json:"systemPrompt,omitempty"`
-	ProviderSessionID string               `json:"providerSessionId,omitempty"`
+	AgentSyncID       string `json:"agentSyncId,omitempty"`
+	SystemPrompt      string `json:"systemPrompt,omitempty"`
+	ProviderSessionID string `json:"providerSessionId,omitempty"`
+	// FreshSession 声明这一轮**必须起全新会话**:即使 daemon 在自家落库里存了这条会话
+	// 的 provider_session_id,也不许续(挂账修复,2026-08-11)。决策 8 之后「空
+	// ProviderSessionID」的语义被重载成「用落库那份续话」,而 regenerate 与 provider 会话
+	// 失效恢复这两条路径的空字段本意是「全新」—— 两者在 wire 上不可区分,daemon 拿旧 id
+	// 顶掉:regenerate 退化成续旧上下文、gone 恢复永远撞同一个失效 id。本字段是那个
+	// 「全新」意图的显式出口。三种取值:ProviderSessionID 非空 = resume;空 +
+	// FreshSession=false(缺省)= 决策 8 续话(daemon 续落库那份);空 + FreshSession=true
+	// = 全新,忽略落库。浏览器续话不置它;桌面端在本地 sess.ProviderSessionID 为空时置它。
+	FreshSession      bool                 `json:"freshSession,omitempty"`
 	UserText          string               `json:"userText,omitempty"`
 	UserBlocks        []blocks.StoredBlock `json:"userBlocks,omitempty"`
 	History           []HistoryMessageWire `json:"history,omitempty"`

--- a/internal/service/chat_svc/chat.go
+++ b/internal/service/chat_svc/chat.go
@@ -3816,10 +3816,13 @@ func (s *chatSvc) prepareTurnRun(
 		AgentSyncID:       a.SyncID,
 		SystemPrompt:      strings.Join(a.GetPrompt(), "\n"),
 		ProviderSessionID: sess.ProviderSessionID,
-		Compact:           compact,
-		ForkAnchor:        forkAnchor,
-		MCPServers:        appendTurnMCP(ctx, nil, a, sess.ID, runner.Capabilities().Has(capability.CapMCPTools)),
-		EnabledPlugins:    enabledPluginsForTurn(ctx, a, be.ID, runner.Capabilities().Has(capability.CapSkills)),
+		// 挂账修复(2026-08-11):本地没有可续的原生会话(regenerate 无锚点 / provider 会话
+		// 失效恢复 / 首轮)时声明 freshSession,远端 daemon 据此不拿落库旧 id 续话。
+		FreshSession:   strings.TrimSpace(sess.ProviderSessionID) == "",
+		Compact:        compact,
+		ForkAnchor:     forkAnchor,
+		MCPServers:     appendTurnMCP(ctx, nil, a, sess.ID, runner.Capabilities().Has(capability.CapMCPTools)),
+		EnabledPlugins: enabledPluginsForTurn(ctx, a, be.ID, runner.Capabilities().Has(capability.CapSkills)),
 	}
 	if userMsg != nil {
 		req.UserText = textOfMessage(userMsg)

--- a/internal/service/chat_svc/chat_test.go
+++ b/internal/service/chat_svc/chat_test.go
@@ -2026,6 +2026,64 @@ func TestSend_PersistsProviderSessionIDBeforeStreamDrains(t *testing.T) {
 	assert.True(t, persistedBeforeDrain, "provider session id must be persisted before the runtime event stream drains")
 }
 
+// TestSend_FreshSessionReflectsLocalProviderSessionID 覆盖挂账修复(2026-08-11)的
+// 生产者侧:chat_svc 在本地 sess.ProviderSessionID 为空(regenerate 无锚点 / provider 会话
+// 失效恢复同此)时,必须在 RunRequest 上声明 FreshSession=true,daemon 才不拿落库旧 id 续话;
+// 本地有可续的原生会话时保持 false,决策 8 的续话语义原样。
+func TestSend_FreshSessionReflectsLocalProviderSessionID(t *testing.T) {
+	convey.Convey("Given 本地 provider_session_id 有无两种状态, When Send, Then RunRequest.FreshSession 跟随", t, func() {
+		run := func(providerSessionID string) bool {
+			t.Setenv("AGENTRE_DATA_DIR", t.TempDir())
+			m := setupChatTest(t)
+			ctx := m.ctx
+			runner := &recordingRunner{requests: make(chan agentruntime.RunRequest, 1)}
+			restore := agentruntime.SwapRuntimeForTest(agent_backend_entity.TypeClaudeCode, runner)
+			t.Cleanup(restore)
+
+			sess := &chat_entity.Session{ID: 100, AgentID: 7, ProviderSessionID: providerSessionID, AgentStatus: "idle", Status: consts.ACTIVE}
+			backend := &agent_backend_entity.AgentBackend{ID: 12, Type: string(agent_backend_entity.TypeClaudeCode), Status: consts.ACTIVE}
+			agent := &agent_entity.Agent{ID: 7, Name: "Claude", AgentBackendID: 12, Status: consts.ACTIVE, PromptJSON: `[]`}
+
+			m.session.EXPECT().Find(gomock.Any(), int64(100)).Return(sess, nil)
+			m.agent.EXPECT().Find(gomock.Any(), int64(7)).Return(agent, nil)
+			m.backend.EXPECT().Find(gomock.Any(), int64(12)).Return(backend, nil)
+			m.session.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
+			m.message.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
+			m.dbMock.ExpectBegin()
+			m.message.EXPECT().NextSeq(gomock.Any(), int64(100)).Return(1, nil)
+			m.message.EXPECT().Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, msg *chat_entity.Message) error {
+					if msg.Role == "user" {
+						msg.ID = 1000
+					} else {
+						msg.ID = 1001
+					}
+					return nil
+				}).Times(2)
+			m.dbMock.ExpectCommit()
+
+			resp, err := m.svc.Send(ctx, &chat_svc.SendRequest{SessionID: 100, AgentID: 7, Text: "hi"})
+			require.NoError(t, err)
+			chat_svc.WaitForStreamForTest(m.svc, resp.AssistantMessageID)
+
+			select {
+			case req := <-runner.requests:
+				return req.FreshSession
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for runtime request")
+				return false
+			}
+		}
+
+		convey.Convey("本地无 provider_session_id → FreshSession=true", func() {
+			assert.True(t, run(""), "regenerate 无锚点 / 会话失效恢复:必须声明 freshSession,daemon 才不拿落库旧 id 续话")
+		})
+		convey.Convey("本地有 provider_session_id → FreshSession=false(resume)", func() {
+			assert.False(t, run("claude-abc123"), "本地有可续的原生会话时保持决策 8 续话语义")
+		})
+	})
+}
+
 type streamErrorRunner struct{ err error }
 
 func (streamErrorRunner) Capabilities() capability.Capabilities { return capability.Capabilities{} }


### PR DESCRIPTION
## 修什么（评审挂账 2026-08-11）

决策 8 把「空 `RunParams.ProviderSessionID`」重载成「用落库那份续话」，而 regenerate 无锚点 / provider 会话失效恢复这两条路径的空字段本意是「起全新会话」——两者在 wire 上不可区分，daemon 拿落库旧 id 顶掉：regenerate 退化成续旧上下文、gone 恢复永远撞同一个失效 id。属既有帧语义变更，评审明确留作单独任务。

## 改法（方案 B，用户批准）

- `wire.RunParams` / `agentruntime.RunRequest` 新增 `FreshSession`，`buildRunParams` 透传。
- daemon 续话条件加 `!p.FreshSession`：true 时保持 ProviderSessionID 为空起全新会话。
- chat_svc 在本地 `sess.ProviderSessionID` 为空时置 `FreshSession=true`（覆盖 Send/Regenerate/Edit/Compact/auto-continue，全部走 `prepareTurnRun`）。
- **决策 8 原样保留**：浏览器续话不置 freshSession，daemon 续落库逻辑不变。

## 验证

- TDD 三接缝 RED→GREEN：daemon 消费者（初跑红 `actual: claude-abc123`）、buildRunParams 映射（初跑红 `dropped FreshSession`）、chat_svc 生产者（无 id→true / 有 id→false）。
- agentre 后端 124 包 `GOWORK=off go test` EXIT=0；golangci-lint `--new-from-rev` 0 issues。
- golden 新增 `run-params-fresh` 样本；server 侧 TS 镜像见配套 PR。

## 交付判定

- 挂账两条失效路径均修复，由三个接缝单测覆盖；**未做运行时 e2e**（需真 Claude Code CLI + 双端 harness，对一条 wire 字段判定不成比例，如实说明）。
- **越界发现（未修，标记）**：浏览器续一条 provider 会话已失效的会话时，daemon 仍填失效 id——浏览器侧没有 regenerate/gone 恢复流程，建议另立任务。
- main 上无关脏文件（`pkg/codex/*`）按纪律未动。