### PR TITLE
✨ 完成 agentred 跨平台安装与后台服务引导

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Verify Windows agentred IPC and service management
+        run: go test ./cmd/agentred ./internal/pkg/agentredipc
       - name: Verify PowerShell installer
         shell: pwsh
         run: scripts/test-install.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,31 @@ jobs:
       - name: Test
         run: cd frontend && pnpm run test
 
+  agentred-packaging:
+    name: agentred Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Verify release workflows and POSIX installer
+        run: |
+          python3 scripts/test-release-workflows.py
+          bash scripts/test-install.sh
+
+  agentred-installer-windows:
+    name: agentred Windows Installer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Verify PowerShell installer
+        shell: pwsh
+        run: scripts/test-install.ps1
+
   e2e:
     name: E2E
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -173,14 +173,14 @@ jobs:
         if: matrix.goos != 'windows'
         run: |
           if [ -n "${{ matrix.extra_tags }}" ]; then
-            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}" -tags "${{ matrix.extra_tags }}"
+            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}" -tags "${{ matrix.extra_tags }}"
           else
-            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}"
+            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}"
           fi
 
       - name: Build desktop app (Windows)
         if: matrix.goos == 'windows'
-        run: wails build -nsis -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}"
+        run: wails build -nsis -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ needs.prepare.outputs.sha }}"
 
       - name: Import Apple certificate
         if: matrix.goos == 'darwin'
@@ -281,9 +281,61 @@ jobs:
           name: nightly-agentre-${{ matrix.platform }}
           path: agentre-${{ env.VERSION }}-${{ matrix.platform }}*
 
+  build-agentred:
+    name: agentred (${{ matrix.platform }})
+    needs: [prepare]
+    if: ${{ always() && !failure() && !cancelled() && needs.prepare.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      COMMIT_ID: ${{ needs.prepare.outputs.sha }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            platform: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            platform: darwin-arm64
+          - goos: linux
+            goarch: amd64
+            platform: linux-amd64
+          - goos: linux
+            goarch: arm64
+            platform: linux-arm64
+          - goos: windows
+            goarch: amd64
+            platform: windows-amd64
+          - goos: windows
+            goarch: arm64
+            platform: windows-arm64
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: nightly
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and package agentred
+        run: |
+          make agentred-package \
+            VERSION="${VERSION}" \
+            COMMIT_ID="${COMMIT_ID}" \
+            AGENTRED_GOOS=${{ matrix.goos }} \
+            AGENTRED_GOARCH=${{ matrix.goarch }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: nightly-agentred-${{ matrix.platform }}
+          path: build/agentred-dist/*
+
   release:
     name: Update Nightly Release
-    needs: [prepare, build-desktop]
+    needs: [prepare, build-desktop, build-agentred]
     if: ${{ always() && !failure() && !cancelled() && needs.prepare.outputs.skip != 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -297,8 +349,14 @@ jobs:
           pattern: nightly-*
           merge-multiple: true
 
-      - name: Generate checksums
-        run: cd artifacts && sha256sum * > SHA256SUMS.txt
+      - name: Add nightly installers and generate compatibility checksums
+        run: |
+          sed 's#https://github.com/agentre-ai/agentre/releases/latest/download#https://github.com/agentre-ai/agentre/releases/download/nightly#g' scripts/install.sh > artifacts/install.sh
+          sed 's#https://github.com/agentre-ai/agentre/releases/latest/download#https://github.com/agentre-ai/agentre/releases/download/nightly#g' scripts/install.ps1 > artifacts/install.ps1
+          cd artifacts
+          sha256sum * > SHA256SUMS
+          cp SHA256SUMS SHA256SUMS.txt
+          cmp SHA256SUMS SHA256SUMS.txt
 
       - name: Update nightly release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,14 +94,14 @@ jobs:
         if: matrix.goos != 'windows'
         run: |
           if [ -n "${{ matrix.extra_tags }}" ]; then
-            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}" -tags "${{ matrix.extra_tags }}"
+            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}" -tags "${{ matrix.extra_tags }}"
           else
-            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}"
+            wails build -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}"
           fi
 
       - name: Build desktop app (Windows)
         if: matrix.goos == 'windows'
-        run: wails build -nsis -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}"
+        run: wails build -nsis -platform ${{ matrix.goos }}/${{ matrix.goarch }} -ldflags="-s -w -X github.com/cago-frame/cago/configs.Version=${{ env.VERSION }} -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=${{ env.COMMIT_ID }}"
 
       - name: Import Apple certificate
         if: matrix.goos == 'darwin'
@@ -203,9 +203,54 @@ jobs:
           name: release-agentre-${{ matrix.platform }}
           path: agentre-${{ env.VERSION }}-${{ matrix.platform }}*
 
+  build-agentred:
+    name: agentred (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            platform: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            platform: darwin-arm64
+          - goos: linux
+            goarch: amd64
+            platform: linux-amd64
+          - goos: linux
+            goarch: arm64
+            platform: linux-arm64
+          - goos: windows
+            goarch: amd64
+            platform: windows-amd64
+          - goos: windows
+            goarch: arm64
+            platform: windows-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and package agentred
+        run: |
+          make agentred-package \
+            VERSION="${VERSION}" \
+            COMMIT_ID="${COMMIT_ID}" \
+            AGENTRED_GOOS=${{ matrix.goos }} \
+            AGENTRED_GOARCH=${{ matrix.goarch }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-agentred-${{ matrix.platform }}
+          path: build/agentred-dist/*
+
   release:
     name: Create Release
-    needs: [build-desktop]
+    needs: [build-desktop, build-agentred]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -218,8 +263,13 @@ jobs:
           pattern: release-*
           merge-multiple: true
 
-      - name: Generate checksums
-        run: cd artifacts && sha256sum * > SHA256SUMS.txt
+      - name: Add installers and generate compatibility checksums
+        run: |
+          cp scripts/install.sh scripts/install.ps1 artifacts/
+          cd artifacts
+          sha256sum * > SHA256SUMS
+          cp SHA256SUMS SHA256SUMS.txt
+          cmp SHA256SUMS SHA256SUMS.txt
 
       - name: Determine prerelease
         id: prerelease

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run dev build agrctl agentred agentred-linux agentred-deploy agentred-deploy-restart agentred-deploy-local-coding agentred-local-coding generate test test-backend test-frontend test-cover lint lint-backend lint-frontend lint-fix lint-fix-backend lint-fix-frontend mock install install-deps clean check e2e e2e-scratch
+.PHONY: run dev build agrctl agentred agentred-package agentred-linux agentred-deploy agentred-deploy-restart agentred-deploy-local-coding agentred-local-coding generate test test-backend test-frontend test-cover test-agentred-packaging lint lint-backend lint-frontend lint-fix lint-fix-backend lint-fix-frontend mock install install-deps clean check e2e e2e-scratch
 
 APP_NAME := Agentre
 VERSION ?= 0.1.0
@@ -26,10 +26,12 @@ PREFIX ?= /usr/local
 WAILS_PLATFORM ?=
 WAILS_BUILD_FLAGS ?=
 AGENTRED_BUILD_DIR ?= build/bin
+AGENTRED_DIST_DIR ?= build/agentred-dist
 AGRCTL_BINARY := $(AGENTRED_BUILD_DIR)/agrctl$(EXE)
 AGENTRED_LOCAL_BINARY := $(AGENTRED_BUILD_DIR)/agentred
 AGENTRED_GOOS ?= linux
 AGENTRED_GOARCH ?= amd64
+AGENTRED_PACKAGE_NAME := agentred-$(VERSION)-$(AGENTRED_GOOS)-$(AGENTRED_GOARCH)
 AGENTRED_LINUX_BINARY := $(AGENTRED_BUILD_DIR)/agentred-$(AGENTRED_GOOS)-$(AGENTRED_GOARCH)
 AGENTRED_TARGET ?= local-coding
 AGENTRED_REMOTE_PATH ?= /usr/local/bin/agentred
@@ -64,6 +66,19 @@ agrctl:
 agentred:
 	mkdir -p "$(AGENTRED_BUILD_DIR)"
 	go build -ldflags="$(LDFLAGS)" -o "$(AGENTRED_LOCAL_BINARY)" ./cmd/agentred
+
+# 构建可发布的 agentred 跨平台归档（darwin/linux: tar.gz；windows: zip）。
+agentred-package:
+	rm -rf "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)"
+	mkdir -p "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)"
+ifeq ($(AGENTRED_GOOS),windows)
+	CGO_ENABLED=0 GOOS=$(AGENTRED_GOOS) GOARCH=$(AGENTRED_GOARCH) go build -ldflags="$(LDFLAGS)" -o "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)/agentred.exe" ./cmd/agentred
+	cd "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)" && zip -q "../$(AGENTRED_PACKAGE_NAME).zip" agentred.exe
+else
+	CGO_ENABLED=0 GOOS=$(AGENTRED_GOOS) GOARCH=$(AGENTRED_GOARCH) go build -ldflags="$(LDFLAGS)" -o "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)/agentred" ./cmd/agentred
+	tar -C "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)" -czf "$(AGENTRED_DIST_DIR)/$(AGENTRED_PACKAGE_NAME).tar.gz" agentred
+endif
+	rm -rf "$(AGENTRED_DIST_DIR)/.$(AGENTRED_PACKAGE_NAME)"
 
 # 构建 agentred Linux 版本(默认 linux/amd64，可覆盖 AGENTRED_GOOS/AGENTRED_GOARCH)
 agentred-linux:
@@ -164,6 +179,12 @@ test-cover:
 	go test -coverprofile=coverage.out $(BACKEND_PKGS)
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "覆盖率报告已生成: coverage.html"
+
+# 发布资产、安装脚本与 workflow 契约的聚焦测试。
+test-agentred-packaging:
+	python3 scripts/test-release-workflows.py
+	bash scripts/test-install.sh
+	@if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -File scripts/test-install.ps1; else echo "pwsh not found; install.ps1 runs on the Windows CI job"; fi
 
 # 前后端代码检查
 lint: lint-backend lint-frontend

--- a/README.md
+++ b/README.md
@@ -60,9 +60,29 @@ Agentre gives that workflow one desktop home. Each **Agent** has a role, avatar,
 
 ## Remote Execution
 
-Agentre includes `agentred`, a companion daemon for running sessions on another Linux or macOS machine on your LAN.
+Agentre uses `agentred`, a companion daemon for running sessions on another macOS, Linux, or Windows machine on your LAN. Released builds are available for amd64 and arm64.
 
-1. Open **Settings → Remote devices** and pair an `agentred` daemon.
+Install the latest release on macOS or Linux:
+
+```bash
+curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh
+agentred --version
+agentred service install --start
+agentred service status
+```
+
+Install the latest release from PowerShell on Windows (no administrator shell required):
+
+```powershell
+irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex
+agentred --version
+agentred service install --start
+agentred service status
+```
+
+Then connect it to the desktop app:
+
+1. Open **Settings → Remote devices** and pair the `agentred` daemon.
 2. Open **Settings → Agent backends** and create a backend whose run device is the paired machine.
 3. In **Project → Settings → Members**, add an agent that uses that backend and points to the working path on the remote machine.
 4. Start a chat from the command palette. The session runs remotely, and the desktop app still shows tool approvals, questions, status, and output.

--- a/cmd/agentred/README.md
+++ b/cmd/agentred/README.md
@@ -1,78 +1,103 @@
 # agentred
 
-Headless agent compute daemon for Agentre — a stateless executor that runs
-claude-code / codex subprocesses on behalf of remote desktops over a
-JSON-RPC over WebSocket control API on the local network.
+`agentred` is Agentre's headless compute daemon. It runs Claude Code and Codex
+subprocesses on a remote macOS, Linux, or Windows machine and connects to the
+desktop over JSON-RPC over WebSocket on the LAN.
 
-## Quickstart
+The daemon is stateful: it keeps runtime/account configuration in `state.json`
+and durable session and notification journals in its own `agentred.db` SQLite
+database.
+
+## Install a release
+
+macOS or Linux (amd64/arm64):
 
 ```bash
-# build the binary
-go build -o agentred ./cmd/agentred
-
-# in one shell — start the daemon
-./agentred run
-
-# in another shell on the same machine — mint a pairing code
-./agentred pair
-# → Pairing code: ABC2DE
-#   Expires in 300 seconds.
-#   On desktop, use any of:
-#     ws://192.168.1.100:7456/rpc
-
-# anywhere — inspect status
-./agentred status
-# → Daemon running, pid 12345
-#   Listening on:
-#     ws://192.168.1.100:7456/rpc
-#   Paired devices: 0
-#   Active sessions: 0
-#   LLM providers: 0
+curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh
+agentred --version
+agentred service install --start
+agentred service status
 ```
+
+Windows PowerShell (amd64/arm64, no administrator shell required):
+
+```powershell
+irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex
+agentred --version
+agentred service install --start
+agentred service status
+```
+
+The POSIX installer verifies `SHA256SUMS` and installs to writable
+`/usr/local/bin`, falling back to `~/.local/bin`. The PowerShell installer
+verifies the same checksum manifest, installs to
+`%LOCALAPPDATA%\Programs\agentred\`, and updates the user PATH.
+
+## Pair with Agentre
+
+After the service is running, mint a one-shot pairing code:
+
+```bash
+agentred pair
+# Pairing code: ABC2DE
+# Expires in 300 seconds.
+```
+
+Enter the code in **Settings → Remote devices** in the desktop app. Use
+`agentred status` or `agentred service status` to inspect the running daemon,
+including its build version, listen URLs, active sessions, and database size.
+
+## Service lifecycle
+
+`agentred service` manages a user-level background service and does not require
+a system-wide service installation:
+
+| Platform | Manager |
+|---|---|
+| macOS | launchd LaunchAgent |
+| Linux | `systemd --user` (installation attempts to enable linger and prints a repair command if host policy rejects it) |
+| Windows | Task Scheduler task for the current user |
+
+```bash
+agentred service install          # install/update registration only
+agentred service install --start  # install/update and start
+agentred service start
+agentred service status
+agentred service restart
+agentred service stop
+agentred service uninstall
+```
+
+The generated service runs the currently installed binary's `run` command with
+the resolved `AGENTRED_DATA_DIR`. Explicit run configuration is persisted, so
+moving from a foreground invocation to the background service does not discard
+listen or account-server settings.
 
 ## CLI subcommands
 
 | Command | Purpose |
 |---|---|
-| `agentred run [flags]` | Boot the daemon (foreground; SIGINT/SIGTERM to stop). |
-| `agentred status` | Print daemon state via the local unix socket. |
-| `agentred pair` | Mint a one-shot pairing code + advertise listen URLs. |
+| `agentred --version` | Print `agentred <semver> (<commit>)`. |
+| `agentred run [flags]` | Boot the daemon in the foreground. |
+| `agentred status` | Query daemon state over local IPC (Unix socket or current-user Windows named pipe). |
+| `agentred pair` | Mint a one-shot pairing code and advertise listen URLs. |
+| `agentred login --server=<url>` | Claim the daemon through the account device flow and persist the server URL. |
+| `agentred unclaim` | Remove the local account claim. |
+| `agentred service <action>` | Manage the user-level background service. |
 | `agentred llm list` | List LLM providers without printing raw API keys. |
 | `agentred llm add --key=<uuid> --name=<name> --type=<type> --api-key=<key>` | Add or update an LLM provider. |
 | `agentred llm remove --key=<uuid>` | Delete an LLM provider. |
-| `agentred claudecode <args...>` | Internal: claudecode hook passthrough used by spawned subprocesses. |
+| `agentred claudecode <args...>` | Internal Claude Code hook passthrough used by spawned subprocesses. |
 
-`agentred run` flags:
-- `--host HOST` (default `0.0.0.0`) — LAN listen address
-- `--port PORT` (default `7456`) — LAN listen port
-- `--tls-cert PATH` — PEM certificate path; enables `wss://` (must pair with `--tls-key`)
-- `--tls-key PATH` — PEM private key path
-
-## Encryption (optional)
-
-By default agentred serves plain `ws://`. To enable `wss://`, provide a cert/key
-pair. The recommended way to generate a locally trusted cert is `mkcert`:
-
-```bash
-brew install mkcert     # macOS; or use your platform's installer
-mkcert -install
-mkcert agentred.local 192.168.1.100
-
-./agentred run \
-  --tls-cert agentred.local+1.pem \
-  --tls-key  agentred.local+1-key.pem
-# → serves wss://192.168.1.100:7456/rpc
-```
-
-On the desktop side, the user picks one of four TLS trust modes (spec §4.7):
-- `default` — OS trust store (works for mkcert-installed CAs)
-- `pin-cert` — pin the daemon's leaf cert
-- `ca-bundle` — supply a custom CA bundle (corporate PKI)
-- `skip-verify` — debug only; bypasses verification
+`agentred run` accepts `--host`, `--port`, `--tls-cert`, `--tls-key`, and
+`--server`. Resolution order is explicit flag, environment, persisted state,
+then default. The corresponding environment variables are `AGENTRED_HOST`,
+`AGENTRED_PORT`, `AGENTRED_TLS_CERT`, `AGENTRED_TLS_KEY`, and
+`AGENTRED_SERVER_URL`.
 
 ## Storage layout
 
-agentred uses its own `AppDataDir` (separate from agentre desktop):
+`agentred` uses a data directory separate from the desktop app:
 
 | Platform | Path |
 |---|---|
@@ -80,27 +105,21 @@ agentred uses its own `AppDataDir` (separate from agentre desktop):
 | Linux | `~/.config/agentred/` |
 | Windows | `%LOCALAPPDATA%\agentred\` |
 
-Inside:
+Important files are:
 
-```
+```text
 <AppDataDir>/
-  state.json         — daemon runtime state (UUID, listen prefs, paired peers, LLM providers)
-  agentred.sock      — unix socket for local CLI ↔ daemon IPC
-  logs/              — (reserved; structured logging not wired in MVP)
+  state.json    runtime state, listen preferences, account claim, and LLM providers
+  agentred.db   SQLite session and notification journals
 ```
 
-LLM API keys are stored directly in `state.json`. `agentred llm list` only
-prints masked key tails and never returns raw API keys.
+Local CLI IPC uses `agentred.sock` on Unix and a current-user named pipe on
+Windows. Override the data directory for testing or operations with
+`AGENTRED_DATA_DIR`.
 
-Override the data dir for testing or ops with `AGENTRED_DATA_DIR=/tmp/...`.
+## Encryption
 
-## Architecture
-
-- Single binary, no SQLite, no embedded frontend — purely a control daemon.
-- Transport: JSON-RPC 2.0 over WebSocket with subprotocol `agentred-jsonrpc.v1`.
-- Pairing: 6-char base32 code (TTL 5 min, one-shot, per-IP rate-limited) + 256-bit
-  device token + TOFU daemon fingerprint pinning.
-- LLM gateway: reuses `internal/pkg/httpgateway` to mint per-call tokens and forward
-  Anthropic / OpenAI requests with keys loaded from daemon state.
-- Subprocess: dispatches to `internal/pkg/agentruntime`'s BackendRunner registry
-  (claudecode / codex backends; builtin not supported).
+By default the LAN endpoint uses `ws://`. Supply both `--tls-cert` and
+`--tls-key` to use `wss://`. A locally trusted certificate can be generated with
+`mkcert`; the desktop supports OS trust, leaf-certificate pinning, a custom CA
+bundle, and an explicit development-only skip-verification mode.

--- a/cmd/agentred/client.go
+++ b/cmd/agentred/client.go
@@ -1,27 +1,17 @@
 package main
 
 import (
-	"context"
 	"io"
-	"net"
 	"net/http"
-	"path/filepath"
 
 	"github.com/agentre-ai/agentre/internal/pkg/paths"
 )
 
-// localClient dials the daemon's unix socket so CLI subcommands can talk to a
-// locally running agentred without re-implementing the JSON-RPC transport.
+// localClient dials the daemon's platform-local endpoint so CLI subcommands
+// can use the same HTTP routes on Unix sockets and Windows named pipes.
 func localClient() *http.Client {
 	dir, _ := paths.AgentredDataDir()
-	sock := filepath.Join(dir, "agentred.sock")
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", sock)
-			},
-		},
-	}
+	return &http.Client{Transport: &http.Transport{DialContext: localDialContext(dir)}}
 }
 
 func localGET(path string) ([]byte, error) {

--- a/cmd/agentred/client_unix.go
+++ b/cmd/agentred/client_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"net"
+
+	"github.com/agentre-ai/agentre/internal/pkg/agentredipc"
+)
+
+func localDialContext(dataDir string) func(context.Context, string, string) (net.Conn, error) {
+	return agentredipc.DialContext(dataDir)
+}

--- a/cmd/agentred/client_windows.go
+++ b/cmd/agentred/client_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"net"
+
+	"github.com/agentre-ai/agentre/internal/pkg/agentredipc"
+)
+
+func localDialContext(dataDir string) func(context.Context, string, string) (net.Conn, error) {
+	return agentredipc.DialContext(dataDir)
+}

--- a/cmd/agentred/login.go
+++ b/cmd/agentred/login.go
@@ -205,6 +205,9 @@ func login(cmd *cobra.Command, deps loginDeps, st *state.State, serverURL string
 		RefreshToken:          token.RefreshToken,
 		RefreshTokenExpiresAt: now.Add(time.Duration(token.RefreshExpiresIn) * time.Second).Unix(),
 	})
+	st.Mutate(func(current *state.State) {
+		current.HubServerURL = serverURL
+	})
 	if err := st.Save(); err != nil {
 		return fmt.Errorf("save account claim: %w", err)
 	}

--- a/cmd/agentred/login.go
+++ b/cmd/agentred/login.go
@@ -79,7 +79,7 @@ func newLoginCmd() *cobra.Command {
 			return nil
 		},
 		platform: runtime.GOOS,
-		version:  "dev",
+		version:  agentredBuildIdentity(),
 	})
 }
 

--- a/cmd/agentred/login_test.go
+++ b/cmd/agentred/login_test.go
@@ -101,6 +101,31 @@ func TestLoginCompletesDeviceFlowAndPersistsOpaqueAccountClaim(t *testing.T) {
 	assert.NotZero(t, got.Credential.RefreshTokenExpiresAt)
 }
 
+func TestGivenInjectedBuildIdentityWhenLoginAuthorizesThenRegistersSameIdentity(t *testing.T) {
+	setAgentredBuildIdentityForTest(t, "v1.2.3", "abcdef1234567890")
+
+	t.Setenv("AGENTRED_DATA_DIR", t.TempDir())
+	var registeredVersion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/oauth/device/authorize", r.URL.Path)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		registeredVersion, _ = body["version"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer server.Close()
+
+	cmd := newLoginCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--server", server.URL})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid response")
+	assert.Equal(t, "v1.2.3 (abcdef1)", registeredVersion)
+}
+
 func TestLoginRejectsAlreadyClaimedDaemonWithoutNetwork(t *testing.T) {
 	dir := t.TempDir()
 	st, err := state.Load(dir)

--- a/cmd/agentred/login_test.go
+++ b/cmd/agentred/login_test.go
@@ -99,12 +99,14 @@ func TestLoginCompletesDeviceFlowAndPersistsOpaqueAccountClaim(t *testing.T) {
 	assert.Equal(t, "refresh-token", got.Credential.RefreshToken)
 	assert.NotZero(t, got.Credential.AccessTokenExpiresAt)
 	assert.NotZero(t, got.Credential.RefreshTokenExpiresAt)
+	assert.Equal(t, server.URL, got.HubServerURL, "successful login must persist the server used by service startup")
 }
 
 func TestGivenInjectedBuildIdentityWhenLoginAuthorizesThenRegistersSameIdentity(t *testing.T) {
 	setAgentredBuildIdentityForTest(t, "v1.2.3", "abcdef1234567890")
 
-	t.Setenv("AGENTRED_DATA_DIR", t.TempDir())
+	dir := t.TempDir()
+	t.Setenv("AGENTRED_DATA_DIR", dir)
 	var registeredVersion string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/v1/oauth/device/authorize", r.URL.Path)
@@ -124,6 +126,9 @@ func TestGivenInjectedBuildIdentityWhenLoginAuthorizesThenRegistersSameIdentity(
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid response")
 	assert.Equal(t, "v1.2.3 (abcdef1)", registeredVersion)
+	got, loadErr := state.Load(dir)
+	require.NoError(t, loadErr)
+	assert.Empty(t, got.HubServerURL, "failed login must not replace persisted runtime configuration")
 }
 
 func TestLoginRejectsAlreadyClaimedDaemonWithoutNetwork(t *testing.T) {

--- a/cmd/agentred/main_test.go
+++ b/cmd/agentred/main_test.go
@@ -10,13 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
 	"github.com/agentre-ai/agentre/internal/pkg/paths"
+	"github.com/cago-frame/cago/configs"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func setAgentredBuildIdentityForTest(t *testing.T, version, commit string) {
+	t.Helper()
+	previousVersion, previousCommit := configs.Version, buildinfo.CommitID
+	configs.Version, buildinfo.CommitID = version, commit
+	t.Cleanup(func() {
+		configs.Version, buildinfo.CommitID = previousVersion, previousCommit
+	})
+}
 
 // TestRootSubcommands locks in the public CLI surface: any accidental rename
 // or removal of a subcommand here breaks the test, which is much louder than
@@ -169,6 +180,17 @@ func TestRunFlagDefaults(t *testing.T) {
 	assert.Equal(t, "0.0.0.0", host)
 
 	assert.Nil(t, runCmd.Flags().Lookup("key-storage"))
+}
+
+func TestGivenInjectedBuildIdentityWhenRequestingVersionThenReportsStableFormat(t *testing.T) {
+	setAgentredBuildIdentityForTest(t, "v1.2.3", "abcdef1234567890")
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"--version"})
+	require.NoError(t, root.Execute())
+	assert.Equal(t, "agentred v1.2.3 (abcdef1)\n", buf.String())
 }
 
 func TestRootHelpMentionsBinary(t *testing.T) {

--- a/cmd/agentred/main_test.go
+++ b/cmd/agentred/main_test.go
@@ -39,7 +39,7 @@ func TestRootSubcommands(t *testing.T) {
 	for _, c := range root.Commands() {
 		got[c.Name()] = true
 	}
-	for _, want := range []string{"run", "status", "pair", "login", "unclaim", "llm", "claudecode"} {
+	for _, want := range []string{"run", "status", "pair", "login", "unclaim", "llm", "claudecode", "service"} {
 		assert.True(t, got[want], "missing subcommand %q", want)
 	}
 

--- a/cmd/agentred/main_test.go
+++ b/cmd/agentred/main_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cago-frame/cago/configs"
+
 	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
 	"github.com/agentre-ai/agentre/internal/pkg/paths"
-	"github.com/cago-frame/cago/configs"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/cmd/agentred/root.go
+++ b/cmd/agentred/root.go
@@ -38,6 +38,7 @@ remote desktops over a JSON-RPC over WebSocket control API on the LAN.`,
 		newUnclaimCmd(),
 		newLLMCmd(),
 		newClaudeCodeCmd(),
+		newServiceCmd(),
 	)
 	return root
 }

--- a/cmd/agentred/root.go
+++ b/cmd/agentred/root.go
@@ -19,8 +19,9 @@ func newUsageError(format string, args ...any) error {
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "agentred",
-		Short: "Headless agent compute daemon",
+		Use:     "agentred",
+		Short:   "Headless agent compute daemon",
+		Version: agentredBuildIdentity(),
 		Long: `agentred — headless agent compute daemon.
 
 Stateless executor that runs claude-code / codex subprocesses on behalf of
@@ -28,6 +29,7 @@ remote desktops over a JSON-RPC over WebSocket control API on the LAN.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 	}
+	root.SetVersionTemplate("agentred {{.Version}}\n")
 	root.AddCommand(
 		newRunCmd(),
 		newStatusCmd(),

--- a/cmd/agentred/run.go
+++ b/cmd/agentred/run.go
@@ -139,6 +139,9 @@ func resolveRunConfig(cmd *cobra.Command, persisted state.State, flagHost string
 	config.listen.TLSCertFile = strings.TrimSpace(config.listen.TLSCertFile)
 	config.listen.TLSKeyFile = strings.TrimSpace(config.listen.TLSKeyFile)
 	config.serverURL = strings.TrimSpace(config.serverURL)
+	if (config.listen.TLSCertFile == "") != (config.listen.TLSKeyFile == "") {
+		return resolvedRunConfig{}, newUsageError("both --tls-cert and --tls-key must be set or neither")
+	}
 	if config.serverURL != "" {
 		config.serverURL, err = validServerURL(config.serverURL)
 		if err != nil {

--- a/cmd/agentred/run.go
+++ b/cmd/agentred/run.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -10,10 +13,40 @@ import (
 
 	"github.com/agentre-ai/agentre/e2e/fakes"
 	"github.com/agentre-ai/agentre/internal/daemon"
+	"github.com/agentre-ai/agentre/internal/daemon/state"
 	"github.com/agentre-ai/agentre/internal/pkg/paths"
 )
 
+const (
+	defaultAgentredHost = "0.0.0.0"
+	defaultAgentredPort = 7456
+)
+
+type runDaemon interface {
+	Run(context.Context) error
+}
+
+type runDeps struct {
+	dataDir   func() (string, error)
+	newDaemon func(daemon.Options) (runDaemon, error)
+}
+
+type resolvedRunConfig struct {
+	listen       state.ListenPrefs
+	serverURL    string
+	hasOverrides bool
+}
+
 func newRunCmd() *cobra.Command {
+	return newRunCmdWithDeps(runDeps{
+		dataDir: paths.AgentredDataDir,
+		newDaemon: func(opts daemon.Options) (runDaemon, error) {
+			return daemon.New(opts)
+		},
+	})
+}
+
+func newRunCmdWithDeps(deps runDeps) *cobra.Command {
 	var (
 		tlsCert   string
 		tlsKey    string
@@ -26,31 +59,38 @@ func newRunCmd() *cobra.Command {
 		Short: "Boot the daemon (foreground; SIGINT/SIGTERM to stop)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			serverURL = strings.TrimSpace(serverURL)
-			if serverURL != "" {
-				var err error
-				serverURL, err = validServerURL(serverURL)
-				if err != nil {
-					return err
-				}
-			}
-			dir, err := paths.AgentredDataDir()
+			dir, err := deps.dataDir()
 			if err != nil {
 				return err
 			}
-			if err := os.MkdirAll(dir, 0o700); err != nil {
+			st, err := state.Load(dir)
+			if err != nil {
 				return err
 			}
+			config, err := resolveRunConfig(cmd, st.Snapshot(), host, port, tlsCert, tlsKey, serverURL)
+			if err != nil {
+				return err
+			}
+			if config.hasOverrides {
+				st.Mutate(func(s *state.State) {
+					s.Listen = config.listen
+					s.HubServerURL = config.serverURL
+				})
+				if err := st.Save(); err != nil {
+					return fmt.Errorf("save daemon runtime configuration: %w", err)
+				}
+			}
+
 			// e2e 构建(go build -tags e2e)在这里安装确定性 fake runtime,让 web 端到端
 			// 对 agentred 的 runtime.run 得到字节稳定的回复;默认构建里是空操作。
 			fakes.InstallAgentred(cmd.Context())
-			d, err := daemon.New(daemon.Options{
+			d, err := deps.newDaemon(daemon.Options{
 				DataDir:      dir,
-				LANHost:      host,
-				LANPort:      port,
-				TLSCertFile:  tlsCert,
-				TLSKeyFile:   tlsKey,
-				HubServerURL: serverURL,
+				LANHost:      config.listen.LanHost,
+				LANPort:      config.listen.LanPort,
+				TLSCertFile:  config.listen.TLSCertFile,
+				TLSKeyFile:   config.listen.TLSKeyFile,
+				HubServerURL: config.serverURL,
 			})
 			if err != nil {
 				return err
@@ -60,10 +100,80 @@ func newRunCmd() *cobra.Command {
 			return d.Run(ctx)
 		},
 	}
-	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "PEM certificate path; enables wss://")
-	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "PEM private key path; required with --tls-cert")
-	cmd.Flags().StringVar(&host, "host", "0.0.0.0", "LAN listen host")
-	cmd.Flags().IntVar(&port, "port", 7456, "LAN listen port")
+	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "PEM certificate path (or AGENTRED_TLS_CERT); enables wss://")
+	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "PEM private key path (or AGENTRED_TLS_KEY); required with --tls-cert")
+	cmd.Flags().StringVar(&host, "host", defaultAgentredHost, "LAN listen host (or AGENTRED_HOST)")
+	cmd.Flags().IntVar(&port, "port", defaultAgentredPort, "LAN listen port (or AGENTRED_PORT)")
 	cmd.Flags().StringVar(&serverURL, "server", strings.TrimSpace(os.Getenv("AGENTRED_SERVER_URL")), "account server base URL (or AGENTRED_SERVER_URL)")
 	return cmd
+}
+
+func resolveRunConfig(cmd *cobra.Command, persisted state.State, flagHost string, flagPort int,
+	flagTLSCert, flagTLSKey, flagServerURL string) (resolvedRunConfig, error) {
+	config := resolvedRunConfig{}
+	config.listen.LanHost, config.hasOverrides = resolveString(
+		cmd.Flags().Changed("host"), flagHost, "AGENTRED_HOST", persisted.Listen.LanHost, defaultAgentredHost,
+	)
+
+	port, portOverride, err := resolvePort(cmd.Flags().Changed("port"), flagPort, persisted.Listen.LanPort)
+	if err != nil {
+		return resolvedRunConfig{}, err
+	}
+	config.listen.LanPort = port
+	config.hasOverrides = config.hasOverrides || portOverride
+
+	config.listen.TLSCertFile, portOverride = resolveString(
+		cmd.Flags().Changed("tls-cert"), flagTLSCert, "AGENTRED_TLS_CERT", persisted.Listen.TLSCertFile, "",
+	)
+	config.hasOverrides = config.hasOverrides || portOverride
+	config.listen.TLSKeyFile, portOverride = resolveString(
+		cmd.Flags().Changed("tls-key"), flagTLSKey, "AGENTRED_TLS_KEY", persisted.Listen.TLSKeyFile, "",
+	)
+	config.hasOverrides = config.hasOverrides || portOverride
+	config.serverURL, portOverride = resolveString(
+		cmd.Flags().Changed("server"), flagServerURL, "AGENTRED_SERVER_URL", persisted.HubServerURL, "",
+	)
+	config.hasOverrides = config.hasOverrides || portOverride
+
+	config.listen.LanHost = strings.TrimSpace(config.listen.LanHost)
+	config.listen.TLSCertFile = strings.TrimSpace(config.listen.TLSCertFile)
+	config.listen.TLSKeyFile = strings.TrimSpace(config.listen.TLSKeyFile)
+	config.serverURL = strings.TrimSpace(config.serverURL)
+	if config.serverURL != "" {
+		config.serverURL, err = validServerURL(config.serverURL)
+		if err != nil {
+			return resolvedRunConfig{}, err
+		}
+	}
+	return config, nil
+}
+
+func resolveString(flagChanged bool, flagValue, envName, persisted, fallback string) (string, bool) {
+	if flagChanged {
+		return flagValue, true
+	}
+	if value, ok := os.LookupEnv(envName); ok {
+		return value, true
+	}
+	if persisted != "" {
+		return persisted, false
+	}
+	return fallback, false
+}
+
+func resolvePort(flagChanged bool, flagValue, persisted int) (int, bool, error) {
+	if flagChanged {
+		return flagValue, true, nil
+	}
+	if raw, ok := os.LookupEnv("AGENTRED_PORT"); ok {
+		port, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			return 0, false, newUsageError("AGENTRED_PORT must be an integer")
+		}
+		return port, true, nil
+	}
+	if persisted != 0 {
+		return persisted, false, nil
+	}
+	return defaultAgentredPort, false, nil
 }

--- a/cmd/agentred/run.go
+++ b/cmd/agentred/run.go
@@ -163,17 +163,24 @@ func resolveString(flagChanged bool, flagValue, envName, persisted, fallback str
 
 func resolvePort(flagChanged bool, flagValue, persisted int) (int, bool, error) {
 	if flagChanged {
-		return flagValue, true, nil
+		return validatePort(flagValue, true)
 	}
 	if raw, ok := os.LookupEnv("AGENTRED_PORT"); ok {
 		port, err := strconv.Atoi(strings.TrimSpace(raw))
 		if err != nil {
 			return 0, false, newUsageError("AGENTRED_PORT must be an integer")
 		}
-		return port, true, nil
+		return validatePort(port, true)
 	}
 	if persisted != 0 {
-		return persisted, false, nil
+		return validatePort(persisted, false)
 	}
 	return defaultAgentredPort, false, nil
+}
+
+func validatePort(port int, override bool) (int, bool, error) {
+	if port < 1 || port > 65535 {
+		return 0, false, newUsageError("port must be between 1 and 65535")
+	}
+	return port, override, nil
 }

--- a/cmd/agentred/run_test.go
+++ b/cmd/agentred/run_test.go
@@ -165,3 +165,33 @@ func TestGivenOutOfRangePortWhenRunStartsThenItReturnsUsageErrorWithoutStartingD
 	assert.Contains(t, err.Error(), "port must be between 1 and 65535")
 	assert.False(t, started)
 }
+
+func TestGivenOnlyOneTLSPathWhenRunStartsThenItReturnsUsageErrorWithoutPersistingConfiguration(t *testing.T) {
+	clearRunEnvironment(t)
+	dir := t.TempDir()
+	st, err := state.Load(dir)
+	require.NoError(t, err)
+	original := st.Snapshot()
+	started := false
+	cmd := newRunCmdWithDeps(runDeps{
+		dataDir: func() (string, error) { return dir, nil },
+		newDaemon: func(daemon.Options) (runDaemon, error) {
+			started = true
+			return fakeRunDaemon{}, nil
+		},
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--tls-cert", "/tmp/cert.pem"})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	var usage *usageError
+	assert.ErrorAs(t, err, &usage)
+	assert.Contains(t, err.Error(), "both --tls-cert and --tls-key")
+	assert.False(t, started)
+
+	reloaded, err := state.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, original.Listen, reloaded.Listen)
+}

--- a/cmd/agentred/run_test.go
+++ b/cmd/agentred/run_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/daemon"
+	"github.com/agentre-ai/agentre/internal/daemon/state"
+)
+
+type fakeRunDaemon struct{}
+
+func (fakeRunDaemon) Run(context.Context) error { return nil }
+
+func clearRunEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"AGENTRED_HOST",
+		"AGENTRED_PORT",
+		"AGENTRED_TLS_CERT",
+		"AGENTRED_TLS_KEY",
+		"AGENTRED_SERVER_URL",
+	} {
+		value, exists := os.LookupEnv(name)
+		require.NoError(t, os.Unsetenv(name))
+		t.Cleanup(func() {
+			if exists {
+				_ = os.Setenv(name, value)
+				return
+			}
+			_ = os.Unsetenv(name)
+		})
+	}
+}
+
+func executeRunForOptions(t *testing.T, dir string, args ...string) (daemon.Options, error) {
+	t.Helper()
+	var got daemon.Options
+	cmd := newRunCmdWithDeps(runDeps{
+		dataDir: func() (string, error) { return dir, nil },
+		newDaemon: func(opts daemon.Options) (runDaemon, error) {
+			got = opts
+			return fakeRunDaemon{}, nil
+		},
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return got, err
+}
+
+func TestGivenPersistedRuntimeConfigurationWhenRunHasNoOverridesThenConfigurationIsRestored(t *testing.T) {
+	clearRunEnvironment(t)
+	dir := t.TempDir()
+	st, err := state.Load(dir)
+	require.NoError(t, err)
+	st.Mutate(func(s *state.State) {
+		s.Listen = state.ListenPrefs{
+			LanHost:     "192.0.2.10",
+			LanPort:     8123,
+			TLSCertFile: "/persisted/cert.pem",
+			TLSKeyFile:  "/persisted/key.pem",
+		}
+		s.HubServerURL = "https://persisted.example"
+	})
+	require.NoError(t, st.Save())
+
+	got, err := executeRunForOptions(t, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "192.0.2.10", got.LANHost)
+	assert.Equal(t, 8123, got.LANPort)
+	assert.Equal(t, "/persisted/cert.pem", got.TLSCertFile)
+	assert.Equal(t, "/persisted/key.pem", got.TLSKeyFile)
+	assert.Equal(t, "https://persisted.example", got.HubServerURL)
+}
+
+func TestGivenFlagsEnvironmentAndStateWhenRunStartsThenPriorityIsFlagsEnvironmentStateDefault(t *testing.T) {
+	clearRunEnvironment(t)
+	dir := t.TempDir()
+	st, err := state.Load(dir)
+	require.NoError(t, err)
+	st.Mutate(func(s *state.State) {
+		s.Listen = state.ListenPrefs{
+			LanHost:     "state-host",
+			LanPort:     7001,
+			TLSCertFile: "/state/cert.pem",
+			TLSKeyFile:  "/state/key.pem",
+		}
+		s.HubServerURL = "https://state.example"
+	})
+	require.NoError(t, st.Save())
+	t.Setenv("AGENTRED_HOST", "env-host")
+	t.Setenv("AGENTRED_PORT", "7002")
+	t.Setenv("AGENTRED_TLS_CERT", "/env/cert.pem")
+	t.Setenv("AGENTRED_SERVER_URL", "https://env.example/")
+
+	got, err := executeRunForOptions(t, dir,
+		"--host", "flag-host",
+		"--tls-key", "/flag/key.pem",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "flag-host", got.LANHost, "flag must override environment")
+	assert.Equal(t, 7002, got.LANPort, "environment must override state")
+	assert.Equal(t, "/env/cert.pem", got.TLSCertFile)
+	assert.Equal(t, "/flag/key.pem", got.TLSKeyFile)
+	assert.Equal(t, "https://env.example", got.HubServerURL)
+
+	reloaded, err := state.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, state.ListenPrefs{
+		LanHost:     "flag-host",
+		LanPort:     7002,
+		TLSCertFile: "/env/cert.pem",
+		TLSKeyFile:  "/flag/key.pem",
+	}, reloaded.Listen, "resolved explicit configuration must survive service startup")
+	assert.Equal(t, "https://env.example", reloaded.HubServerURL)
+}
+
+func TestGivenInvalidPortEnvironmentWhenRunStartsThenItReturnsUsageErrorWithoutStartingDaemon(t *testing.T) {
+	clearRunEnvironment(t)
+	t.Setenv("AGENTRED_PORT", "not-a-port")
+	started := false
+	cmd := newRunCmdWithDeps(runDeps{
+		dataDir: func() (string, error) { return t.TempDir(), nil },
+		newDaemon: func(daemon.Options) (runDaemon, error) {
+			started = true
+			return fakeRunDaemon{}, nil
+		},
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	var usage *usageError
+	assert.ErrorAs(t, err, &usage)
+	assert.Contains(t, err.Error(), "AGENTRED_PORT")
+	assert.False(t, started)
+}

--- a/cmd/agentred/run_test.go
+++ b/cmd/agentred/run_test.go
@@ -143,3 +143,25 @@ func TestGivenInvalidPortEnvironmentWhenRunStartsThenItReturnsUsageErrorWithoutS
 	assert.Contains(t, err.Error(), "AGENTRED_PORT")
 	assert.False(t, started)
 }
+
+func TestGivenOutOfRangePortWhenRunStartsThenItReturnsUsageErrorWithoutStartingDaemon(t *testing.T) {
+	clearRunEnvironment(t)
+	started := false
+	cmd := newRunCmdWithDeps(runDeps{
+		dataDir: func() (string, error) { return t.TempDir(), nil },
+		newDaemon: func(daemon.Options) (runDaemon, error) {
+			started = true
+			return fakeRunDaemon{}, nil
+		},
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--port", "70000"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	var usage *usageError
+	assert.ErrorAs(t, err, &usage)
+	assert.Contains(t, err.Error(), "port must be between 1 and 65535")
+	assert.False(t, started)
+}

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -5,13 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type serviceManagerFactory func() (ServiceManager, error)
 type serviceAction func(context.Context, ServiceManager) (ServiceStatus, error)
-type serviceStatusLoader func() (map[string]any, error)
+type serviceStatusLoader func(context.Context) (map[string]any, error)
+
+const (
+	serviceReadyTimeout      = 15 * time.Second
+	serviceReadyPollInterval = 100 * time.Millisecond
+)
 
 type serviceCommandDeps struct {
 	managerFactory serviceManagerFactory
@@ -47,7 +55,7 @@ func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
 			return ServiceStatus{}, err
 		}
 		if startAfterInstall {
-			started, err := manager.Start(ctx)
+			started, err := startService(ctx, manager, deps.localStatus)
 			if err != nil {
 				return ServiceStatus{}, err
 			}
@@ -60,7 +68,7 @@ func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
 	cmd.AddCommand(
 		install,
 		newServiceActionCmd("start", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
-			return manager.Start(ctx)
+			return startService(ctx, manager, deps.localStatus)
 		}, printServiceStatus),
 		newServiceActionCmd("status", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Status(ctx)
@@ -68,7 +76,11 @@ func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
 			printServiceInspection(w, status, deps.localStatus)
 		}),
 		newServiceActionCmd("restart", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
-			return manager.Restart(ctx)
+			status, err := manager.Restart(ctx)
+			if err != nil {
+				return ServiceStatus{}, err
+			}
+			return waitForLocalDaemon(ctx, manager, status, deps.localStatus)
 		}, printServiceStatus),
 		newServiceActionCmd("stop", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Stop(ctx)
@@ -120,21 +132,71 @@ func serviceActionDescription(action string) string {
 	}
 }
 
-func loadLocalDaemonStatus() (map[string]any, error) {
-	body, err := localGET("/local/status")
+func startService(ctx context.Context, manager ServiceManager, load serviceStatusLoader) (ServiceStatus, error) {
+	status, err := manager.Start(ctx)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	return waitForLocalDaemon(ctx, manager, status, load)
+}
+
+func waitForLocalDaemon(ctx context.Context, manager ServiceManager, status ServiceStatus,
+	load serviceStatusLoader) (ServiceStatus, error) {
+	if load == nil {
+		return status, nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+	defer cancel()
+	var (
+		lastErr    error
+		lastStatus = status
+	)
+	for {
+		if _, err := load(waitCtx); err == nil {
+			return status, nil
+		} else {
+			lastErr = err
+		}
+		observed, err := manager.Status(waitCtx)
+		if err != nil {
+			return ServiceStatus{}, fmt.Errorf("inspect service while waiting for local daemon status: %w", err)
+		}
+		lastStatus = observed
+		if !observed.Running {
+			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: service stopped before becoming ready (last error: %v; service: %s); Run manually: agentred service status", lastErr, strings.Join(observed.Details, ", "))
+		}
+		select {
+		case <-waitCtx.Done():
+			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: %w (last error: %v; service: %s); Run manually: agentred service status", waitCtx.Err(), lastErr, strings.Join(lastStatus.Details, ", "))
+		case <-time.After(serviceReadyPollInterval):
+		}
+	}
+}
+
+func loadLocalDaemonStatus(ctx context.Context) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://daemon/local/status", nil)
 	if err != nil {
 		return nil, err
 	}
+	resp, err := localClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
 	var status map[string]any
-	if err := json.Unmarshal(body, &status); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
 		return nil, err
 	}
 	return status, nil
 }
 
 func printServiceInspection(w io.Writer, status ServiceStatus, load serviceStatusLoader) {
+	printServiceInspectionContext(context.Background(), w, status, load)
+}
+
+func printServiceInspectionContext(ctx context.Context, w io.Writer, status ServiceStatus, load serviceStatusLoader) {
 	if status.Running && load != nil {
-		localStatus, err := load()
+		localStatus, err := load(ctx)
 		if err == nil {
 			printServiceDaemonStatus(w, localStatus)
 			printServiceDetails(w, status.Details)

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -31,7 +31,9 @@ type serviceCommandDeps struct {
 func newServiceCmd() *cobra.Command {
 	return newServiceCmdWithDeps(serviceCommandDeps{
 		managerFactory: newPlatformServiceManager,
-		localStatus:    loadLocalDaemonStatus,
+		localStatus: func(ctx context.Context) (map[string]any, error) {
+			return loadLocalDaemonStatus(ctx, localClient())
+		},
 	})
 }
 
@@ -228,16 +230,19 @@ func daemonStatusPID(status map[string]any) string {
 	return fmt.Sprint(status["pid"])
 }
 
-func loadLocalDaemonStatus(ctx context.Context) (map[string]any, error) {
+func loadLocalDaemonStatus(ctx context.Context, client *http.Client) (map[string]any, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://daemon/local/status", nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := localClient().Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("local daemon status request failed: %s", resp.Status)
+	}
 	var status map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
 		return nil, err

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+type serviceManagerFactory func() (ServiceManager, error)
+type serviceAction func(context.Context, ServiceManager) (ServiceStatus, error)
+type serviceStatusLoader func() (map[string]any, error)
+
+type serviceCommandDeps struct {
+	managerFactory serviceManagerFactory
+	localStatus    serviceStatusLoader
+}
+
+func newServiceCmd() *cobra.Command {
+	return newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: newPlatformServiceManager,
+		localStatus:    loadLocalDaemonStatus,
+	})
+}
+
+func newServiceCmdWithManager(manager ServiceManager) *cobra.Command {
+	return newServiceCmdWithFactory(func() (ServiceManager, error) { return manager, nil })
+}
+
+func newServiceCmdWithFactory(factory serviceManagerFactory) *cobra.Command {
+	return newServiceCmdWithDeps(serviceCommandDeps{managerFactory: factory})
+}
+
+func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "service",
+		Short: "Manage agentred as a user-level background service",
+		Args:  cobra.NoArgs,
+	}
+
+	var startAfterInstall bool
+	install := newServiceActionCmd("install", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+		status, err := manager.Install(ctx)
+		if err != nil {
+			return ServiceStatus{}, err
+		}
+		if startAfterInstall {
+			started, err := manager.Start(ctx)
+			if err != nil {
+				return ServiceStatus{}, err
+			}
+			started.Details = append(status.Details, started.Details...)
+			return started, nil
+		}
+		return status, nil
+	}, printServiceStatus)
+	install.Flags().BoolVar(&startAfterInstall, "start", false, "start the service immediately after installation")
+	cmd.AddCommand(
+		install,
+		newServiceActionCmd("start", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+			return manager.Start(ctx)
+		}, printServiceStatus),
+		newServiceActionCmd("status", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+			return manager.Status(ctx)
+		}, func(w io.Writer, status ServiceStatus) {
+			printServiceInspection(w, status, deps.localStatus)
+		}),
+		newServiceActionCmd("restart", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+			return manager.Restart(ctx)
+		}, printServiceStatus),
+		newServiceActionCmd("stop", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+			return manager.Stop(ctx)
+		}, printServiceStatus),
+		newServiceActionCmd("uninstall", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
+			return manager.Uninstall(ctx)
+		}, printServiceStatus),
+	)
+	return cmd
+}
+
+func newServiceActionCmd(name string, factory serviceManagerFactory, action serviceAction,
+	printer func(io.Writer, ServiceStatus)) *cobra.Command {
+	return &cobra.Command{
+		Use:   name,
+		Short: serviceActionDescription(name),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			manager, err := factory()
+			if err != nil {
+				return fmt.Errorf("%s service: %w", name, err)
+			}
+			status, err := action(cmd.Context(), manager)
+			if err != nil {
+				return fmt.Errorf("%s service: %w", name, err)
+			}
+			printer(cmd.OutOrStdout(), status)
+			return nil
+		},
+	}
+}
+
+func serviceActionDescription(action string) string {
+	switch action {
+	case "install":
+		return "Install or update the user-level service"
+	case "start":
+		return "Start the installed service"
+	case "status":
+		return "Inspect service registration and daemon state"
+	case "restart":
+		return "Restart the installed service"
+	case "stop":
+		return "Stop the installed service"
+	case "uninstall":
+		return "Stop and remove the user-level service"
+	default:
+		return action
+	}
+}
+
+func loadLocalDaemonStatus() (map[string]any, error) {
+	body, err := localGET("/local/status")
+	if err != nil {
+		return nil, err
+	}
+	var status map[string]any
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+func printServiceInspection(w io.Writer, status ServiceStatus, load serviceStatusLoader) {
+	if status.Running && load != nil {
+		localStatus, err := load()
+		if err == nil {
+			printStatus(w, localStatus)
+			printServiceDetails(w, status.Details)
+			return
+		}
+		status.Details = append(status.Details, "Local status unavailable: "+err.Error())
+	}
+	printServiceStatus(w, status)
+}
+
+func printServiceStatus(w io.Writer, status ServiceStatus) {
+	switch {
+	case !status.Installed:
+		_, _ = fmt.Fprintln(w, "Service not installed")
+	case status.Running:
+		_, _ = fmt.Fprintln(w, "Daemon running")
+	default:
+		_, _ = fmt.Fprintln(w, "Daemon stopped")
+	}
+	printServiceDetails(w, status.Details)
+}
+
+func printServiceDetails(w io.Writer, details []string) {
+	for _, detail := range details {
+		_, _ = fmt.Fprintln(w, detail)
+	}
+}

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -136,7 +136,7 @@ func printServiceInspection(w io.Writer, status ServiceStatus, load serviceStatu
 	if status.Running && load != nil {
 		localStatus, err := load()
 		if err == nil {
-			printStatus(w, localStatus)
+			printServiceDaemonStatus(w, localStatus)
 			printServiceDetails(w, status.Details)
 			return
 		}

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -76,11 +76,7 @@ func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
 			printServiceInspection(w, status, deps.localStatus)
 		}),
 		newServiceActionCmd("restart", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
-			status, err := manager.Restart(ctx)
-			if err != nil {
-				return ServiceStatus{}, err
-			}
-			return waitForLocalDaemon(ctx, manager, status, deps.localStatus)
+			return restartService(ctx, manager, deps.localStatus)
 		}, printServiceStatus),
 		newServiceActionCmd("stop", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Stop(ctx)
@@ -140,8 +136,39 @@ func startService(ctx context.Context, manager ServiceManager, load serviceStatu
 	return waitForLocalDaemon(ctx, manager, status, load)
 }
 
+func restartService(ctx context.Context, manager ServiceManager, load serviceStatusLoader) (ServiceStatus, error) {
+	previousPID := ""
+	if load != nil {
+		if current, err := load(ctx); err == nil {
+			previousPID = daemonStatusPID(current)
+		}
+	}
+	status, err := manager.Restart(ctx)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !requiresRestartPIDChange(status) {
+		previousPID = ""
+	}
+	return waitForLocalDaemonPIDChange(ctx, manager, status, load, previousPID)
+}
+
+func requiresRestartPIDChange(status ServiceStatus) bool {
+	for _, detail := range status.Details {
+		if strings.HasPrefix(detail, "Manager: launchd") || strings.HasPrefix(detail, "Manager: systemd") {
+			return true
+		}
+	}
+	return false
+}
+
 func waitForLocalDaemon(ctx context.Context, manager ServiceManager, status ServiceStatus,
 	load serviceStatusLoader) (ServiceStatus, error) {
+	return waitForLocalDaemonPIDChange(ctx, manager, status, load, "")
+}
+
+func waitForLocalDaemonPIDChange(ctx context.Context, manager ServiceManager, status ServiceStatus,
+	load serviceStatusLoader, previousPID string) (ServiceStatus, error) {
 	if load == nil {
 		return status, nil
 	}
@@ -152,8 +179,12 @@ func waitForLocalDaemon(ctx context.Context, manager ServiceManager, status Serv
 		lastStatus = status
 	)
 	for {
-		if _, err := load(waitCtx); err == nil {
-			return status, nil
+		if localStatus, err := load(waitCtx); err == nil {
+			currentPID := daemonStatusPID(localStatus)
+			if previousPID == "" || (currentPID != "" && currentPID != previousPID) {
+				return status, nil
+			}
+			lastErr = fmt.Errorf("local daemon still reports pre-restart PID %s", previousPID)
 		} else {
 			lastErr = err
 		}
@@ -163,14 +194,30 @@ func waitForLocalDaemon(ctx context.Context, manager ServiceManager, status Serv
 		}
 		lastStatus = observed
 		if !observed.Running {
-			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: service stopped before becoming ready (last error: %v; service: %s); Run manually: agentred service status", lastErr, strings.Join(observed.Details, ", "))
+			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: service stopped before becoming ready (last error: %v; service: %s); %s", lastErr, strings.Join(observed.Details, ", "), serviceReadinessDiagnostic(observed))
 		}
 		select {
 		case <-waitCtx.Done():
-			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: %w (last error: %v; service: %s); Run manually: agentred service status", waitCtx.Err(), lastErr, strings.Join(lastStatus.Details, ", "))
+			return ServiceStatus{}, fmt.Errorf("wait for local daemon status: %w (last error: %v; service: %s); %s", waitCtx.Err(), lastErr, strings.Join(lastStatus.Details, ", "), serviceReadinessDiagnostic(lastStatus))
 		case <-time.After(serviceReadyPollInterval):
 		}
 	}
+}
+
+func serviceReadinessDiagnostic(status ServiceStatus) string {
+	for _, detail := range status.Details {
+		if target, ok := strings.CutPrefix(detail, "Target: "); ok {
+			return fmt.Sprintf("launchctl target %s; Run manually: launchctl print %s", target, target)
+		}
+	}
+	return "Run manually: agentred service status"
+}
+
+func daemonStatusPID(status map[string]any) string {
+	if status == nil || status["pid"] == nil {
+		return ""
+	}
+	return fmt.Sprint(status["pid"])
 }
 
 func loadLocalDaemonStatus(ctx context.Context) (map[string]any, error) {

--- a/cmd/agentred/service.go
+++ b/cmd/agentred/service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 type serviceManagerFactory func() (ServiceManager, error)
 type serviceAction func(context.Context, ServiceManager) (ServiceStatus, error)
 type serviceStatusLoader func(context.Context) (map[string]any, error)
+type serviceStatusPrinter func(context.Context, io.Writer, ServiceStatus)
 
 const (
 	serviceReadyTimeout      = 15 * time.Second
@@ -63,33 +65,33 @@ func newServiceCmdWithDeps(deps serviceCommandDeps) *cobra.Command {
 			return started, nil
 		}
 		return status, nil
-	}, printServiceStatus)
+	}, printServiceStatusContext)
 	install.Flags().BoolVar(&startAfterInstall, "start", false, "start the service immediately after installation")
 	cmd.AddCommand(
 		install,
 		newServiceActionCmd("start", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return startService(ctx, manager, deps.localStatus)
-		}, printServiceStatus),
+		}, printServiceStatusContext),
 		newServiceActionCmd("status", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Status(ctx)
-		}, func(w io.Writer, status ServiceStatus) {
-			printServiceInspection(w, status, deps.localStatus)
+		}, func(ctx context.Context, w io.Writer, status ServiceStatus) {
+			printServiceInspectionContext(ctx, w, status, deps.localStatus)
 		}),
 		newServiceActionCmd("restart", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return restartService(ctx, manager, deps.localStatus)
-		}, printServiceStatus),
+		}, printServiceStatusContext),
 		newServiceActionCmd("stop", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Stop(ctx)
-		}, printServiceStatus),
+		}, printServiceStatusContext),
 		newServiceActionCmd("uninstall", deps.managerFactory, func(ctx context.Context, manager ServiceManager) (ServiceStatus, error) {
 			return manager.Uninstall(ctx)
-		}, printServiceStatus),
+		}, printServiceStatusContext),
 	)
 	return cmd
 }
 
 func newServiceActionCmd(name string, factory serviceManagerFactory, action serviceAction,
-	printer func(io.Writer, ServiceStatus)) *cobra.Command {
+	printer serviceStatusPrinter) *cobra.Command {
 	return &cobra.Command{
 		Use:   name,
 		Short: serviceActionDescription(name),
@@ -103,7 +105,7 @@ func newServiceActionCmd(name string, factory serviceManagerFactory, action serv
 			if err != nil {
 				return fmt.Errorf("%s service: %w", name, err)
 			}
-			printer(cmd.OutOrStdout(), status)
+			printer(cmd.Context(), cmd.OutOrStdout(), status)
 			return nil
 		},
 	}
@@ -139,9 +141,11 @@ func startService(ctx context.Context, manager ServiceManager, load serviceStatu
 func restartService(ctx context.Context, manager ServiceManager, load serviceStatusLoader) (ServiceStatus, error) {
 	previousPID := ""
 	if load != nil {
-		if current, err := load(ctx); err == nil {
+		probeCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+		if current, err := load(probeCtx); err == nil {
 			previousPID = daemonStatusPID(current)
 		}
+		cancel()
 	}
 	status, err := manager.Restart(ctx)
 	if err != nil {
@@ -181,10 +185,14 @@ func waitForLocalDaemonPIDChange(ctx context.Context, manager ServiceManager, st
 	for {
 		if localStatus, err := load(waitCtx); err == nil {
 			currentPID := daemonStatusPID(localStatus)
-			if previousPID == "" || (currentPID != "" && currentPID != previousPID) {
+			switch {
+			case currentPID == "":
+				lastErr = errors.New("local daemon status is missing PID")
+			case previousPID == "" || currentPID != previousPID:
 				return status, nil
+			default:
+				lastErr = fmt.Errorf("local daemon still reports pre-restart PID %s", previousPID)
 			}
-			lastErr = fmt.Errorf("local daemon still reports pre-restart PID %s", previousPID)
 		} else {
 			lastErr = err
 		}
@@ -237,10 +245,6 @@ func loadLocalDaemonStatus(ctx context.Context) (map[string]any, error) {
 	return status, nil
 }
 
-func printServiceInspection(w io.Writer, status ServiceStatus, load serviceStatusLoader) {
-	printServiceInspectionContext(context.Background(), w, status, load)
-}
-
 func printServiceInspectionContext(ctx context.Context, w io.Writer, status ServiceStatus, load serviceStatusLoader) {
 	if status.Running && load != nil {
 		localStatus, err := load(ctx)
@@ -251,10 +255,10 @@ func printServiceInspectionContext(ctx context.Context, w io.Writer, status Serv
 		}
 		status.Details = append(status.Details, "Local status unavailable: "+err.Error())
 	}
-	printServiceStatus(w, status)
+	printServiceStatusContext(ctx, w, status)
 }
 
-func printServiceStatus(w io.Writer, status ServiceStatus) {
+func printServiceStatusContext(_ context.Context, w io.Writer, status ServiceStatus) {
 	switch {
 	case !status.Installed:
 		_, _ = fmt.Fprintln(w, "Service not installed")

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -160,7 +160,13 @@ func launchdTerminalFailure(output []byte) bool {
 	}
 	for _, line := range strings.Split(detail, "\n") {
 		value, ok := strings.CutPrefix(strings.TrimSpace(line), "last exit code =")
-		if ok && strings.TrimSpace(value) != "0" {
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(value) {
+		case "0", "(never exited)":
+			continue
+		default:
 			return true
 		}
 	}

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -55,7 +55,7 @@ func (m *launchdServiceManager) Stop(ctx context.Context) (ServiceStatus, error)
 		return ServiceStatus{}, err
 	}
 	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isServiceCommandExit(err) {
+	if err != nil && !isLaunchdMissingService(output) {
 		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
 	}
 	return m.Status(ctx)
@@ -80,7 +80,7 @@ func (m *launchdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, e
 		return ServiceStatus{}, nil
 	}
 	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isServiceCommandExit(err) {
+	if err != nil && !isLaunchdMissingService(output) {
 		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
 	}
 	if err := os.Remove(m.plistPath); err != nil && !os.IsNotExist(err) {
@@ -99,7 +99,7 @@ func (m *launchdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 	}
 	args := []string{"print", m.target}
 	output, err := m.config.Runner.Run(ctx, "launchctl", args...)
-	if err != nil && !isServiceCommandExit(err) {
+	if err != nil && !isLaunchdMissingService(output) {
 		return ServiceStatus{}, serviceCommandError("launchctl", args, output, err)
 	}
 	loaded := err == nil
@@ -116,6 +116,14 @@ func (m *launchdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 	}, nil
 }
 
+func isLaunchdMissingService(output []byte) bool {
+	detail := strings.ToLower(string(output))
+	return strings.Contains(detail, "could not find service") ||
+		strings.Contains(detail, "service not found") ||
+		strings.Contains(detail, "no such process") ||
+		strings.Contains(detail, "service cannot load in requested session")
+}
+
 func (m *launchdServiceManager) bootstrap(ctx context.Context) error {
 	if err := m.bootout(ctx); err != nil {
 		return err
@@ -125,7 +133,7 @@ func (m *launchdServiceManager) bootstrap(ctx context.Context) error {
 
 func (m *launchdServiceManager) bootout(ctx context.Context) error {
 	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isServiceCommandExit(err) {
+	if err != nil && !isLaunchdMissingService(output) {
 		return serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
 	}
 	return nil

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const launchdServiceLabel = "ai.agentre.agentred"
@@ -34,41 +35,58 @@ func (m *launchdServiceManager) Install(ctx context.Context) (ServiceStatus, err
 	if err := writeServiceFile(m.plistPath, []byte(m.plist())); err != nil {
 		return ServiceStatus{}, err
 	}
-	if err := m.bootout(ctx); err != nil {
+	if err := m.bootoutAndWait(ctx); err != nil {
 		return ServiceStatus{}, err
 	}
 	return ServiceStatus{Installed: true}, nil
 }
 
 func (m *launchdServiceManager) Start(ctx context.Context) (ServiceStatus, error) {
-	if err := requireInstalled(m.plistPath); err != nil {
-		return ServiceStatus{}, err
-	}
-	if err := m.bootstrap(ctx); err != nil {
-		return ServiceStatus{}, err
-	}
-	return m.Status(ctx)
+	return m.start(ctx, false)
 }
 
 func (m *launchdServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
 	if err := requireInstalled(m.plistPath); err != nil {
 		return ServiceStatus{}, err
 	}
-	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isLaunchdMissingService(output) {
-		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
+	if err := m.bootoutAndWait(ctx); err != nil {
+		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return ServiceStatus{
+		Installed: true,
+		Details: []string{
+			"Manager: launchd LaunchAgent",
+			"Plist: " + m.plistPath,
+			"Loaded: false",
+			"Running: false",
+		},
+	}, nil
 }
 
 func (m *launchdServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
+	return m.start(ctx, true)
+}
+
+func (m *launchdServiceManager) start(ctx context.Context, restart bool) (ServiceStatus, error) {
 	if err := requireInstalled(m.plistPath); err != nil {
 		return ServiceStatus{}, err
 	}
-	if err := m.bootstrap(ctx); err != nil {
+	_, loaded, err := m.inspect(ctx)
+	if err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	if loaded {
+		args := []string{"kickstart", m.target}
+		if restart {
+			args = []string{"kickstart", "-k", m.target}
+		}
+		if err := m.run(ctx, "launchctl", args...); err != nil {
+			return ServiceStatus{}, err
+		}
+	} else if err := m.run(ctx, "launchctl", "bootstrap", m.domain, m.plistPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.waitForRunning(ctx)
 }
 
 func (m *launchdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
@@ -79,9 +97,8 @@ func (m *launchdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, e
 	if !installed {
 		return ServiceStatus{}, nil
 	}
-	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isLaunchdMissingService(output) {
-		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
+	if err := m.bootoutAndWait(ctx); err != nil {
+		return ServiceStatus{}, err
 	}
 	if err := os.Remove(m.plistPath); err != nil && !os.IsNotExist(err) {
 		return ServiceStatus{}, fmt.Errorf("remove LaunchAgent plist: %w", err)
@@ -90,17 +107,27 @@ func (m *launchdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, e
 }
 
 func (m *launchdServiceManager) Status(ctx context.Context) (ServiceStatus, error) {
+	status, _, err := m.inspect(ctx)
+	return status, err
+}
+
+func (m *launchdServiceManager) inspect(ctx context.Context) (ServiceStatus, bool, error) {
+	status, loaded, _, err := m.inspectOutput(ctx)
+	return status, loaded, err
+}
+
+func (m *launchdServiceManager) inspectOutput(ctx context.Context) (ServiceStatus, bool, []byte, error) {
 	installed, err := serviceFileExists(m.plistPath)
 	if err != nil {
-		return ServiceStatus{}, err
+		return ServiceStatus{}, false, nil, err
 	}
 	if !installed {
-		return ServiceStatus{}, nil
+		return ServiceStatus{}, false, nil, nil
 	}
 	args := []string{"print", m.target}
 	output, err := m.config.Runner.Run(ctx, "launchctl", args...)
 	if err != nil && !isLaunchdMissingService(output) {
-		return ServiceStatus{}, serviceCommandError("launchctl", args, output, err)
+		return ServiceStatus{}, false, output, serviceCommandError("launchctl", args, output, err)
 	}
 	loaded := err == nil
 	running := loaded && strings.Contains(string(output), "state = running")
@@ -113,7 +140,7 @@ func (m *launchdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 			fmt.Sprintf("Loaded: %t", loaded),
 			fmt.Sprintf("Running: %t", running),
 		},
-	}, nil
+	}, loaded, output, nil
 }
 
 func isLaunchdMissingService(output []byte) bool {
@@ -124,19 +151,62 @@ func isLaunchdMissingService(output []byte) bool {
 		strings.Contains(detail, "service cannot load in requested session")
 }
 
-func (m *launchdServiceManager) bootstrap(ctx context.Context) error {
-	if err := m.bootout(ctx); err != nil {
-		return err
-	}
-	return m.run(ctx, "launchctl", "bootstrap", m.domain, m.plistPath)
+func launchdTerminalFailure(output []byte) bool {
+	detail := strings.ToLower(string(output))
+	return strings.Contains(detail, "state = exited") ||
+		strings.Contains(detail, "state = crashed") ||
+		strings.Contains(detail, "last exit code =")
 }
 
-func (m *launchdServiceManager) bootout(ctx context.Context) error {
+func (m *launchdServiceManager) waitForRunning(ctx context.Context) (ServiceStatus, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+	defer cancel()
+	for {
+		status, loaded, output, err := m.inspectOutput(waitCtx)
+		if err != nil {
+			return ServiceStatus{}, err
+		}
+		if status.Running {
+			return status, nil
+		}
+		if !loaded {
+			return ServiceStatus{}, fmt.Errorf("wait for launchd target %s to run: job unloaded; Run manually: launchctl print %s", m.target, m.target)
+		}
+		if launchdTerminalFailure(output) {
+			return ServiceStatus{}, fmt.Errorf("wait for launchd target %s to run: terminal failure (%s); Run manually: launchctl print %s", m.target, strings.TrimSpace(string(output)), m.target)
+		}
+		select {
+		case <-waitCtx.Done():
+			return ServiceStatus{}, fmt.Errorf("wait for launchd target %s to run: %w; Run manually: launchctl print %s", m.target, waitCtx.Err(), m.target)
+		case <-time.After(serviceReadyPollInterval):
+		}
+	}
+}
+
+func (m *launchdServiceManager) bootoutAndWait(ctx context.Context) error {
 	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
-	if err != nil && !isLaunchdMissingService(output) {
+	if err != nil {
+		if isLaunchdMissingService(output) {
+			return nil
+		}
 		return serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
 	}
-	return nil
+	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+	defer cancel()
+	for {
+		_, loaded, inspectErr := m.inspect(waitCtx)
+		if inspectErr != nil {
+			return inspectErr
+		}
+		if !loaded {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("wait for launchd target %s to unload: %w; Run manually: launchctl print %s", m.target, waitCtx.Err(), m.target)
+		case <-time.After(serviceReadyPollInterval):
+		}
+	}
 }
 
 func (m *launchdServiceManager) run(ctx context.Context, name string, args ...string) error {

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const launchdServiceLabel = "ai.agentre.agentred"
+
+type launchdServiceManager struct {
+	config    serviceManagerConfig
+	plistPath string
+	domain    string
+	target    string
+}
+
+func newLaunchdServiceManager(config serviceManagerConfig) ServiceManager {
+	domain := "gui/" + strconv.Itoa(config.UID)
+	return &launchdServiceManager{
+		config:    config,
+		plistPath: filepath.Join(config.HomeDir, "Library", "LaunchAgents", launchdServiceLabel+".plist"),
+		domain:    domain,
+		target:    domain + "/" + launchdServiceLabel,
+	}
+}
+
+func (m *launchdServiceManager) Install(ctx context.Context) (ServiceStatus, error) {
+	if err := writeServiceFile(m.plistPath, []byte(m.plist())); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.bootout(ctx); err != nil {
+		return ServiceStatus{}, err
+	}
+	return ServiceStatus{Installed: true}, nil
+}
+
+func (m *launchdServiceManager) Start(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.plistPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.bootstrap(ctx); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *launchdServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.plistPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
+	if err != nil && !isServiceCommandExit(err) {
+		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
+	}
+	return m.Status(ctx)
+}
+
+func (m *launchdServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.plistPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.bootstrap(ctx); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *launchdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
+	installed, err := serviceFileExists(m.plistPath)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !installed {
+		return ServiceStatus{}, nil
+	}
+	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
+	if err != nil && !isServiceCommandExit(err) {
+		return ServiceStatus{}, serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
+	}
+	if err := os.Remove(m.plistPath); err != nil && !os.IsNotExist(err) {
+		return ServiceStatus{}, fmt.Errorf("remove LaunchAgent plist: %w", err)
+	}
+	return ServiceStatus{}, nil
+}
+
+func (m *launchdServiceManager) Status(ctx context.Context) (ServiceStatus, error) {
+	installed, err := serviceFileExists(m.plistPath)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !installed {
+		return ServiceStatus{}, nil
+	}
+	args := []string{"print", m.target}
+	output, err := m.config.Runner.Run(ctx, "launchctl", args...)
+	if err != nil && !isServiceCommandExit(err) {
+		return ServiceStatus{}, serviceCommandError("launchctl", args, output, err)
+	}
+	loaded := err == nil
+	running := loaded && strings.Contains(string(output), "state = running")
+	return ServiceStatus{
+		Installed: true,
+		Running:   running,
+		Details: []string{
+			"Manager: launchd LaunchAgent",
+			"Plist: " + m.plistPath,
+			fmt.Sprintf("Loaded: %t", loaded),
+			fmt.Sprintf("Running: %t", running),
+		},
+	}, nil
+}
+
+func (m *launchdServiceManager) bootstrap(ctx context.Context) error {
+	if err := m.bootout(ctx); err != nil {
+		return err
+	}
+	return m.run(ctx, "launchctl", "bootstrap", m.domain, m.plistPath)
+}
+
+func (m *launchdServiceManager) bootout(ctx context.Context) error {
+	output, err := m.config.Runner.Run(ctx, "launchctl", "bootout", m.target)
+	if err != nil && !isServiceCommandExit(err) {
+		return serviceCommandError("launchctl", []string{"bootout", m.target}, output, err)
+	}
+	return nil
+}
+
+func (m *launchdServiceManager) run(ctx context.Context, name string, args ...string) error {
+	output, err := m.config.Runner.Run(ctx, name, args...)
+	if err != nil {
+		return serviceCommandError(name, args, output, err)
+	}
+	return nil
+}
+
+func (m *launchdServiceManager) plist() string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>` + xmlText(launchdServiceLabel) + `</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>` + xmlText(m.config.BinaryPath) + `</string>
+    <string>run</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENTRED_DATA_DIR</key>
+    <string>` + xmlText(m.config.DataDir) + `</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+`
+}
+
+func xmlText(value string) string {
+	var escaped bytes.Buffer
+	_ = xml.EscapeText(&escaped, []byte(value))
+	return escaped.String()
+}

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -155,9 +155,16 @@ func isLaunchdMissingService(output []byte) bool {
 
 func launchdTerminalFailure(output []byte) bool {
 	detail := strings.ToLower(string(output))
-	return strings.Contains(detail, "state = exited") ||
-		strings.Contains(detail, "state = crashed") ||
-		strings.Contains(detail, "last exit code =")
+	if strings.Contains(detail, "state = exited") || strings.Contains(detail, "state = crashed") {
+		return true
+	}
+	for _, line := range strings.Split(detail, "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "last exit code =")
+		if ok && strings.TrimSpace(value) != "0" {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *launchdServiceManager) waitForRunning(ctx context.Context) (ServiceStatus, error) {

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -57,6 +57,7 @@ func (m *launchdServiceManager) Stop(ctx context.Context) (ServiceStatus, error)
 		Details: []string{
 			"Manager: launchd LaunchAgent",
 			"Plist: " + m.plistPath,
+			"Target: " + m.target,
 			"Loaded: false",
 			"Running: false",
 		},
@@ -137,6 +138,7 @@ func (m *launchdServiceManager) inspectOutput(ctx context.Context) (ServiceStatu
 		Details: []string{
 			"Manager: launchd LaunchAgent",
 			"Plist: " + m.plistPath,
+			"Target: " + m.target,
 			fmt.Sprintf("Loaded: %t", loaded),
 			fmt.Sprintf("Running: %t", running),
 		},

--- a/cmd/agentred/service_launchd.go
+++ b/cmd/agentred/service_launchd.go
@@ -158,6 +158,9 @@ func launchdTerminalFailure(output []byte) bool {
 	if strings.Contains(detail, "state = exited") || strings.Contains(detail, "state = crashed") {
 		return true
 	}
+	if strings.Contains(detail, "state = running") || strings.Contains(detail, "state = xpcproxy") {
+		return false
+	}
 	for _, line := range strings.Split(detail, "\n") {
 		value, ok := strings.CutPrefix(strings.TrimSpace(line), "last exit code =")
 		if !ok {

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,7 +75,7 @@ func TestGivenLaunchAgentWhenInspectingAndManagingThenLoadedRunningStateIsReport
 		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
 		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
-		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 		{name: "launchctl", args: []string{"bootstrap", "gui/501", plistPath}},
 		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 	}, runner.calls)
@@ -87,7 +88,7 @@ func TestGivenInstalledLaunchAgentWhenStartingAndUninstallingThenLifecycleComman
 	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
 		{output: "Could not find service", err: &exec.ExitError{}}, {}, {output: "state = running\n"},
-		{},
+		{}, {output: "Could not find service", err: &exec.ExitError{}},
 	}}
 	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
 
@@ -100,10 +101,11 @@ func TestGivenInstalledLaunchAgentWhenStartingAndUninstallingThenLifecycleComman
 	_, err = os.Stat(plistPath)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	assert.Equal(t, []serviceCommandCall{
-		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 		{name: "launchctl", args: []string{"bootstrap", "gui/501", plistPath}},
 		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
 	}, runner.calls)
 }
 
@@ -157,6 +159,111 @@ func TestGivenLaunchdStatusPermissionFailureWhenInspectingThenItIsNotReportedAsS
 	_, err := manager.Status(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Operation not permitted")
+	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
+}
+
+func TestGivenLoadedLaunchAgentWhenRestartingThenKickstartReplacesBootoutBootstrap(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "state = running\n"},
+		{},
+		{output: "state = running\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Restart(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"kickstart", "-k", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+	}, runner.calls)
+}
+
+func TestGivenUnloadedLaunchAgentWhenStartingThenBootstrapWaitsUntilRunning(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Could not find service", err: &exec.ExitError{}},
+		{},
+		{output: "state = waiting\n"},
+		{output: "state = running\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootstrap", "gui/501", plistPath}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+	}, runner.calls)
+}
+
+func TestGivenLaunchAgentStillRunningAfterBootoutWhenStoppingThenItWaitsUntilUnloaded(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{},
+		{output: "state = running\n"},
+		{output: "Could not find service", err: &exec.ExitError{}},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.False(t, status.Running)
+	assert.Len(t, runner.calls, 3)
+}
+
+func TestGivenLaunchAgentExitsWhileStartingThenItReturnsFailureWithoutWaitingForTimeout(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Could not find service", err: &exec.ExitError{}},
+		{},
+		{output: "state = waiting\nlast exit code = 1\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	_, err := manager.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal failure")
+	assert.Contains(t, err.Error(), "last exit code = 1")
+	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
+	assert.Len(t, runner.calls, 3, "terminal daemon failure must not be retried until timeout")
+}
+
+func TestGivenLaunchAgentNeverRunsWhenStartingThenContextDeadlineReturnsActionableFailure(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "state = waiting\n"},
+		{},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	_, err := manager.Start(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "wait for launchd target gui/501/ai.agentre.agentred to run")
 	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
 }
 

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -261,6 +261,39 @@ func TestGivenLaunchAgentInXPCProxyWhenStartingThenItKeepsWaitingUntilRunning(t 
 	assert.Len(t, runner.calls, 4, "an active xpcproxy job must be polled until launchd reports it running")
 }
 
+func TestGivenLaunchAgentInXPCProxyWithHistoricalFailureWhenStartingThenItKeepsWaitingUntilRunning(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Could not find service", err: &exec.ExitError{}},
+		{},
+		{output: `gui/501/ai.agentre.agentred = {
+	active count = 1
+	state = xpcproxy
+	runs = 2
+	pid = 40108
+	last exit code = 78
+}
+`},
+		{output: `gui/501/ai.agentre.agentred = {
+	active count = 1
+	state = running
+	runs = 2
+	pid = 40108
+	last exit code = 78
+}
+`},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Len(t, runner.calls, 4, "a historical exit code must not terminate an active xpcproxy startup")
+}
+
 func TestGivenLaunchAgentPreviouslyExitedCleanlyWhenStartingThenItKeepsWaitingUntilRunning(t *testing.T) {
 	home := t.TempDir()
 	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -227,6 +227,25 @@ func TestGivenLaunchAgentStillRunningAfterBootoutWhenStoppingThenItWaitsUntilUnl
 	assert.Len(t, runner.calls, 3)
 }
 
+func TestGivenLaunchAgentPreviouslyExitedCleanlyWhenStartingThenItKeepsWaitingUntilRunning(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Could not find service", err: &exec.ExitError{}},
+		{},
+		{output: "state = waiting\nlast exit code = 0\n"},
+		{output: "state = running\nlast exit code = 0\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Len(t, runner.calls, 4, "a historical successful exit must not be treated as terminal failure")
+}
+
 func TestGivenLaunchAgentExitsWhileStartingThenItReturnsFailureWithoutWaitingForTimeout(t *testing.T) {
 	home := t.TempDir()
 	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -15,7 +15,7 @@ import (
 func TestGivenLaunchdManagerWhenInstallingThenItWritesLaunchAgentWithoutStartingIt(t *testing.T) {
 	home := t.TempDir()
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
-		{err: &exec.ExitError{}},
+		{output: "Could not find service", err: &exec.ExitError{}},
 	}}
 	manager := newLaunchdServiceManager(serviceManagerConfig{
 		BinaryPath: "/Applications/Agentre & Tools/agentred",
@@ -53,8 +53,8 @@ func TestGivenLaunchAgentWhenInspectingAndManagingThenLoadedRunningStateIsReport
 	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
 		{output: "state = running\n"},
-		{}, {err: &exec.ExitError{}},
-		{err: &exec.ExitError{}}, {}, {output: "state = running\n"},
+		{}, {output: "Could not find service", err: &exec.ExitError{}},
+		{output: "Could not find service", err: &exec.ExitError{}}, {}, {output: "state = running\n"},
 	}}
 	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
 
@@ -86,7 +86,7 @@ func TestGivenInstalledLaunchAgentWhenStartingAndUninstallingThenLifecycleComman
 	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
 	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
-		{err: &exec.ExitError{}}, {}, {output: "state = running\n"},
+		{output: "Could not find service", err: &exec.ExitError{}}, {}, {output: "state = running\n"},
 		{},
 	}}
 	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
@@ -115,4 +115,64 @@ func TestGivenMissingLaunchAgentWhenUninstallingThenOperationIsIdempotent(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, ServiceStatus{}, status)
 	assert.Empty(t, runner.calls)
+}
+
+func TestGivenLaunchdMissingServiceWhenInspectingThenItIsReportedAsStopped(t *testing.T) {
+	for _, output := range []string{
+		"Could not find service \"ai.agentre.agentred\" in domain for user gui: 501\n",
+		"Bad request.\nCould not find service \"ai.agentre.agentred\" in domain for user domain\n",
+		"Bootstrap failed: 125: Domain does not support specified action\nService cannot load in requested session\n",
+	} {
+		t.Run(output, func(t *testing.T) {
+			home := t.TempDir()
+			plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+			require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+			require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+			runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{
+				output: output,
+				err:    &exec.ExitError{},
+			}}}
+			manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+			status, err := manager.Status(context.Background())
+			require.NoError(t, err)
+			assert.True(t, status.Installed)
+			assert.False(t, status.Running)
+			assert.Contains(t, status.Details, "Loaded: false")
+		})
+	}
+}
+
+func TestGivenLaunchdStatusPermissionFailureWhenInspectingThenItIsNotReportedAsStopped(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{
+		output: "Could not access service: Operation not permitted\n",
+		err:    &exec.ExitError{},
+	}}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	_, err := manager.Status(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Operation not permitted")
+	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
+}
+
+func TestGivenLaunchdStopPermissionFailureWhenStoppingThenItReturnsRecoveryCommand(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{
+		output: "Boot-out failed: 1: Operation not permitted\n",
+		err:    &exec.ExitError{},
+	}}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	_, err := manager.Stop(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Operation not permitted")
+	assert.Contains(t, err.Error(), "Run manually: launchctl bootout gui/501/ai.agentre.agentred")
 }

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"encoding/xml"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGivenLaunchdManagerWhenInstallingThenItWritesLaunchAgentWithoutStartingIt(t *testing.T) {
+	home := t.TempDir()
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{err: &exec.ExitError{}},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{
+		BinaryPath: "/Applications/Agentre & Tools/agentred",
+		DataDir:    "/Users/alice/Library/Application Support/agentred",
+		HomeDir:    home,
+		UID:        501,
+		Runner:     runner,
+	})
+
+	status, err := manager.Install(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{Installed: true}, status)
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	body, err := os.ReadFile(plistPath) //nolint:gosec // plistPath is assembled under the test's temporary home directory.
+	require.NoError(t, err)
+	plist := string(body)
+	var document any
+	require.NoError(t, xml.Unmarshal(body, &document), "generated LaunchAgent must be valid XML")
+	assert.Contains(t, plist, "<string>/Applications/Agentre &amp; Tools/agentred</string>")
+	assert.Contains(t, plist, "<string>run</string>")
+	assert.Contains(t, plist, "<key>AGENTRED_DATA_DIR</key>")
+	assert.Contains(t, plist, "<string>/Users/alice/Library/Application Support/agentred</string>")
+	assert.Contains(t, plist, "<key>RunAtLoad</key>")
+	assert.Contains(t, plist, "<key>KeepAlive</key>")
+	assert.Equal(t, []serviceCommandCall{
+		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+	}, runner.calls, "install without --start must register the plist without launching the daemon")
+}
+
+func TestGivenLaunchAgentWhenInspectingAndManagingThenLoadedRunningStateIsReported(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "state = running\n"},
+		{}, {err: &exec.ExitError{}},
+		{err: &exec.ExitError{}}, {}, {output: "state = running\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.True(t, status.Running)
+
+	status, err = manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Running)
+
+	status, err = manager.Restart(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootstrap", "gui/501", plistPath}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+	}, runner.calls)
+}
+
+func TestGivenInstalledLaunchAgentWhenStartingAndUninstallingThenLifecycleCommandsAreGenerated(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{err: &exec.ExitError{}}, {}, {output: "state = running\n"},
+		{},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	status, err = manager.Uninstall(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Installed)
+	_, err = os.Stat(plistPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootstrap", "gui/501", plistPath}},
+		{name: "launchctl", args: []string{"print", "gui/501/ai.agentre.agentred"}},
+		{name: "launchctl", args: []string{"bootout", "gui/501/ai.agentre.agentred"}},
+	}, runner.calls)
+}
+
+func TestGivenMissingLaunchAgentWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
+	runner := &fakeServiceCommandRunner{}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: t.TempDir(), UID: 501, Runner: runner})
+
+	status, err := manager.Uninstall(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{}, status)
+	assert.Empty(t, runner.calls)
+}

--- a/cmd/agentred/service_launchd_test.go
+++ b/cmd/agentred/service_launchd_test.go
@@ -227,6 +227,40 @@ func TestGivenLaunchAgentStillRunningAfterBootoutWhenStoppingThenItWaitsUntilUnl
 	assert.Len(t, runner.calls, 3)
 }
 
+func TestGivenLaunchAgentInXPCProxyWhenStartingThenItKeepsWaitingUntilRunning(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Could not find service", err: &exec.ExitError{}},
+		{},
+		{output: `gui/501/ai.agentre.agentred = {
+	active count = 1
+	state = xpcproxy
+	runs = 1
+	pid = 40108
+	last exit code = (never exited)
+	properties = keepalive | runatload | inferred program
+}
+`},
+		{output: `gui/501/ai.agentre.agentred = {
+	active count = 1
+	state = running
+	runs = 1
+	pid = 40108
+	last exit code = (never exited)
+}
+`},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Len(t, runner.calls, 4, "an active xpcproxy job must be polled until launchd reports it running")
+}
+
 func TestGivenLaunchAgentPreviouslyExitedCleanlyWhenStartingThenItKeepsWaitingUntilRunning(t *testing.T) {
 	home := t.TempDir()
 	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
@@ -282,6 +316,27 @@ func TestGivenLaunchAgentNeverRunsWhenStartingThenContextDeadlineReturnsActionab
 	_, err := manager.Start(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "wait for launchd target gui/501/ai.agentre.agentred to run")
+	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
+}
+
+func TestGivenLaunchAgentNeverRunsWhenStartingThenContextCancellationReturnsActionableFailure(t *testing.T) {
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "ai.agentre.agentred.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0o755))
+	require.NoError(t, os.WriteFile(plistPath, []byte("plist"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "state = waiting\n"},
+		{},
+		{output: "state = waiting\n"},
+	}}
+	manager := newLaunchdServiceManager(serviceManagerConfig{HomeDir: home, UID: 501, Runner: runner})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := manager.Start(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 	assert.Contains(t, err.Error(), "wait for launchd target gui/501/ai.agentre.agentred to run")
 	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
 }

--- a/cmd/agentred/service_manager.go
+++ b/cmd/agentred/service_manager.go
@@ -8,8 +8,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/agentre-ai/agentre/internal/pkg/paths"
@@ -88,19 +86,7 @@ func newPlatformServiceManager() (ServiceManager, error) {
 		UserName:   currentUser.Username,
 		Runner:     execServiceCommandRunner{},
 	}
-	switch runtime.GOOS {
-	case "linux":
-		return newSystemdServiceManager(config), nil
-	case "darwin":
-		uid, err := strconv.Atoi(currentUser.Uid)
-		if err != nil {
-			return nil, fmt.Errorf("resolve current user id: %w", err)
-		}
-		config.UID = uid
-		return newLaunchdServiceManager(config), nil
-	default:
-		return &unsupportedServiceManager{platform: runtime.GOOS}, nil
-	}
+	return newOSServiceManager(config, currentUser)
 }
 
 func writeServiceFile(path string, body []byte) error {

--- a/cmd/agentred/service_manager.go
+++ b/cmd/agentred/service_manager.go
@@ -115,11 +115,6 @@ func serviceFileExists(path string) (bool, error) {
 	return false, err
 }
 
-func isServiceCommandExit(err error) bool {
-	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr)
-}
-
 func serviceCommandError(name string, args []string, output []byte, err error) error {
 	command := strings.Join(append([]string{name}, args...), " ")
 	if detail := strings.TrimSpace(string(output)); detail != "" {

--- a/cmd/agentred/service_manager.go
+++ b/cmd/agentred/service_manager.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/agentre-ai/agentre/internal/pkg/paths"
+	"github.com/agentre-ai/agentre/internal/pkg/procattr"
+)
+
+// ServiceManager is the platform-neutral lifecycle contract shared by the CLI
+// and each user-level service implementation.
+type ServiceManager interface {
+	Install(context.Context) (ServiceStatus, error)
+	Start(context.Context) (ServiceStatus, error)
+	Stop(context.Context) (ServiceStatus, error)
+	Restart(context.Context) (ServiceStatus, error)
+	Uninstall(context.Context) (ServiceStatus, error)
+	Status(context.Context) (ServiceStatus, error)
+}
+
+// ServiceStatus is intentionally platform-neutral so onboarding can consume
+// the same installed/running states on every supported operating system.
+type ServiceStatus struct {
+	Installed bool
+	Running   bool
+	Details   []string
+}
+
+type serviceCommandRunner interface {
+	Run(context.Context, string, ...string) ([]byte, error)
+}
+
+type execServiceCommandRunner struct{}
+
+func (execServiceCommandRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // command names and arguments are fixed service-manager inputs.
+	procattr.ApplyNoConsoleWindow(cmd)
+	return cmd.CombinedOutput()
+}
+
+type serviceManagerConfig struct {
+	BinaryPath string
+	DataDir    string
+	HomeDir    string
+	UserName   string
+	UID        int
+	Runner     serviceCommandRunner
+}
+
+func newPlatformServiceManager() (ServiceManager, error) {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve agentred executable: %w", err)
+	}
+	binaryPath, err = filepath.Abs(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve absolute agentred executable: %w", err)
+	}
+	dataDir, err := paths.AgentredDataDir()
+	if err != nil {
+		return nil, err
+	}
+	dataDir, err = filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve absolute agentred data directory: %w", err)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve user home directory: %w", err)
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current user: %w", err)
+	}
+	config := serviceManagerConfig{
+		BinaryPath: binaryPath,
+		DataDir:    dataDir,
+		HomeDir:    homeDir,
+		UserName:   currentUser.Username,
+		Runner:     execServiceCommandRunner{},
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return newSystemdServiceManager(config), nil
+	case "darwin":
+		uid, err := strconv.Atoi(currentUser.Uid)
+		if err != nil {
+			return nil, fmt.Errorf("resolve current user id: %w", err)
+		}
+		config.UID = uid
+		return newLaunchdServiceManager(config), nil
+	default:
+		return &unsupportedServiceManager{platform: runtime.GOOS}, nil
+	}
+}
+
+func writeServiceFile(path string, body []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create service directory: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o644); err != nil {
+		return fmt.Errorf("write service definition: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("install service definition: %w", err)
+	}
+	return nil
+}
+
+func serviceFileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func isServiceCommandExit(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
+}
+
+func serviceCommandError(name string, args []string, output []byte, err error) error {
+	command := strings.Join(append([]string{name}, args...), " ")
+	if detail := strings.TrimSpace(string(output)); detail != "" {
+		return fmt.Errorf("run %s: %w: %s; Run manually: %s", command, err, detail, command)
+	}
+	return fmt.Errorf("run %s: %w; Run manually: %s", command, err, command)
+}
+
+func requireInstalled(path string) error {
+	installed, err := serviceFileExists(path)
+	if err != nil {
+		return err
+	}
+	if !installed {
+		return fmt.Errorf("service is not installed; run agentred service install")
+	}
+	return nil
+}

--- a/cmd/agentred/service_systemd.go
+++ b/cmd/agentred/service_systemd.go
@@ -105,7 +105,7 @@ func (m *systemdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 	args := []string{"--user", "is-active", systemdServiceName}
 	output, err := m.config.Runner.Run(ctx, "systemctl", args...)
 	state := strings.TrimSpace(string(output))
-	if err != nil && !isServiceCommandExit(err) {
+	if err != nil && !isSystemdInactiveState(state) {
 		return ServiceStatus{}, serviceCommandError("systemctl", args, output, err)
 	}
 	return ServiceStatus{
@@ -113,6 +113,15 @@ func (m *systemdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 		Running:   state == "active",
 		Details:   []string{"Manager: systemd --user", "Unit: " + m.unitPath, "State: " + state},
 	}, nil
+}
+
+func isSystemdInactiveState(state string) bool {
+	switch state {
+	case "inactive", "failed", "activating", "deactivating":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *systemdServiceManager) run(ctx context.Context, name string, args ...string) error {

--- a/cmd/agentred/service_systemd.go
+++ b/cmd/agentred/service_systemd.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const systemdServiceName = "agentred.service"
+
+type systemdServiceManager struct {
+	config   serviceManagerConfig
+	unitPath string
+}
+
+func newSystemdServiceManager(config serviceManagerConfig) ServiceManager {
+	return &systemdServiceManager{
+		config:   config,
+		unitPath: filepath.Join(config.HomeDir, ".config", "systemd", "user", systemdServiceName),
+	}
+}
+
+func (m *systemdServiceManager) Install(ctx context.Context) (ServiceStatus, error) {
+	if err := writeServiceFile(m.unitPath, []byte(m.unit())); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.run(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.run(ctx, "systemctl", "--user", "enable", systemdServiceName); err != nil {
+		return ServiceStatus{}, err
+	}
+	status := ServiceStatus{Installed: true}
+	output, err := m.config.Runner.Run(ctx, "loginctl", "enable-linger", m.config.UserName)
+	if err != nil {
+		status.Details = append(status.Details,
+			fmt.Sprintf("Linger setup failed: %v", serviceCommandError("loginctl", []string{"enable-linger", m.config.UserName}, output, err)),
+			fmt.Sprintf("Run: loginctl enable-linger %s", m.config.UserName),
+		)
+	}
+	return status, nil
+}
+
+func (m *systemdServiceManager) Start(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.unitPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.run(ctx, "systemctl", "--user", "start", systemdServiceName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *systemdServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.unitPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.run(ctx, "systemctl", "--user", "stop", systemdServiceName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *systemdServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
+	if err := requireInstalled(m.unitPath); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := m.run(ctx, "systemctl", "--user", "restart", systemdServiceName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *systemdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
+	installed, err := serviceFileExists(m.unitPath)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !installed {
+		return ServiceStatus{}, nil
+	}
+	if err := m.run(ctx, "systemctl", "--user", "disable", "--now", systemdServiceName); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := os.Remove(m.unitPath); err != nil && !os.IsNotExist(err) {
+		return ServiceStatus{}, fmt.Errorf("remove systemd user unit: %w", err)
+	}
+	if err := m.run(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+		return ServiceStatus{}, err
+	}
+	return ServiceStatus{}, nil
+}
+
+func (m *systemdServiceManager) Status(ctx context.Context) (ServiceStatus, error) {
+	installed, err := serviceFileExists(m.unitPath)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !installed {
+		return ServiceStatus{}, nil
+	}
+	args := []string{"--user", "is-active", systemdServiceName}
+	output, err := m.config.Runner.Run(ctx, "systemctl", args...)
+	state := strings.TrimSpace(string(output))
+	if err != nil && !isServiceCommandExit(err) {
+		return ServiceStatus{}, serviceCommandError("systemctl", args, output, err)
+	}
+	return ServiceStatus{
+		Installed: true,
+		Running:   state == "active",
+		Details:   []string{"Manager: systemd --user", "Unit: " + m.unitPath, "State: " + state},
+	}, nil
+}
+
+func (m *systemdServiceManager) run(ctx context.Context, name string, args ...string) error {
+	output, err := m.config.Runner.Run(ctx, name, args...)
+	if err != nil {
+		return serviceCommandError(name, args, output, err)
+	}
+	return nil
+}
+
+func (m *systemdServiceManager) unit() string {
+	return `[Unit]
+Description=Agentre agentred daemon
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=` + systemdQuote(m.config.BinaryPath) + ` run
+Environment=` + systemdQuote("AGENTRED_DATA_DIR="+m.config.DataDir) + `
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`
+}
+
+func systemdQuote(value string) string {
+	return strconv.Quote(strings.ReplaceAll(value, "%", "%%"))
+}

--- a/cmd/agentred/service_systemd.go
+++ b/cmd/agentred/service_systemd.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const systemdServiceName = "agentred.service"
@@ -51,7 +52,7 @@ func (m *systemdServiceManager) Start(ctx context.Context) (ServiceStatus, error
 	if err := m.run(ctx, "systemctl", "--user", "start", systemdServiceName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, true)
 }
 
 func (m *systemdServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
@@ -61,7 +62,7 @@ func (m *systemdServiceManager) Stop(ctx context.Context) (ServiceStatus, error)
 	if err := m.run(ctx, "systemctl", "--user", "stop", systemdServiceName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, false)
 }
 
 func (m *systemdServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
@@ -71,7 +72,7 @@ func (m *systemdServiceManager) Restart(ctx context.Context) (ServiceStatus, err
 	if err := m.run(ctx, "systemctl", "--user", "restart", systemdServiceName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, true)
 }
 
 func (m *systemdServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
@@ -113,6 +114,36 @@ func (m *systemdServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 		Running:   state == "active",
 		Details:   []string{"Manager: systemd --user", "Unit: " + m.unitPath, "State: " + state},
 	}, nil
+}
+
+func (m *systemdServiceManager) waitForState(ctx context.Context, running bool) (ServiceStatus, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+	defer cancel()
+	for {
+		status, err := m.Status(waitCtx)
+		if err != nil {
+			return ServiceStatus{}, err
+		}
+		state := ""
+		if len(status.Details) != 0 {
+			state = strings.TrimPrefix(status.Details[len(status.Details)-1], "State: ")
+		}
+		if running && state == "failed" {
+			return ServiceStatus{}, fmt.Errorf("wait for systemd unit %s to become active: state failed; Run manually: systemctl --user status %s", systemdServiceName, systemdServiceName)
+		}
+		if status.Running == running && state != "activating" && state != "deactivating" {
+			return status, nil
+		}
+		select {
+		case <-waitCtx.Done():
+			want := "inactive"
+			if running {
+				want = "active"
+			}
+			return ServiceStatus{}, fmt.Errorf("wait for systemd unit %s to become %s: %w (last state: %s); Run manually: systemctl --user status %s", systemdServiceName, want, waitCtx.Err(), state, systemdServiceName)
+		case <-time.After(serviceReadyPollInterval):
+		}
+	}
 }
 
 func isSystemdInactiveState(state string) bool {

--- a/cmd/agentred/service_systemd_test.go
+++ b/cmd/agentred/service_systemd_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type serviceCommandCall struct {
+	name string
+	args []string
+}
+
+type fakeServiceCommandRunner struct {
+	calls   []serviceCommandCall
+	results []fakeServiceCommandResult
+}
+
+type fakeServiceCommandResult struct {
+	output string
+	err    error
+}
+
+func (f *fakeServiceCommandRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, serviceCommandCall{name: name, args: append([]string(nil), args...)})
+	if len(f.results) == 0 {
+		return nil, nil
+	}
+	result := f.results[0]
+	f.results = f.results[1:]
+	return []byte(result.output), result.err
+}
+
+func TestGivenSystemdManagerWhenInstallingThenItWritesUserUnitAndEnablesStartup(t *testing.T) {
+	home := t.TempDir()
+	runner := &fakeServiceCommandRunner{}
+	manager := newSystemdServiceManager(serviceManagerConfig{
+		BinaryPath: "/opt/Agentre % Tools/agentred",
+		DataDir:    "/home/alice/.config/agentred 100%",
+		HomeDir:    home,
+		UserName:   "alice",
+		Runner:     runner,
+	})
+
+	status, err := manager.Install(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{Installed: true}, status)
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	body, err := os.ReadFile(unitPath) //nolint:gosec // unitPath is assembled under the test's temporary home directory.
+	require.NoError(t, err)
+	unit := string(body)
+	assert.Contains(t, unit, `ExecStart="/opt/Agentre %% Tools/agentred" run`)
+	assert.Contains(t, unit, `Environment="AGENTRED_DATA_DIR=/home/alice/.config/agentred 100%%"`)
+	assert.Contains(t, unit, "WantedBy=default.target")
+	assert.Equal(t, []serviceCommandCall{
+		{name: "systemctl", args: []string{"--user", "daemon-reload"}},
+		{name: "systemctl", args: []string{"--user", "enable", "agentred.service"}},
+		{name: "loginctl", args: []string{"enable-linger", "alice"}},
+	}, runner.calls)
+}
+
+func TestGivenLingerPolicyRejectsWhenSystemdServiceInstallsThenInstallSucceedsWithRepairCommand(t *testing.T) {
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {}, {err: errors.New("access denied")},
+	}}
+	manager := newSystemdServiceManager(serviceManagerConfig{
+		BinaryPath: "/usr/local/bin/agentred",
+		DataDir:    "/home/alice/.config/agentred",
+		HomeDir:    t.TempDir(),
+		UserName:   "alice",
+		Runner:     runner,
+	})
+
+	status, err := manager.Install(context.Background())
+	require.NoError(t, err, "host linger policy must not undo successful service registration")
+	assert.True(t, status.Installed)
+	assert.Contains(t, strings.Join(status.Details, "\n"), "loginctl enable-linger alice")
+	assert.Contains(t, strings.Join(status.Details, "\n"), "access denied")
+}
+
+func TestGivenSystemdUnitWhenInspectingAndManagingThenCommandsAndStatesAreStable(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "active\n"},
+		{}, {output: "inactive\n", err: &exec.ExitError{}},
+		{}, {output: "active\n"},
+	}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	status, err := manager.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+
+	status, err = manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.False(t, status.Running)
+
+	status, err = manager.Restart(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "stop", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "restart", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+	}, runner.calls)
+}
+
+func TestGivenInstalledSystemdUnitWhenStartingAndUninstallingThenLifecycleCommandsAreGenerated(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {output: "active\n"},
+		{}, {},
+	}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	status, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+	status, err = manager.Uninstall(context.Background())
+	require.NoError(t, err)
+	assert.False(t, status.Installed)
+	_, err = os.Stat(unitPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "systemctl", args: []string{"--user", "start", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "disable", "--now", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "daemon-reload"}},
+	}, runner.calls)
+}
+
+func TestGivenSystemdCommandFailureWhenStartingThenErrorIncludesRecoveryCommand(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{err: errors.New("dbus unavailable")}}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	_, err := manager.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Run manually: systemctl --user start agentred.service")
+}
+
+func TestGivenMissingSystemdUnitWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
+	runner := &fakeServiceCommandRunner{}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: t.TempDir(), Runner: runner})
+
+	status, err := manager.Uninstall(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{}, status)
+	assert.Empty(t, runner.calls)
+}

--- a/cmd/agentred/service_systemd_test.go
+++ b/cmd/agentred/service_systemd_test.go
@@ -146,6 +146,52 @@ func TestGivenInstalledSystemdUnitWhenStartingAndUninstallingThenLifecycleComman
 	}, runner.calls)
 }
 
+func TestGivenSystemdLifecycleTransitionsWhenManagingThenActionsWaitForTerminalStates(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {output: "activating\n", err: &exec.ExitError{}}, {output: "active\n"},
+		{}, {output: "deactivating\n", err: &exec.ExitError{}}, {output: "inactive\n", err: &exec.ExitError{}},
+	}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	started, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, started.Running)
+	stopped, err := manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.False(t, stopped.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "systemctl", args: []string{"--user", "start", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "stop", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+		{name: "systemctl", args: []string{"--user", "is-active", "agentred.service"}},
+	}, runner.calls)
+}
+
+func TestGivenSystemdNeverActivatesWhenStartingThenCancellationIsActionable(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {output: "activating\n", err: &exec.ExitError{}},
+	}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := manager.Start(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, err.Error(), "wait for systemd unit agentred.service to become active")
+	assert.Contains(t, err.Error(), "Run manually: systemctl --user status agentred.service")
+}
+
 func TestGivenSystemdCommandFailureWhenStartingThenErrorIncludesRecoveryCommand(t *testing.T) {
 	home := t.TempDir()
 	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")

--- a/cmd/agentred/service_systemd_test.go
+++ b/cmd/agentred/service_systemd_test.go
@@ -159,6 +159,41 @@ func TestGivenSystemdCommandFailureWhenStartingThenErrorIncludesRecoveryCommand(
 	assert.Contains(t, err.Error(), "Run manually: systemctl --user start agentred.service")
 }
 
+func TestGivenSystemdFailedStateWhenInspectingThenItIsReportedAsStopped(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{
+		output: "failed\n",
+		err:    &exec.ExitError{},
+	}}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	status, err := manager.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.False(t, status.Running)
+	assert.Contains(t, status.Details, "State: failed")
+}
+
+func TestGivenSystemdStatusPermissionFailureWhenInspectingThenItIsNotReportedAsStopped(t *testing.T) {
+	home := t.TempDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "agentred.service")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unitPath), 0o755))
+	require.NoError(t, os.WriteFile(unitPath, []byte("unit"), 0o644))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{
+		output: "Failed to connect to bus: Permission denied\n",
+		err:    &exec.ExitError{},
+	}}}
+	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: home, Runner: runner})
+
+	_, err := manager.Status(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+	assert.Contains(t, err.Error(), "Run manually: systemctl --user is-active agentred.service")
+}
+
 func TestGivenMissingSystemdUnitWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
 	runner := &fakeServiceCommandRunner{}
 	manager := newSystemdServiceManager(serviceManagerConfig{HomeDir: t.TempDir(), Runner: runner})

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +80,118 @@ func TestGivenInstallWithStartWhenExecutedThenManagerInstallsBeforeStarting(t *t
 	assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out), "\n")[0])
 }
 
+func TestGivenRunningManagerButUnreadableLocalDaemonWhenStartingThenCommandFailsWithoutPrintingSuccess(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			return nil, errors.New("dial local socket: connection refused")
+		},
+	})
+	cmd.SilenceUsage = true
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"start"})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+	assert.Contains(t, err.Error(), "wait for local daemon status")
+	assert.Contains(t, err.Error(), "dial local socket: connection refused")
+}
+
+func TestGivenLocalDaemonNeverBecomesReadyWhenStartingThenCancellationStopsObservation(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{
+		Installed: true,
+		Running:   true,
+		Details:   []string{"State: active"},
+	}}
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			return nil, errors.New("socket missing")
+		},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"start"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, err.Error(), "socket missing")
+	assert.Contains(t, err.Error(), "State: active")
+}
+
+func TestGivenLocalDaemonFailureStopsServiceWhenStartingThenItReturnsEarlyWithServiceEvidence(t *testing.T) {
+	manager := &fakeServiceManager{statusByCall: map[string]ServiceStatus{
+		"start":  {Installed: true, Running: true},
+		"status": {Installed: true, Details: []string{"State: failed"}},
+	}}
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			return nil, errors.New("connection reset")
+		},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"start"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service stopped before becoming ready")
+	assert.Contains(t, err.Error(), "State: failed")
+	assert.Contains(t, err.Error(), "connection reset")
+}
+
+func TestGivenLifecycleStartActionsWhenLocalDaemonBecomesReadableThenTheyPrintRunning(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCalls []string
+	}{
+		{name: "install --start", args: []string{"install", "--start"}, wantCalls: []string{"install", "start", "status"}},
+		{name: "start", args: []string{"start"}, wantCalls: []string{"start", "status"}},
+		{name: "restart", args: []string{"restart"}, wantCalls: []string{"restart", "status"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+			attempts := 0
+			cmd := newServiceCmdWithDeps(serviceCommandDeps{
+				managerFactory: func() (ServiceManager, error) { return manager, nil },
+				localStatus: func(context.Context) (map[string]any, error) {
+					attempts++
+					if attempts == 1 {
+						return nil, errors.New("socket not ready")
+					}
+					return map[string]any{"pid": float64(42)}, nil
+				},
+			})
+			cmd.SilenceUsage = true
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, tt.wantCalls, manager.calls)
+			assert.Equal(t, 2, attempts)
+			assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
+		})
+	}
+}
+
 func TestGivenInstallWithStartAndLingerWarningWhenExecutedThenRepairDetailIsPreserved(t *testing.T) {
 	manager := &fakeServiceManager{statusByCall: map[string]ServiceStatus{
 		"install": {Installed: true, Details: []string{"Run: loginctl enable-linger alice"}},
@@ -119,7 +232,7 @@ func TestGivenRunningServiceWhenStatusIsRequestedThenStableHeaderPrecedesLocalDa
 	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
 	cmd := newServiceCmdWithDeps(serviceCommandDeps{
 		managerFactory: func() (ServiceManager, error) { return manager, nil },
-		localStatus: func() (map[string]any, error) {
+		localStatus: func(context.Context) (map[string]any, error) {
 			return map[string]any{
 				"pid":              float64(42),
 				"version":          "v1.2.3 (abcdef1)",

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -143,6 +143,35 @@ func TestGivenRunningManagerButUnreadableLocalDaemonWhenStartingThenCommandFails
 	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
 }
 
+func TestGivenCanceledStatusCommandWhenLoadingLocalDaemonThenCancellationIsPropagated(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	seenContext := make(chan context.Context, 1)
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(ctx context.Context) (map[string]any, error) {
+			seenContext <- ctx
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return nil, errors.New("status loader lost command cancellation")
+		},
+	})
+	cmd.SilenceUsage = true
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"status"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	require.NoError(t, cmd.Execute())
+	seen := <-seenContext
+	assert.ErrorIs(t, seen.Err(), context.Canceled)
+	assert.Contains(t, out.String(), context.Canceled.Error())
+	assert.NotContains(t, out.String(), "lost command cancellation")
+}
+
 func TestGivenLocalDaemonNeverBecomesReadyWhenStartingThenCancellationStopsObservation(t *testing.T) {
 	manager := &fakeServiceManager{status: ServiceStatus{
 		Installed: true,
@@ -229,6 +258,59 @@ func TestGivenLifecycleStartActionsWhenLocalDaemonBecomesReadableThenTheyPrintRu
 			assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
 		})
 	}
+}
+
+func TestGivenReadableLocalStatusWithoutPIDWhenStartingThenItKeepsWaitingForDaemonIdentity(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	attempts := 0
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			attempts++
+			if attempts == 1 {
+				return map[string]any{"version": "starting"}, nil
+			}
+			return map[string]any{"pid": float64(42)}, nil
+		},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"start"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, 2, attempts, "a decodable status without daemon PID must not satisfy readiness")
+	assert.Equal(t, []string{"start", "status"}, manager.calls)
+}
+
+func TestGivenRestartPreflightWhenLocalStatusStallsThenItsProbeIsBounded(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{
+		Installed: true,
+		Running:   true,
+		Details:   []string{"Manager: systemd --user"},
+	}}
+	attempts := 0
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(ctx context.Context) (map[string]any, error) {
+			attempts++
+			if _, bounded := ctx.Deadline(); !bounded {
+				return nil, errors.New("pre-restart local status probe has no deadline")
+			}
+			if attempts < 3 {
+				return map[string]any{"pid": float64(41)}, nil
+			}
+			return map[string]any{"pid": float64(42)}, nil
+		},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"restart"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, 3, attempts, "the bounded preflight must capture the old PID before restart")
+	assert.Equal(t, []string{"restart", "status"}, manager.calls)
 }
 
 func TestGivenRestartWhenOldDaemonStillAnswersThenItWaitsForANewDaemonPID(t *testing.T) {

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -115,7 +115,7 @@ func TestGivenServiceLifecycleActionsWhenExecutedThenTheyDelegateAndPrintStableS
 	}
 }
 
-func TestGivenRunningServiceWhenStatusIsRequestedThenLocalDaemonStatusUsesFrozenRenderer(t *testing.T) {
+func TestGivenRunningServiceWhenStatusIsRequestedThenStableHeaderPrecedesLocalDaemonDetails(t *testing.T) {
 	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
 	cmd := newServiceCmdWithDeps(serviceCommandDeps{
 		managerFactory: func() (ServiceManager, error) { return manager, nil },
@@ -135,7 +135,8 @@ func TestGivenRunningServiceWhenStatusIsRequestedThenLocalDaemonStatusUsesFrozen
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"status"})
 	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.HasPrefix(out.String(), "Daemon running, pid 42\n"))
+	assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
+	assert.Contains(t, out.String(), "PID: 42")
 	assert.Contains(t, out.String(), "Version: v1.2.3 (abcdef1)")
 }
 

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeServiceManager struct {
+	calls        []string
+	status       ServiceStatus
+	statusByCall map[string]ServiceStatus
+	errAt        string
+}
+
+func (f *fakeServiceManager) result(call string) (ServiceStatus, error) {
+	f.calls = append(f.calls, call)
+	if f.errAt == call {
+		return ServiceStatus{}, errors.New("manager failed")
+	}
+	if status, ok := f.statusByCall[call]; ok {
+		return status, nil
+	}
+	return f.status, nil
+}
+
+func (f *fakeServiceManager) Install(context.Context) (ServiceStatus, error) {
+	return f.result("install")
+}
+func (f *fakeServiceManager) Start(context.Context) (ServiceStatus, error) {
+	return f.result("start")
+}
+func (f *fakeServiceManager) Stop(context.Context) (ServiceStatus, error) {
+	return f.result("stop")
+}
+func (f *fakeServiceManager) Restart(context.Context) (ServiceStatus, error) {
+	return f.result("restart")
+}
+func (f *fakeServiceManager) Uninstall(context.Context) (ServiceStatus, error) {
+	return f.result("uninstall")
+}
+func (f *fakeServiceManager) Status(context.Context) (ServiceStatus, error) {
+	return f.result("status")
+}
+
+func executeServiceCommand(t *testing.T, manager ServiceManager, args ...string) (string, error) {
+	t.Helper()
+	cmd := newServiceCmdWithManager(manager)
+	cmd.SilenceUsage = true
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestGivenServiceCommandWhenInspectingSubcommandsThenLifecycleSurfaceIsStable(t *testing.T) {
+	cmd := newServiceCmdWithManager(&fakeServiceManager{})
+	got := map[string]bool{}
+	for _, child := range cmd.Commands() {
+		got[child.Name()] = true
+	}
+	assert.Equal(t, map[string]bool{
+		"install": true, "start": true, "status": true, "restart": true, "stop": true, "uninstall": true,
+	}, got)
+}
+
+func TestGivenInstallWithStartWhenExecutedThenManagerInstallsBeforeStarting(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	out, err := executeServiceCommand(t, manager, "install", "--start")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"install", "start"}, manager.calls)
+	assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out), "\n")[0])
+}
+
+func TestGivenInstallWithStartAndLingerWarningWhenExecutedThenRepairDetailIsPreserved(t *testing.T) {
+	manager := &fakeServiceManager{statusByCall: map[string]ServiceStatus{
+		"install": {Installed: true, Details: []string{"Run: loginctl enable-linger alice"}},
+		"start":   {Installed: true, Running: true},
+	}}
+	out, err := executeServiceCommand(t, manager, "install", "--start")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Run: loginctl enable-linger alice")
+}
+
+func TestGivenServiceLifecycleActionsWhenExecutedThenTheyDelegateAndPrintStableState(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		status    ServiceStatus
+		wantCall  string
+		wantFirst string
+	}{
+		{name: "installed but stopped", args: []string{"install"}, status: ServiceStatus{Installed: true}, wantCall: "install", wantFirst: "Daemon stopped"},
+		{name: "start", args: []string{"start"}, status: ServiceStatus{Installed: true, Running: true}, wantCall: "start", wantFirst: "Daemon running"},
+		{name: "status not installed", args: []string{"status"}, status: ServiceStatus{}, wantCall: "status", wantFirst: "Service not installed"},
+		{name: "restart", args: []string{"restart"}, status: ServiceStatus{Installed: true, Running: true}, wantCall: "restart", wantFirst: "Daemon running"},
+		{name: "stop", args: []string{"stop"}, status: ServiceStatus{Installed: true}, wantCall: "stop", wantFirst: "Daemon stopped"},
+		{name: "idempotent uninstall", args: []string{"uninstall"}, status: ServiceStatus{}, wantCall: "uninstall", wantFirst: "Service not installed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &fakeServiceManager{status: tt.status}
+			out, err := executeServiceCommand(t, manager, tt.args...)
+			require.NoError(t, err)
+			assert.Equal(t, []string{tt.wantCall}, manager.calls)
+			assert.Equal(t, tt.wantFirst, strings.Split(strings.TrimSpace(out), "\n")[0])
+		})
+	}
+}
+
+func TestGivenRunningServiceWhenStatusIsRequestedThenLocalDaemonStatusUsesFrozenRenderer(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func() (map[string]any, error) {
+			return map[string]any{
+				"pid":              float64(42),
+				"version":          "v1.2.3 (abcdef1)",
+				"listenURLs":       []any{"ws://127.0.0.1:7456"},
+				"pairedPeers":      []any{},
+				"activeSessions":   float64(0),
+				"llmProviderCount": float64(0),
+			}, nil
+		},
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"status"})
+	require.NoError(t, cmd.Execute())
+	assert.True(t, strings.HasPrefix(out.String(), "Daemon running, pid 42\n"))
+	assert.Contains(t, out.String(), "Version: v1.2.3 (abcdef1)")
+}
+
+func TestGivenManagerFailureWhenServiceActionRunsThenCommandReturnsActionableError(t *testing.T) {
+	manager := &fakeServiceManager{errAt: "restart"}
+	out, err := executeServiceCommand(t, manager, "restart")
+	require.Error(t, err)
+	assert.Empty(t, out)
+	assert.Contains(t, err.Error(), "restart service")
+	assert.Contains(t, err.Error(), "manager failed")
+}

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -7,6 +7,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -429,6 +431,20 @@ func TestGivenRunningServiceWhenStatusIsRequestedThenStableHeaderPrecedesLocalDa
 	assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
 	assert.Contains(t, out.String(), "PID: 42")
 	assert.Contains(t, out.String(), "Version: v1.2.3 (abcdef1)")
+}
+
+func TestGivenLocalStatusEndpointRejectsTheRequestWhenLoadingThenReadinessReturnsTheHTTPFailure(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader(`{"pid":42}`)),
+		}, nil
+	})}
+
+	_, err := loadLocalDaemonStatus(context.Background(), client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503 Service Unavailable")
 }
 
 func TestGivenManagerFailureWhenServiceActionRunsThenCommandReturnsActionableError(t *testing.T) {

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +62,33 @@ func executeServiceCommand(t *testing.T, manager ServiceManager, args ...string)
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return out.String(), err
+}
+
+func TestGivenWindowsLifecycleIsOutOfScopeWhenReviewingServiceManagersThenNoReadinessWaitIsAdded(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "service_windows.go", nil, 0)
+	require.NoError(t, err)
+
+	checked := 0
+	for _, declaration := range file.Decls {
+		method, ok := declaration.(*ast.FuncDecl)
+		if !ok || method.Recv == nil || (method.Name.Name != "Start" && method.Name.Name != "Stop" && method.Name.Name != "Restart") {
+			continue
+		}
+		checked++
+		ast.Inspect(method.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if ok {
+				assert.NotEqual(t, "waitForState", selector.Sel.Name,
+					"Windows lifecycle behavior is an explicit non-goal of this change")
+			}
+			return true
+		})
+	}
+	assert.Equal(t, 3, checked)
 }
 
 func TestGivenServiceCommandWhenInspectingSubcommandsThenLifecycleSurfaceIsStable(t *testing.T) {

--- a/cmd/agentred/service_test.go
+++ b/cmd/agentred/service_test.go
@@ -111,7 +111,14 @@ func TestGivenInstallWithStartWhenExecutedThenManagerInstallsBeforeStarting(t *t
 }
 
 func TestGivenRunningManagerButUnreadableLocalDaemonWhenStartingThenCommandFailsWithoutPrintingSuccess(t *testing.T) {
-	manager := &fakeServiceManager{status: ServiceStatus{Installed: true, Running: true}}
+	manager := &fakeServiceManager{status: ServiceStatus{
+		Installed: true,
+		Running:   true,
+		Details: []string{
+			"Manager: launchd LaunchAgent",
+			"Target: gui/501/ai.agentre.agentred",
+		},
+	}}
 	cmd := newServiceCmdWithDeps(serviceCommandDeps{
 		managerFactory: func() (ServiceManager, error) { return manager, nil },
 		localStatus: func(context.Context) (map[string]any, error) {
@@ -132,6 +139,8 @@ func TestGivenRunningManagerButUnreadableLocalDaemonWhenStartingThenCommandFails
 	assert.Empty(t, out.String())
 	assert.Contains(t, err.Error(), "wait for local daemon status")
 	assert.Contains(t, err.Error(), "dial local socket: connection refused")
+	assert.Contains(t, err.Error(), "launchctl target gui/501/ai.agentre.agentred")
+	assert.Contains(t, err.Error(), "Run manually: launchctl print gui/501/ai.agentre.agentred")
 }
 
 func TestGivenLocalDaemonNeverBecomesReadyWhenStartingThenCancellationStopsObservation(t *testing.T) {
@@ -192,7 +201,7 @@ func TestGivenLifecycleStartActionsWhenLocalDaemonBecomesReadableThenTheyPrintRu
 	}{
 		{name: "install --start", args: []string{"install", "--start"}, wantCalls: []string{"install", "start", "status"}},
 		{name: "start", args: []string{"start"}, wantCalls: []string{"start", "status"}},
-		{name: "restart", args: []string{"restart"}, wantCalls: []string{"restart", "status"}},
+		{name: "restart", args: []string{"restart"}, wantCalls: []string{"restart"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -220,6 +229,63 @@ func TestGivenLifecycleStartActionsWhenLocalDaemonBecomesReadableThenTheyPrintRu
 			assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
 		})
 	}
+}
+
+func TestGivenRestartWhenOldDaemonStillAnswersThenItWaitsForANewDaemonPID(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{
+		Installed: true,
+		Running:   true,
+		Details:   []string{"Manager: launchd LaunchAgent"},
+	}}
+	attempts := 0
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			attempts++
+			switch attempts {
+			case 1, 2:
+				return map[string]any{"pid": float64(41)}, nil
+			default:
+				return map[string]any{"pid": float64(42)}, nil
+			}
+		},
+	})
+	cmd.SilenceUsage = true
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"restart"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, 3, attempts, "the pre-restart daemon must not satisfy post-restart readiness")
+	assert.Equal(t, []string{"restart", "status"}, manager.calls)
+	assert.Equal(t, "Daemon running", strings.Split(strings.TrimSpace(out.String()), "\n")[0])
+}
+
+func TestGivenWindowsRestartWhenLocalStatusIsReadableThenNoNewPIDContractIsAdded(t *testing.T) {
+	manager := &fakeServiceManager{status: ServiceStatus{
+		Installed: true,
+		Running:   true,
+		Details:   []string{"Manager: Windows Task Scheduler"},
+	}}
+	attempts := 0
+	cmd := newServiceCmdWithDeps(serviceCommandDeps{
+		managerFactory: func() (ServiceManager, error) { return manager, nil },
+		localStatus: func(context.Context) (map[string]any, error) {
+			attempts++
+			return map[string]any{"pid": float64(41)}, nil
+		},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"restart"})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, 2, attempts, "Windows restart keeps the pre-existing readable-status contract")
 }
 
 func TestGivenInstallWithStartAndLingerWarningWhenExecutedThenRepairDetailIsPreserved(t *testing.T) {

--- a/cmd/agentred/service_unsupported.go
+++ b/cmd/agentred/service_unsupported.go
@@ -1,9 +1,30 @@
+//go:build !windows
+
 package main
 
 import (
 	"context"
 	"fmt"
+	"os/user"
+	"runtime"
+	"strconv"
 )
+
+func newOSServiceManager(config serviceManagerConfig, currentUser *user.User) (ServiceManager, error) {
+	switch runtime.GOOS {
+	case "linux":
+		return newSystemdServiceManager(config), nil
+	case "darwin":
+		uid, err := strconv.Atoi(currentUser.Uid)
+		if err != nil {
+			return nil, fmt.Errorf("resolve current user id: %w", err)
+		}
+		config.UID = uid
+		return newLaunchdServiceManager(config), nil
+	default:
+		return &unsupportedServiceManager{platform: runtime.GOOS}, nil
+	}
+}
 
 type unsupportedServiceManager struct {
 	platform string

--- a/cmd/agentred/service_unsupported.go
+++ b/cmd/agentred/service_unsupported.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+type unsupportedServiceManager struct {
+	platform string
+}
+
+func (m *unsupportedServiceManager) unsupported() (ServiceStatus, error) {
+	return ServiceStatus{}, fmt.Errorf("user service management is not supported on %s", m.platform)
+}
+
+func (m *unsupportedServiceManager) Install(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}
+func (m *unsupportedServiceManager) Start(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}
+func (m *unsupportedServiceManager) Stop(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}
+func (m *unsupportedServiceManager) Restart(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}
+func (m *unsupportedServiceManager) Uninstall(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}
+func (m *unsupportedServiceManager) Status(context.Context) (ServiceStatus, error) {
+	return m.unsupported()
+}

--- a/cmd/agentred/service_windows.go
+++ b/cmd/agentred/service_windows.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	windowsServiceTaskName     = "AgentreAgentred"
+	windowsServiceLauncherName = "agentred-service.ps1"
+)
+
+type windowsServiceManager struct {
+	config       serviceManagerConfig
+	launcherPath string
+}
+
+func newOSServiceManager(config serviceManagerConfig, _ *user.User) (ServiceManager, error) {
+	return newWindowsServiceManager(config), nil
+}
+
+func newWindowsServiceManager(config serviceManagerConfig) ServiceManager {
+	return &windowsServiceManager{
+		config:       config,
+		launcherPath: filepath.Join(config.DataDir, windowsServiceLauncherName),
+	}
+}
+
+func (m *windowsServiceManager) Install(ctx context.Context) (ServiceStatus, error) {
+	if err := m.writeLauncher(); err != nil {
+		return ServiceStatus{}, err
+	}
+	args := windowsInstallArgs(m.config, m.launcherPath)
+	if err := m.run(ctx, "powershell.exe", args...); err != nil {
+		_ = os.Remove(m.launcherPath)
+		return ServiceStatus{}, err
+	}
+	return ServiceStatus{Installed: true}, nil
+}
+
+func (m *windowsServiceManager) Start(ctx context.Context) (ServiceStatus, error) {
+	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *windowsServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
+	status, err := m.Status(ctx)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !status.Installed {
+		return ServiceStatus{}, fmt.Errorf("service is not installed; run agentred service install")
+	}
+	if !status.Running {
+		return status, nil
+	}
+	if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *windowsServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
+	status, err := m.Status(ctx)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !status.Installed {
+		return ServiceStatus{}, fmt.Errorf("service is not installed; run agentred service install")
+	}
+	if status.Running {
+		if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
+			return ServiceStatus{}, err
+		}
+	}
+	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
+		return ServiceStatus{}, err
+	}
+	return m.Status(ctx)
+}
+
+func (m *windowsServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
+	status, err := m.Status(ctx)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	if !status.Installed {
+		return ServiceStatus{}, nil
+	}
+	if status.Running {
+		if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
+			return ServiceStatus{}, err
+		}
+	}
+	if err := m.run(ctx, "schtasks.exe", "/Delete", "/TN", windowsServiceTaskName, "/F"); err != nil {
+		return ServiceStatus{}, err
+	}
+	if err := os.Remove(m.launcherPath); err != nil && !os.IsNotExist(err) {
+		return ServiceStatus{}, fmt.Errorf("remove scheduled-task launcher: %w", err)
+	}
+	return ServiceStatus{}, nil
+}
+
+func (m *windowsServiceManager) Status(ctx context.Context) (ServiceStatus, error) {
+	args := windowsStatusArgs()
+	output, err := m.config.Runner.Run(ctx, "powershell.exe", args...)
+	if err != nil {
+		if isWindowsTaskMissing(err) {
+			return ServiceStatus{}, nil
+		}
+		return ServiceStatus{}, serviceCommandError("powershell.exe", args, output, err)
+	}
+	state := strings.TrimSpace(string(output))
+	return ServiceStatus{
+		Installed: true,
+		Running:   strings.EqualFold(state, "Running"),
+		Details: []string{
+			"Manager: Windows Task Scheduler",
+			"Task: " + windowsServiceTaskName,
+			"State: " + state,
+		},
+	}, nil
+}
+
+func (m *windowsServiceManager) run(ctx context.Context, name string, args ...string) error {
+	output, err := m.config.Runner.Run(ctx, name, args...)
+	if err != nil {
+		return serviceCommandError(name, args, output, err)
+	}
+	return nil
+}
+
+func (m *windowsServiceManager) writeLauncher() error {
+	if err := os.MkdirAll(m.config.DataDir, 0o700); err != nil {
+		return fmt.Errorf("create scheduled-task launcher directory: %w", err)
+	}
+	body := "$ErrorActionPreference = 'Stop'\n" +
+		"$env:AGENTRED_DATA_DIR = '" + windowsPowerShellLiteral(m.config.DataDir) + "'\n" +
+		"& '" + windowsPowerShellLiteral(m.config.BinaryPath) + "' run\n" +
+		"exit $LASTEXITCODE\n"
+	if err := os.WriteFile(m.launcherPath, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("write scheduled-task launcher: %w", err)
+	}
+	return nil
+}
+
+func windowsInstallArgs(config serviceManagerConfig, launcherPath string) []string {
+	actionArgs := `-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "` + launcherPath + `"`
+	script := "$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '" +
+		windowsPowerShellLiteral(actionArgs) + "'; " +
+		"$trigger = New-ScheduledTaskTrigger -AtLogOn -User '" + windowsPowerShellLiteral(config.UserName) + "'; " +
+		"$principal = New-ScheduledTaskPrincipal -UserId '" + windowsPowerShellLiteral(config.UserName) +
+		"' -LogonType Interactive -RunLevel Limited; " +
+		"$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries " +
+		"-ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1); " +
+		"Register-ScheduledTask -TaskName '" + windowsServiceTaskName +
+		"' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null"
+	return []string{"-NoProfile", "-NonInteractive", "-Command", script}
+}
+
+func windowsStatusArgs() []string {
+	return []string{
+		"-NoProfile", "-NonInteractive", "-Command",
+		"$task = Get-ScheduledTask -ErrorAction Stop | Where-Object { $_.TaskName -eq '" + windowsServiceTaskName +
+			"' -and $_.TaskPath -eq '\\' } | Select-Object -First 1; " +
+			"if ($null -eq $task) { exit 3 }; [Console]::Out.Write($task.State.ToString())",
+	}
+}
+
+func windowsPowerShellLiteral(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func isWindowsTaskMissing(err error) bool {
+	type exitCoder interface {
+		ExitCode() int
+	}
+	var exitErr exitCoder
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 3
+}

--- a/cmd/agentred/service_windows.go
+++ b/cmd/agentred/service_windows.go
@@ -8,7 +8,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 const (
@@ -48,7 +47,7 @@ func (m *windowsServiceManager) Start(ctx context.Context) (ServiceStatus, error
 	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.waitForState(ctx, true)
+	return m.Status(ctx)
 }
 
 func (m *windowsServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
@@ -65,7 +64,7 @@ func (m *windowsServiceManager) Stop(ctx context.Context) (ServiceStatus, error)
 	if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.waitForState(ctx, false)
+	return m.Status(ctx)
 }
 
 func (m *windowsServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
@@ -80,14 +79,11 @@ func (m *windowsServiceManager) Restart(ctx context.Context) (ServiceStatus, err
 		if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
 			return ServiceStatus{}, err
 		}
-		if _, err := m.waitForState(ctx, false); err != nil {
-			return ServiceStatus{}, err
-		}
 	}
 	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.waitForState(ctx, true)
+	return m.Status(ctx)
 }
 
 func (m *windowsServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
@@ -131,37 +127,6 @@ func (m *windowsServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 			"State: " + state,
 		},
 	}, nil
-}
-
-func (m *windowsServiceManager) waitForState(ctx context.Context, running bool) (ServiceStatus, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
-	defer cancel()
-	for {
-		status, err := m.Status(waitCtx)
-		if err != nil {
-			return ServiceStatus{}, err
-		}
-		if !status.Installed {
-			return ServiceStatus{}, fmt.Errorf("wait for Windows task %s: task disappeared; Run manually: schtasks.exe /Query /TN %s", windowsServiceTaskName, windowsServiceTaskName)
-		}
-		state := ""
-		if len(status.Details) != 0 {
-			state = strings.TrimPrefix(status.Details[len(status.Details)-1], "State: ")
-		}
-		terminal := strings.EqualFold(state, "Ready") || strings.EqualFold(state, "Disabled")
-		if (running && status.Running) || (!running && terminal) {
-			return status, nil
-		}
-		select {
-		case <-waitCtx.Done():
-			want := "stopped"
-			if running {
-				want = "running"
-			}
-			return ServiceStatus{}, fmt.Errorf("wait for Windows task %s to become %s: %w; Run manually: schtasks.exe /Query /TN %s", windowsServiceTaskName, want, waitCtx.Err(), windowsServiceTaskName)
-		case <-time.After(serviceReadyPollInterval):
-		}
-	}
 }
 
 func (m *windowsServiceManager) run(ctx context.Context, name string, args ...string) error {

--- a/cmd/agentred/service_windows.go
+++ b/cmd/agentred/service_windows.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -47,7 +48,7 @@ func (m *windowsServiceManager) Start(ctx context.Context) (ServiceStatus, error
 	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, true)
 }
 
 func (m *windowsServiceManager) Stop(ctx context.Context) (ServiceStatus, error) {
@@ -64,7 +65,7 @@ func (m *windowsServiceManager) Stop(ctx context.Context) (ServiceStatus, error)
 	if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, false)
 }
 
 func (m *windowsServiceManager) Restart(ctx context.Context) (ServiceStatus, error) {
@@ -79,11 +80,14 @@ func (m *windowsServiceManager) Restart(ctx context.Context) (ServiceStatus, err
 		if err := m.run(ctx, "schtasks.exe", "/End", "/TN", windowsServiceTaskName); err != nil {
 			return ServiceStatus{}, err
 		}
+		if _, err := m.waitForState(ctx, false); err != nil {
+			return ServiceStatus{}, err
+		}
 	}
 	if err := m.run(ctx, "schtasks.exe", "/Run", "/TN", windowsServiceTaskName); err != nil {
 		return ServiceStatus{}, err
 	}
-	return m.Status(ctx)
+	return m.waitForState(ctx, true)
 }
 
 func (m *windowsServiceManager) Uninstall(ctx context.Context) (ServiceStatus, error) {
@@ -127,6 +131,37 @@ func (m *windowsServiceManager) Status(ctx context.Context) (ServiceStatus, erro
 			"State: " + state,
 		},
 	}, nil
+}
+
+func (m *windowsServiceManager) waitForState(ctx context.Context, running bool) (ServiceStatus, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, serviceReadyTimeout)
+	defer cancel()
+	for {
+		status, err := m.Status(waitCtx)
+		if err != nil {
+			return ServiceStatus{}, err
+		}
+		if !status.Installed {
+			return ServiceStatus{}, fmt.Errorf("wait for Windows task %s: task disappeared; Run manually: schtasks.exe /Query /TN %s", windowsServiceTaskName, windowsServiceTaskName)
+		}
+		state := ""
+		if len(status.Details) != 0 {
+			state = strings.TrimPrefix(status.Details[len(status.Details)-1], "State: ")
+		}
+		terminal := strings.EqualFold(state, "Ready") || strings.EqualFold(state, "Disabled")
+		if (running && status.Running) || (!running && terminal) {
+			return status, nil
+		}
+		select {
+		case <-waitCtx.Done():
+			want := "stopped"
+			if running {
+				want = "running"
+			}
+			return ServiceStatus{}, fmt.Errorf("wait for Windows task %s to become %s: %w; Run manually: schtasks.exe /Query /TN %s", windowsServiceTaskName, want, waitCtx.Err(), windowsServiceTaskName)
+		case <-time.After(serviceReadyPollInterval):
+		}
+	}
 }
 
 func (m *windowsServiceManager) run(ctx context.Context, name string, args ...string) error {

--- a/cmd/agentred/service_windows_test.go
+++ b/cmd/agentred/service_windows_test.go
@@ -93,42 +93,6 @@ func TestGivenInstalledWindowsTaskWhenManagingThenScheduledTaskStatesAreReported
 	}, runner.calls)
 }
 
-func TestGivenWindowsTaskTransitionsWhenManagingThenActionsWaitForTerminalStates(t *testing.T) {
-	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
-		{}, {output: "Queued"}, {output: "Running"},
-		{output: "Running"}, {}, {output: "Running"}, {output: "Ready"},
-	}}
-	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
-
-	started, err := manager.Start(context.Background())
-	require.NoError(t, err)
-	assert.True(t, started.Running)
-	stopped, err := manager.Stop(context.Background())
-	require.NoError(t, err)
-	assert.False(t, stopped.Running)
-	assert.Equal(t, []serviceCommandCall{
-		{name: "schtasks.exe", args: []string{"/Run", "/TN", windowsServiceTaskName}},
-		windowsStatusCall(), windowsStatusCall(),
-		windowsStatusCall(), {name: "schtasks.exe", args: []string{"/End", "/TN", windowsServiceTaskName}},
-		windowsStatusCall(), windowsStatusCall(),
-	}, runner.calls)
-}
-
-func TestGivenWindowsTaskNeverRunsWhenStartingThenCancellationIsActionable(t *testing.T) {
-	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
-		{}, {output: "Queued"},
-	}}
-	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := manager.Start(ctx)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Contains(t, err.Error(), "wait for Windows task AgentreAgentred to become running")
-	assert.Contains(t, err.Error(), "Run manually: schtasks.exe /Query /TN AgentreAgentred")
-}
-
 func TestGivenMissingWindowsTaskWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{err: windowsCommandExitError{code: 3}}}}
 	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})

--- a/cmd/agentred/service_windows_test.go
+++ b/cmd/agentred/service_windows_test.go
@@ -93,6 +93,42 @@ func TestGivenInstalledWindowsTaskWhenManagingThenScheduledTaskStatesAreReported
 	}, runner.calls)
 }
 
+func TestGivenWindowsTaskTransitionsWhenManagingThenActionsWaitForTerminalStates(t *testing.T) {
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {output: "Queued"}, {output: "Running"},
+		{output: "Running"}, {}, {output: "Running"}, {output: "Ready"},
+	}}
+	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
+
+	started, err := manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, started.Running)
+	stopped, err := manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.False(t, stopped.Running)
+	assert.Equal(t, []serviceCommandCall{
+		{name: "schtasks.exe", args: []string{"/Run", "/TN", windowsServiceTaskName}},
+		windowsStatusCall(), windowsStatusCall(),
+		windowsStatusCall(), {name: "schtasks.exe", args: []string{"/End", "/TN", windowsServiceTaskName}},
+		windowsStatusCall(), windowsStatusCall(),
+	}, runner.calls)
+}
+
+func TestGivenWindowsTaskNeverRunsWhenStartingThenCancellationIsActionable(t *testing.T) {
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{}, {output: "Queued"},
+	}}
+	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := manager.Start(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, err.Error(), "wait for Windows task AgentreAgentred to become running")
+	assert.Contains(t, err.Error(), "Run manually: schtasks.exe /Query /TN AgentreAgentred")
+}
+
 func TestGivenMissingWindowsTaskWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
 	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{err: windowsCommandExitError{code: 3}}}}
 	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})

--- a/cmd/agentred/service_windows_test.go
+++ b/cmd/agentred/service_windows_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type windowsCommandExitError struct {
+	code int
+}
+
+func (e windowsCommandExitError) Error() string {
+	return "command exited"
+}
+
+func (e windowsCommandExitError) ExitCode() int {
+	return e.code
+}
+
+func TestGivenWindowsManagerWhenInstallingThenItRegistersCurrentUserLogonTask(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "agentred 100%")
+	runner := &fakeServiceCommandRunner{}
+	manager := newWindowsServiceManager(serviceManagerConfig{
+		BinaryPath: `C:\Program Files\Agentre 100%\agentred.exe`,
+		DataDir:    dataDir,
+		UserName:   `WORKSTATION\alice`,
+		Runner:     runner,
+	})
+
+	status, err := manager.Install(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{Installed: true}, status)
+
+	launcherPath := filepath.Join(dataDir, windowsServiceLauncherName)
+	body, err := os.ReadFile(launcherPath) //nolint:gosec // launcherPath is assembled under the test's temporary data directory.
+	require.NoError(t, err)
+	launcher := string(body)
+	assert.Contains(t, launcher, `$env:AGENTRED_DATA_DIR = '`+strings.ReplaceAll(dataDir, `'`, `''`)+`'`)
+	assert.Contains(t, launcher, `& 'C:\Program Files\Agentre 100%\agentred.exe' run`)
+	require.Len(t, runner.calls, 1)
+	assert.Equal(t, "powershell.exe", runner.calls[0].name)
+	require.Len(t, runner.calls[0].args, 4)
+	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command"}, runner.calls[0].args[:3])
+	registration := runner.calls[0].args[3]
+	assert.Contains(t, registration, `New-ScheduledTaskTrigger -AtLogOn -User 'WORKSTATION\alice'`)
+	assert.Contains(t, registration, `New-ScheduledTaskPrincipal -UserId 'WORKSTATION\alice' -LogonType Interactive -RunLevel Limited`)
+	assert.Contains(t, registration, `-ExecutionTimeLimit ([TimeSpan]::Zero)`)
+	assert.Contains(t, registration, `-File "`+launcherPath+`"`)
+	assert.Contains(t, registration, `Register-ScheduledTask -TaskName '`+windowsServiceTaskName+`'`)
+}
+
+func TestGivenInstalledWindowsTaskWhenManagingThenScheduledTaskStatesAreReported(t *testing.T) {
+	dataDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, windowsServiceLauncherName), []byte("launcher"), 0o600))
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{
+		{output: "Ready\r\n"},
+		{}, {output: "Running\r\n"},
+		{output: "Running\r\n"}, {}, {output: "Ready\r\n"},
+		{output: "Ready\r\n"}, {}, {output: "Running\r\n"},
+	}}
+	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: dataDir, Runner: runner})
+
+	status, err := manager.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.False(t, status.Running)
+
+	status, err = manager.Start(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+
+	status, err = manager.Stop(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.False(t, status.Running)
+
+	status, err = manager.Restart(context.Background())
+	require.NoError(t, err)
+	assert.True(t, status.Running)
+
+	assert.Equal(t, []serviceCommandCall{
+		windowsStatusCall(),
+		{name: "schtasks.exe", args: []string{"/Run", "/TN", windowsServiceTaskName}}, windowsStatusCall(),
+		windowsStatusCall(), {name: "schtasks.exe", args: []string{"/End", "/TN", windowsServiceTaskName}}, windowsStatusCall(),
+		windowsStatusCall(), {name: "schtasks.exe", args: []string{"/Run", "/TN", windowsServiceTaskName}}, windowsStatusCall(),
+	}, runner.calls)
+}
+
+func TestGivenMissingWindowsTaskWhenUninstallingThenOperationIsIdempotent(t *testing.T) {
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{err: windowsCommandExitError{code: 3}}}}
+	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
+
+	status, err := manager.Uninstall(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ServiceStatus{}, status)
+	assert.Equal(t, []serviceCommandCall{windowsStatusCall()}, runner.calls)
+}
+
+func TestGivenWindowsTaskQueryFailureWhenInspectingThenErrorIncludesRecoveryCommand(t *testing.T) {
+	runner := &fakeServiceCommandRunner{results: []fakeServiceCommandResult{{err: errors.New("PowerShell unavailable")}}}
+	manager := newWindowsServiceManager(serviceManagerConfig{DataDir: t.TempDir(), Runner: runner})
+
+	_, err := manager.Status(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PowerShell unavailable")
+	assert.Contains(t, err.Error(), "Run manually: powershell.exe")
+}
+
+func windowsStatusCall() serviceCommandCall {
+	return serviceCommandCall{name: "powershell.exe", args: windowsStatusArgs()}
+}

--- a/cmd/agentred/status.go
+++ b/cmd/agentred/status.go
@@ -35,6 +35,16 @@ func newStatusCmd() *cobra.Command {
 // (老版本)时整行不印 —— 印一行空路径会让人以为库文件丢了。
 func printStatus(w io.Writer, v map[string]any) {
 	_, _ = fmt.Fprintf(w, "Daemon running, pid %v\n", v["pid"])
+	printStatusDetails(w, v)
+}
+
+func printServiceDaemonStatus(w io.Writer, v map[string]any) {
+	_, _ = fmt.Fprintln(w, "Daemon running")
+	_, _ = fmt.Fprintf(w, "PID: %v\n", v["pid"])
+	printStatusDetails(w, v)
+}
+
+func printStatusDetails(w io.Writer, v map[string]any) {
 	if version, ok := v["version"].(string); ok && version != "" {
 		_, _ = fmt.Fprintf(w, "Version: %s\n", version)
 	}

--- a/cmd/agentred/status.go
+++ b/cmd/agentred/status.go
@@ -35,6 +35,9 @@ func newStatusCmd() *cobra.Command {
 // (老版本)时整行不印 —— 印一行空路径会让人以为库文件丢了。
 func printStatus(w io.Writer, v map[string]any) {
 	_, _ = fmt.Fprintf(w, "Daemon running, pid %v\n", v["pid"])
+	if version, ok := v["version"].(string); ok && version != "" {
+		_, _ = fmt.Fprintf(w, "Version: %s\n", version)
+	}
 	_, _ = fmt.Fprintln(w, "Listening on:")
 	for _, u := range toAnySlice(v["listenURLs"]) {
 		_, _ = fmt.Fprintf(w, "  %v\n", u)

--- a/cmd/agentred/status_test.go
+++ b/cmd/agentred/status_test.go
@@ -28,6 +28,34 @@ func TestPrintStatus_ShowsDatabasePathAndSize(t *testing.T) {
 	assert.Contains(t, out, "3.0 GB", "体量要印成人读得懂的量级,3221225472 这串数字判断不了该不该清理")
 }
 
+func TestGivenStatusWithVersionWhenPrintingThenShowsDaemonBuildIdentity(t *testing.T) {
+	var buf bytes.Buffer
+	printStatus(&buf, map[string]any{
+		"pid":              float64(1),
+		"version":          "v1.2.3 (abcdef1)",
+		"listenURLs":       []any{},
+		"pairedPeers":      []any{},
+		"activeSessions":   float64(0),
+		"llmProviderCount": float64(0),
+	})
+
+	assert.Contains(t, buf.String(), "Version: v1.2.3 (abcdef1)\n")
+}
+
+func TestGivenOlderStatusWithoutVersionWhenPrintingThenStillRenders(t *testing.T) {
+	var buf bytes.Buffer
+	printStatus(&buf, map[string]any{
+		"pid":              float64(1),
+		"listenURLs":       []any{},
+		"pairedPeers":      []any{},
+		"activeSessions":   float64(0),
+		"llmProviderCount": float64(0),
+	})
+
+	assert.Contains(t, buf.String(), "Daemon running, pid 1\n")
+	assert.NotContains(t, buf.String(), "Version:")
+}
+
 // TestPrintStatus_OmitsDatabaseLineWhenDaemonDoesNotReportIt 老 daemon 的状态应答里没有
 // dbPath,此时不能印一行空路径的 "Database:" —— 那会让人以为库文件丢了。
 func TestPrintStatus_OmitsDatabaseLineWhenDaemonDoesNotReportIt(t *testing.T) {

--- a/cmd/agentred/version.go
+++ b/cmd/agentred/version.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/agentre-ai/agentre/internal/daemon"
+
+func agentredBuildIdentity() string {
+	return daemon.BuildIdentity()
+}

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -60,9 +60,29 @@ Agentre 把这套工作流放进一个桌面应用。每个 **Agent** 都有自�
 
 ## 远端执行
 
-Agentre 附带 `agentred` companion daemon，可以在局域网内另一台 Linux 或 macOS 机器上运行会话。
+Agentre 使用 `agentred` companion daemon，可以在局域网内另一台 macOS、Linux 或 Windows 机器上运行会话。发布版本同时提供 amd64 与 arm64 架构。
 
-1. 打开 **设置 → Remote devices**，配对一台 `agentred` daemon。
+在 macOS 或 Linux 上安装最新版本：
+
+```bash
+curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh
+agentred --version
+agentred service install --start
+agentred service status
+```
+
+在 Windows PowerShell 中安装最新版本（无需管理员终端）：
+
+```powershell
+irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex
+agentred --version
+agentred service install --start
+agentred service status
+```
+
+然后连接桌面应用：
+
+1. 打开 **设置 → Remote devices**，配对这台 `agentred` daemon。
 2. 打开 **设置 → Agent backends**，创建后端，并把运行设备设为刚配对的机器。
 3. 在 **项目 → 设置 → 成员** 中添加 Agent，让它使用该后端，并填写远端机器上的工作路径。
 4. 从命令面板发起对话。会话实际在远端运行，桌面应用仍然显示工具审批、提问、状态和输出。

--- a/docs/specs/2026-08-11-agentred-onboarding.md
+++ b/docs/specs/2026-08-11-agentred-onboarding.md
@@ -1,0 +1,121 @@
+# agentred 安装引导与远端 UI/UX 优化
+
+<!-- File: docs/specs/2026-08-11-agentred-onboarding.md -->
+
+> Status: Approved
+> Owner: 桌面端前端（远端设备页）+ cmd/agentred + 发布流水线
+> Last updated: 2026-08-11
+
+**Objective:** 让用户能从零开始，在「远端设备」设置页按「安装 → 启动服务 → 配对」三步引导，把一台远端机器上的 agentred 安装、注册为后台服务并配对到桌面；发布流程产出可下载的 agentred 独立资产与安装脚本；agentred 提供后台服务生命周期管理命令。
+
+**Hard invariant:** 现有已配对设备的配对安全（6 位一次性配对码、TOFU 指纹、keychain token）、LAN/Relay 连接池、watcher 在线状态（`remote.device.state`）与设备列表行为一律不变；桌面端不新增对远端机器的 shell 访问通道，也不实时拉取远端服务状态；未执行任何引导操作的老用户，「远端设备」页原有能力不回归。
+
+> 交互方向与信息层级已通过本地 mockup 确认（非功能占位，见 `.dev-kit/artifacts/2026-08-11-agentred-onboarding/mockups/`，不提交到 Git）。绑定决策以本文为准。
+
+## Problem
+
+1. **首次使用远端的空态要求执行 `agentred run` / `agentred pair`，但 agentred 从哪来、怎么安装、怎么验证、怎么保持在线没有任何入口。** 空态只有两段 `<code>` 提示（`frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx:307-308`），假设 agentred 已装好、能一直跑着。
+2. **agentred 没有后台服务能力。** `agentred run` 是前台进程（`cmd/agentred/run.go`），SIGINT/SIGTERM 即停止；`root.go` 的子命令只有 `run / status / pair / login / unclaim / llm / claudecode`，没有 `service` 生命周期命令，也没有 `--version`。用户只能开着终端挂一个进程。
+3. **发布流程不产出 agentred 独立资产。** `.github/workflows/release.yml` 与 `nightly.yml` 只构建桌面（DMG / DEB / NSIS installer），README 却写“Agentre includes agentred”；用户无法从正常发布通道获得 agentred 二进制，只能源码 `go build`。
+4. **无法验证安装或排查版本。** 没有 `agentred --version`；daemon 的 `/local/status`（`cmd/agentred/status.go`）不返回版本字段，UI 也没有版本信息可展示。
+5. **远端页初始加载失败被误显示成「还没有设备」。** `if (loading) return null`（`remote-devices-panel.tsx:43 / 89`）在加载时整体空白；首次 `reload()` 失败既无错误态，Promise rejection 还可能成为未处理 rejection，最终被当作用户没配设备。
+6. **引导里的命令不可复制。** `agentred pair` 等只是 `<code>`（`add-device-dialog.tsx:114`），而应用 body 默认 `user-select:none`，用户难以选中复制。
+7. **`cmd/agentred/README.md` 已过时。** 仍声称 stateless / no SQLite / single binary，与当前实现（daemon 持有独立 `agentred.db`、持久化 session journal）不符，误导安装与运维方式。
+
+## Actors and user stories
+
+1. 作为**首次使用远端的用户**，我想在「远端设备」页按「安装 → 启动服务 → 配对」逐步被引导，以便从零接入一台远端机器，而不是面对两句命令猜流程。
+2. 作为**需要长期运行远端的用户**，我想把 agentred 注册为开机自启的后台服务，以便终端关闭也不离线。
+3. 作为**想手动安装的用户**，我想按平台看到可复制、可验证的安装命令。
+4. 作为**已配好设备的老用户**，我不希望引导打扰我；设备列表、在线状态、添加/管理能力照常工作。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | **三步引导放在「远端设备」页空态内（页面内步骤条展开）**，不新建独立页面或弹窗。 | 信息量大、需要跨步骤状态与命令复制，页面内步骤条最稳，且与设置页既有布局一致。Rejected: 弹窗 — 塞不下命令+清单；独立路由 — 打断设置页上下文。 |
+| 2 | **新增 agentred 后台服务闭环**：`service install/start/status/restart/stop/uninstall`；Linux 用 user 级 systemd（含 `loginctl enable-linger`）、macOS 用 launchd LaunchAgent、Windows 用计划任务，**均用户级、无需管理员权限**。 | 真正的闭环，跨平台一致，不要求 sudo。Rejected: 只做前台引导 — 运维门槛仍在；系统级 systemd / Windows Service — 需管理员，跨平台体验割裂。 |
+| 3 | **发布流程新增 agentred 独立资产构建**：release 与 nightly 各加一个 job，产出 `agentred-<version>-<goos>-<goarch>`（darwin/linux 用 tar.gz、windows 用 zip）+ `SHA256SUMS`，上传到同一个 GitHub Release。 | 桌面与远端不是同一台机器，打进桌面安装包无意义；独立资产是「可从正常通道获得」的前提。 |
+| 4 | **新增 `install.sh`（POSIX sh）与 `install.ps1`（Windows）作为发布资产**，UI 显示真实一键安装命令；脚本负责识别 OS/arch、下载对应资产、校验 SHA256SUMS、安装到可写路径（`/usr/local/bin`，不可写则 `~/.local/bin` 并提示 PATH）。 | 一键入口命令简短、可用。Rejected: 只显示手动下载命令 — 又长又易错；不校验 — 无法保证完整性。 |
+| 5 | **新增 `agentred --version`（semver + commit）**；daemon `/local/status` 增加 `version` 字段（向后兼容，老实现无该字段时正常）。安装步骤的验证清单用 `agentred --version`。 | 安装可验证、可排查。Rejected: 不做版本 — 装没装上、哪个版本无从判断。 |
+| 6 | **桌面端不实时拉取远端服务状态**：第二步只给命令 + 「在远端终端自行验证」清单；配对成功后在线状态由现有 watcher（`remote.device.state`）展示。 | 配对前桌面不知道远端地址、也无 shell 通道，实时探测不成立；配对后在线状态已存在。Rejected: 给 watcher 新增服务状态 RPC — 超本轮范围。 |
+| 7 | **远端页加载失败显示错误态 + 重试**，不再被当作空态。 | 消除「加载失败伪装成没有设备」。Rejected: 维持 `return null` — 掩盖故障。 |
+
+## Design
+
+### A. 首次使用：三步引导（「远端设备」页空态）
+
+前置：设备列表为空（未配对任何设备）时，「远端设备」页显示三步步条（安装 agentred → 启动远端服务 → 配对并验证），当前步骤展开；步骤完成标记 ✓。有设备时完全走现有设备列表，不出现引导。
+
+- **步骤 1 · 安装**：平台选择（Linux / macOS / Windows）。选中的平台决定显示的安装命令（带复制按钮，`data-selectable-text`，复制成功 toast）：
+  - Linux / macOS：`curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh`
+  - Windows：`irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex`（管理员 PowerShell）
+  - 提供「手动安装」退路入口。点击「我已安装，下一步 →」进入步骤 2。
+- **步骤 2 · 启动服务**：运行方式切换「后台服务（推荐）/ 前台临时运行」。
+  - 后台服务：`agentred service install --start`、`agentred service status`、`agentred service restart` 各带复制按钮；「确认服务已运行」清单（编号 1/2/3）：在远端终端运行 `agentred service status` 看到 `Daemon running`、确认监听地址含 `ws://…:7456/rpc`、保持服务运行。
+  - 前台运行：`agentred run` 复制，提示保持终端开启、关闭即停止。
+  - 点击「服务已运行，下一步 →」进入步骤 3。
+- **步骤 3 · 配对**：`agentred pair` 复制；连接地址 + 6 位配对码输入（可选名称），字段与校验规则与现有 `AddDeviceDialog` 一致（`URL_RE` / 6 位大写码）；提交走现有配对流程（`RemoteDeviceAdd`），失败在步骤内展示具体原因；成功后设备出现在列表并显示在线（现有 watcher），引导行提示「下一步配置 Agent 后端」。
+
+### B. agentred 后台服务闭环（`cmd/agentred service`）
+
+子命令（cobra 挂到 `agentred service` 下，`root.go` 注册）：
+
+| 命令 | 可观测行为 |
+|---|---|
+| `agentred service install [--start]` | 注册开机自启服务（Linux: user systemd unit + `loginctl enable-linger`；macOS: `~/Library/LaunchAgents/` LaunchAgent；Windows: 计划任务），可选 `--start` 立即启动。重复 install 幂等（更新配置）。 |
+| `agentred service start` / `stop` / `restart` | 启动 / 停止 / 重启已注册服务；失败输出明确错误与恢复提示。 |
+| `agentred service status` | 报告服务注册状态与运行状态（如 systemd `active` / launchd `loaded`+`running` / 计划任务状态），机器可读输出用于引导清单核对。 |
+| `agentred service uninstall` | 移除服务注册（并停止）；幂等。 |
+
+- 跨平台实现收敛到一个 `ServiceManager` 接口，按 GOOS 选择 systemd / launchd / 计划任务实现；`run`（前台）保持现状。
+- 命令输出为纯文本、稳定格式（首行状态词 + 细节行），非当前平台执行时给出清晰的不支持说明，退出码非 0 且带原因。
+- 服务启动实际就是以后台方式拉起 `agentred run`（含数据目录、监听配置不变）。
+
+### C. 版本与发布
+
+- `agentred --version` 输出 `agentred <semver> (<commit>)`；版本经 ldflags 注入（`configs.Version` + `internal/buildinfo.CommitID`），与桌面一致。
+- daemon `/local/status` 应答新增 `version` 字段（老 daemon 无该字段时 `agentred status` 照常工作、不报错）。
+- `.github/workflows/release.yml` 与 `nightly.yml` 各新增 agentred 资产构建 job：复用现有 goos/goarch 矩阵（darwin/linux/windows × amd64/arm64），产出 `agentred-<version>-<platform>`（tar.gz / zip）+ `SHA256SUMS`，并上传 `install.sh` / `install.ps1`，随现有 Release 发布（nightly 传 nightly release）。
+- `install.sh` / `install.ps1` 行为：识别 OS/arch → 从当前发布通道下载对应 agentred 资产 → 校验 SHA256SUMS → 安装到 `/usr/local/bin`（不可写则 `~/.local/bin` 并提示加入 PATH）→ 以 `agentred --version` 完成确认。
+
+### D. 页面状态与交互修复
+
+- 加载中：居中 spinner + `role="status"`，不再整页空白。
+- 首次加载失败：错误卡（`border-status-error/40 bg-destructive-soft` + 重试按钮），明确不是「还没有设备」，不产生未处理 rejection。
+- 命令与配对码等需复制的文本：带复制按钮 + `data-selectable-text`（body 默认 `user-select:none`）。
+- 设备列表、在线状态、LAN/Relay 路径、TLS 徽标、Provider 同步、未认领提示、解除配对等现有行为不变。
+
+### E. i18n
+
+- 全部新增 UI 文案走 `t(...)`，同步更新 `frontend/src/i18n/locales/zh-CN/common.json` 与 `en/common.json`（`remoteDevices` namespace 及新增键）；不硬编码中文。动态输出（命令、设备名、状态）不进入 `t(...)`。
+- 静态命令文本作为 UI 展示文案随 i18n 管理；复制到剪贴板的内容保持原样（命令本身不翻译）。
+
+## Out of scope
+
+- 桌面 SSH / 一键远程部署（把 agentred 直接推到远端机器）。
+- 桌面端对远端服务状态的实时查询（新增 RPC / watcher 扩展）。
+- agentred 自更新（`agentred upgrade`）。
+- daemon outdated 的完整升级闭环（保留现有布尔警告与提示文案，不新增下载/升级入口）。
+- 账号中 account-only agentred 的设备行、自动局域网发现。
+- 解除配对时对 daemon 调用 revoke / 清理 `pairedPeers`。
+- 桌面应用自身安装包中捆绑 agentred。
+
+## Testing decisions
+
+| Seam | 验证内容 | 参考 |
+|---|---|---|
+| Go：`agentred service` 命令层 | 子命令解析、参数（`--start`）传递、输出格式、非支持平台报错；注入 fake `ServiceManager` 断言调用序列 | 现有 `cmd/agentred` 无测试，新建 `service_test.go` |
+| Go：平台 ServiceManager 实现 | systemd unit / launchd plist / 计划任务参数的生成与内容断言（用接口 + 可注入命令执行器） | — |
+| Go：`agentred --version` 与 `/local/status` version 字段 | 版本输出格式；status 应答含 version、老实现无字段时兼容 | 现有 `internal/daemon/daemon_test.go`（真实 SQLite 例外） |
+| 前端：三步引导组件 | 空态显示步骤条；平台切换更新命令；复制；步骤流转；配对表单提交错误；加载中；加载失败显示错误态而非空态 | 现有 `remote-devices/*.test.ts(x)`（vitest + happy-dom + `vi.mock` wails） |
+| 前端：i18n | 新键 zh-CN/en 同步、`t("…")` 静态键可解析 | 现有 `frontend/src/__tests__/i18n.test.ts` 守卫 |
+| 发布流水线（release/nightly workflow） | 无法自动化；wrap-up 时对 workflow 文件做 source review，验证 agentred 资产命名、SHA256SUMS、install 脚本上传齐全；不实际发 Release | 现有 `release.yml` / `nightly.yml` |
+| `install.sh` / `install.ps1` | 无法 TDD（shell）；wrap-up 时在本机真实 shell 各跑一次，验证下载、SHA256SUMS 校验、安装路径选择与 `agentred --version` 确认 | 无 prior art，新建脚本 |
+| 真实后台服务管理（systemd / launchd / 计划任务） | 本机平台手测（macOS 上验证 LaunchAgent 注册/启停）；非本机平台由接口测试覆盖参数生成 + source review | — |
+
+需要你确认的测试决定：agentred 的 `service` 命令与平台实现是否接受「接口 + 注入 fake 的单元测试为主、真实系统服务本机手测、其余平台 review」这一组合；安装脚本无法做自动化单测、只做 wrap-up 手动验证是否可以接受。
+
+## Open questions
+
+（空）

--- a/docs/specs/2026-08-11-agentred-onboarding.md
+++ b/docs/specs/2026-08-11-agentred-onboarding.md
@@ -8,7 +8,7 @@
 
 **Objective:** 让用户能从零开始，在「远端设备」设置页按「安装 → 启动服务 → 配对」三步引导，把一台远端机器上的 agentred 安装、注册为后台服务并配对到桌面；发布流程产出可下载的 agentred 独立资产与安装脚本；agentred 提供后台服务生命周期管理命令。
 
-**Hard invariant:** 现有已配对设备的配对安全（6 位一次性配对码、TOFU 指纹、keychain token）、LAN/Relay 连接池、watcher 在线状态（`remote.device.state`）与设备列表行为一律不变；桌面端不新增对远端机器的 shell 访问通道，也不实时拉取远端服务状态；未执行任何引导操作的老用户，「远端设备」页原有能力不回归。
+**Hard invariant:** 现有已配对设备的配对安全（6 位一次性配对码、TOFU 指纹、keychain token）、LAN/Relay 连接池、watcher 在线状态（`remote.device.state`）与设备列表行为一律不变；桌面端不新增对远端机器的 shell 访问通道，也不实时拉取远端服务状态；Unix 本地 IPC 路径与权限不变，Windows named pipe 只能扩展同等的当前用户本机边界；用户从前台 `run` 切换到后台服务时，自定义数据目录、host/port/TLS/Relay server 配置不得丢失；未执行任何引导操作的老用户，「远端设备」页原有能力不回归。
 
 > 交互方向与信息层级已通过本地 mockup 确认（非功能占位，见 `.dev-kit/artifacts/2026-08-11-agentred-onboarding/mockups/`，不提交到 Git）。绑定决策以本文为准。
 
@@ -21,6 +21,8 @@
 5. **远端页初始加载失败被误显示成「还没有设备」。** `if (loading) return null`（`remote-devices-panel.tsx:43 / 89`）在加载时整体空白；首次 `reload()` 失败既无错误态，Promise rejection 还可能成为未处理 rejection，最终被当作用户没配设备。
 6. **引导里的命令不可复制。** `agentred pair` 等只是 `<code>`（`add-device-dialog.tsx:114`），而应用 body 默认 `user-select:none`，用户难以选中复制。
 7. **`cmd/agentred/README.md` 已过时。** 仍声称 stateless / no SQLite / single binary，与当前实现（daemon 持有独立 `agentred.db`、持久化 session journal）不符，误导安装与运维方式。
+8. **Windows agentred 目前只能交叉编译、不能运行。** `internal/daemon/ipc.go:25-29` 在 Windows 直接返回 `ipc: windows named pipe path not yet wired`，CLI 客户端也只会拨 Unix socket（`cmd/agentred/client.go:15-22`）；不补 named-pipe 本地 IPC，Windows 的 `run / status / pair / llm / service` 和发布资产都无法兑现。
+9. **后台服务没有可靠的运行配置来源。** 当前 `run` 只用本次 flag/环境构造 daemon options（`cmd/agentred/run.go:48-67`），未读写 `state.Listen`；`login --server` 也不持久化 Relay server。服务若只执行裸 `agentred run`，会丢失自定义 host/port/TLS/Relay 和非默认数据目录。
 
 ## Actors and user stories
 
@@ -34,12 +36,14 @@
 | # | Decision | Basis and rejected option |
 |---|---|---|
 | 1 | **三步引导放在「远端设备」页空态内（页面内步骤条展开）**，不新建独立页面或弹窗。 | 信息量大、需要跨步骤状态与命令复制，页面内步骤条最稳，且与设置页既有布局一致。Rejected: 弹窗 — 塞不下命令+清单；独立路由 — 打断设置页上下文。 |
-| 2 | **新增 agentred 后台服务闭环**：`service install/start/status/restart/stop/uninstall`；Linux 用 user 级 systemd（含 `loginctl enable-linger`）、macOS 用 launchd LaunchAgent、Windows 用计划任务，**均用户级、无需管理员权限**。 | 真正的闭环，跨平台一致，不要求 sudo。Rejected: 只做前台引导 — 运维门槛仍在；系统级 systemd / Windows Service — 需管理员，跨平台体验割裂。 |
-| 3 | **发布流程新增 agentred 独立资产构建**：release 与 nightly 各加一个 job，产出 `agentred-<version>-<goos>-<goarch>`（darwin/linux 用 tar.gz、windows 用 zip）+ `SHA256SUMS`，上传到同一个 GitHub Release。 | 桌面与远端不是同一台机器，打进桌面安装包无意义；独立资产是「可从正常通道获得」的前提。 |
-| 4 | **新增 `install.sh`（POSIX sh）与 `install.ps1`（Windows）作为发布资产**，UI 显示真实一键安装命令；脚本负责识别 OS/arch、下载对应资产、校验 SHA256SUMS、安装到可写路径（`/usr/local/bin`，不可写则 `~/.local/bin` 并提示 PATH）。 | 一键入口命令简短、可用。Rejected: 只显示手动下载命令 — 又长又易错；不校验 — 无法保证完整性。 |
-| 5 | **新增 `agentred --version`（semver + commit）**；daemon `/local/status` 增加 `version` 字段（向后兼容，老实现无该字段时正常）。安装步骤的验证清单用 `agentred --version`。 | 安装可验证、可排查。Rejected: 不做版本 — 装没装上、哪个版本无从判断。 |
+| 2 | **新增 agentred 后台服务闭环**：`service install/start/status/restart/stop/uninstall`；Linux 用 user 级 systemd（尝试 `loginctl enable-linger`）、macOS 用 launchd LaunchAgent、Windows 用用户级计划任务，默认不创建系统级服务。 | 真正的闭环，优先用户级以减少权限要求；Linux host policy 不允许 linger 时，注册仍成功但必须输出可执行的修复命令。Rejected: 只做前台引导 — 运维门槛仍在；系统级 systemd / Windows Service — 默认需要管理员，跨平台体验割裂。 |
+| 3 | **发布流程新增 agentred 独立资产构建**：release 与 nightly 各加一个 job，产出 `agentred-<version>-<goos>-<goarch>`（darwin/linux 用 tar.gz、windows 用 zip）+ `SHA256SUMS`，并保留 `SHA256SUMS.txt` 兼容现有桌面更新，上传到同一个 GitHub Release。 | 桌面与远端不是同一台机器，打进桌面安装包无意义；独立资产是「可从正常通道获得」的前提。Rejected: 只改 README — 仍没有可安装产物。 |
+| 4 | **新增 `install.sh`（POSIX sh）与 `install.ps1`（Windows）作为发布资产**，UI 显示真实一键安装命令；脚本负责识别 OS/arch、下载对应资产、校验 SHA256SUMS；Unix 安装到可写的 `/usr/local/bin`，不可写则 `~/.local/bin` 并提示 PATH；Windows 安装到 `%LOCALAPPDATA%\Programs\agentred\` 并写入用户 PATH。 | 一键入口命令简短、可用，Windows 不要求管理员 PowerShell。Rejected: 只显示手动下载命令 — 又长又易错；不校验 — 无法保证完整性。 |
+| 5 | **新增 `agentred --version`（semver + commit）**；daemon `/local/status` 增加 `version` 字段（向后兼容，老实现无该字段时正常），账号登录登记同一真实版本而非固定 `dev`。安装步骤的验证清单用 `agentred --version`。 | 安装可验证、可排查，账号设备版本也不能与二进制身份分叉。Rejected: 不做版本 — 装没装上、哪个版本无从判断。 |
 | 6 | **桌面端不实时拉取远端服务状态**：第二步只给命令 + 「在远端终端自行验证」清单；配对成功后在线状态由现有 watcher（`remote.device.state`）展示。 | 配对前桌面不知道远端地址、也无 shell 通道，实时探测不成立；配对后在线状态已存在。Rejected: 给 watcher 新增服务状态 RPC — 超本轮范围。 |
 | 7 | **远端页加载失败显示错误态 + 重试**，不再被当作空态。 | 消除「加载失败伪装成没有设备」。Rejected: 维持 `return null` — 掩盖故障。 |
+| 8 | **Windows 本地 IPC 扩展为当前用户 ACL 的 named pipe**，Unix socket 的路径、HTTP 路由和 JSON 形状保持不变；daemon 与 CLI 共享同一 endpoint 解析。 | 完整跨平台服务的必要前置。Rejected: 仍发布 Windows 资产但不接 IPC — 二进制启动即退出，属于不可用产物。 |
+| 9 | **agentred 运行配置收敛到 state**：显式 flag → 环境 → 持久化 state → 默认值；显式变更写回 state，`login --server` 持久化 Hub server URL；服务定义只运行当前二进制的 `run` 并固定解析后的 `AGENTRED_DATA_DIR`。 | 避免 systemd/launchd/计划任务各复制一套参数规则，也避免从前台切后台时丢配置。Rejected: 把当前 flags 全写进三种服务 manifest — 重复、易漂移。 |
 
 ## Design
 
@@ -49,7 +53,7 @@
 
 - **步骤 1 · 安装**：平台选择（Linux / macOS / Windows）。选中的平台决定显示的安装命令（带复制按钮，`data-selectable-text`，复制成功 toast）：
   - Linux / macOS：`curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh`
-  - Windows：`irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex`（管理员 PowerShell）
+  - Windows：`irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex`（普通 PowerShell）
   - 提供「手动安装」退路入口。点击「我已安装，下一步 →」进入步骤 2。
 - **步骤 2 · 启动服务**：运行方式切换「后台服务（推荐）/ 前台临时运行」。
   - 后台服务：`agentred service install --start`、`agentred service status`、`agentred service restart` 各带复制按钮；「确认服务已运行」清单（编号 1/2/3）：在远端终端运行 `agentred service status` 看到 `Daemon running`、确认监听地址含 `ws://…:7456/rpc`、保持服务运行。
@@ -68,16 +72,20 @@
 | `agentred service status` | 报告服务注册状态与运行状态（如 systemd `active` / launchd `loaded`+`running` / 计划任务状态），机器可读输出用于引导清单核对。 |
 | `agentred service uninstall` | 移除服务注册（并停止）；幂等。 |
 
-- 跨平台实现收敛到一个 `ServiceManager` 接口，按 GOOS 选择 systemd / launchd / 计划任务实现；`run`（前台）保持现状。
-- 命令输出为纯文本、稳定格式（首行状态词 + 细节行），非当前平台执行时给出清晰的不支持说明，退出码非 0 且带原因。
-- 服务启动实际就是以后台方式拉起 `agentred run`（含数据目录、监听配置不变）。
+- 跨平台实现收敛到一个 `ServiceManager` 接口，按 GOOS 选择 systemd / launchd / 计划任务实现；`run`（前台）保持现有命令面。
+- 命令输出为纯文本、稳定格式：`Daemon running` / `Daemon stopped` / `Service not installed` 为首行状态词，后接细节；失败退出码非 0 且带原因。
+- 服务启动实际就是以后台方式拉起当前二进制的 `agentred run`，设置解析后的 `AGENTRED_DATA_DIR`；host/port/TLS/Hub server 由 state 统一恢复。
+- `run` 的运行配置优先级为显式 flag → 环境 → 持久化 state → 默认值；显式变更写回 state；`login --server` 成功后持久化 Hub server URL。
+- Windows local IPC 使用当前用户 ACL 的 named pipe；`run / pair / status / llm` 的 HTTP 路径与 JSON 形状与 Unix 完全一致，CLI 与 daemon 共享 endpoint 解析，Unix socket 行为不变。
 
 ### C. 版本与发布
 
 - `agentred --version` 输出 `agentred <semver> (<commit>)`；版本经 ldflags 注入（`configs.Version` + `internal/buildinfo.CommitID`），与桌面一致。
 - daemon `/local/status` 应答新增 `version` 字段（老 daemon 无该字段时 `agentred status` 照常工作、不报错）。
-- `.github/workflows/release.yml` 与 `nightly.yml` 各新增 agentred 资产构建 job：复用现有 goos/goarch 矩阵（darwin/linux/windows × amd64/arm64），产出 `agentred-<version>-<platform>`（tar.gz / zip）+ `SHA256SUMS`，并上传 `install.sh` / `install.ps1`，随现有 Release 发布（nightly 传 nightly release）。
-- `install.sh` / `install.ps1` 行为：识别 OS/arch → 从当前发布通道下载对应 agentred 资产 → 校验 SHA256SUMS → 安装到 `/usr/local/bin`（不可写则 `~/.local/bin` 并提示加入 PATH）→ 以 `agentred --version` 完成确认。
+- `.github/workflows/release.yml` 与 `nightly.yml` 各新增 agentred 资产构建 job：复用现有 goos/goarch 矩阵（darwin/linux/windows × amd64/arm64），产出 `agentred-<version>-<platform>`（tar.gz / zip）+ `SHA256SUMS`，同时上传内容相同的 `SHA256SUMS.txt` 兼容现有 `update_svc`，并上传 `install.sh` / `install.ps1`，随现有 Release 发布（nightly 传 nightly release）。
+- Windows agentred 资产只在 named-pipe IPC 与计划任务服务可用后发布，不能发布“能构建但启动即失败”的二进制。
+- `install.sh` / `install.ps1` 行为：识别 OS/arch → 从当前发布通道下载对应 agentred 资产 → 校验 SHA256SUMS → Unix 安装到 `/usr/local/bin`（不可写则 `~/.local/bin` 并提示加入 PATH），Windows 安装到 `%LOCALAPPDATA%\Programs\agentred\` 并写入用户 PATH → 以 `agentred --version` 完成确认。
+- workflow 的 ldflags 统一使用完整模块路径 `github.com/agentre-ai/agentre/internal/buildinfo.CommitID`，release/nightly 与 Makefile 不各自维护不同版本注入规则。
 
 ### D. 页面状态与交互修复
 
@@ -105,16 +113,15 @@
 
 | Seam | 验证内容 | 参考 |
 |---|---|---|
-| Go：`agentred service` 命令层 | 子命令解析、参数（`--start`）传递、输出格式、非支持平台报错；注入 fake `ServiceManager` 断言调用序列 | 现有 `cmd/agentred` 无测试，新建 `service_test.go` |
-| Go：平台 ServiceManager 实现 | systemd unit / launchd plist / 计划任务参数的生成与内容断言（用接口 + 可注入命令执行器） | — |
-| Go：`agentred --version` 与 `/local/status` version 字段 | 版本输出格式；status 应答含 version、老实现无字段时兼容 | 现有 `internal/daemon/daemon_test.go`（真实 SQLite 例外） |
-| 前端：三步引导组件 | 空态显示步骤条；平台切换更新命令；复制；步骤流转；配对表单提交错误；加载中；加载失败显示错误态而非空态 | 现有 `remote-devices/*.test.ts(x)`（vitest + happy-dom + `vi.mock` wails） |
+| Go：构建身份与 local status | `--version` 稳定格式；`/local/status.version`；老 daemon 无字段兼容；账号登录登记真实版本 | `cmd/agentred/main_test.go`、`status_test.go`、`login_test.go`、`internal/daemon/daemon_test.go` |
+| Go：`agentred service` 命令层 | 子命令解析、`--start` 编排、稳定首行状态、错误与幂等；注入 fake `ServiceManager` 断言调用序列 | 新建 `cmd/agentred/service_test.go` |
+| Go：平台 ServiceManager 与配置 state | systemd unit / launchd plist / 计划任务参数生成；可注入命令执行器；显式 flag/环境/state/default 优先级；自定义配置切后台不丢失 | 参考 `internal/app/system_test.go` 与 `internal/pkg/agrctlinstall/install_test.go` |
+| Go：Windows local IPC | 公共 mux 路由不变；named-pipe endpoint 稳定且不暴露原始路径；Windows round trip；Unix socket 回归；windows/amd64 与 windows/arm64 交叉构建 | 现有 `internal/daemon/daemon_test.go` + 新平台测试 |
+| 安装脚本 | 先用本地 HTTP fixture + `AGENTRED_RELEASE_BASE_URL` / `AGENTRED_INSTALL_DIR` 让 checksum 成功、checksum 不匹配拒绝、fallback 安装目录、`--version` 确认自动变红/变绿；PowerShell 在 Windows runner 执行 | 新建 installer fixture/test seam，不再只靠目视 review |
+| 前端：加载状态机与三步引导 | loading/error/ready；错误重试且不误显示空态；平台切换更新命令；复制；步骤流转；配对失败保留输入；成功后衔接 Agent 后端 | 现有 `remote-devices/*.test.ts(x)`（vitest + happy-dom + `vi.mock` wails） |
 | 前端：i18n | 新键 zh-CN/en 同步、`t("…")` 静态键可解析 | 现有 `frontend/src/__tests__/i18n.test.ts` 守卫 |
-| 发布流水线（release/nightly workflow） | 无法自动化；wrap-up 时对 workflow 文件做 source review，验证 agentred 资产命名、SHA256SUMS、install 脚本上传齐全；不实际发 Release | 现有 `release.yml` / `nightly.yml` |
-| `install.sh` / `install.ps1` | 无法 TDD（shell）；wrap-up 时在本机真实 shell 各跑一次，验证下载、SHA256SUMS 校验、安装路径选择与 `agentred --version` 确认 | 无 prior art，新建脚本 |
-| 真实后台服务管理（systemd / launchd / 计划任务） | 本机平台手测（macOS 上验证 LaunchAgent 注册/启停）；非本机平台由接口测试覆盖参数生成 + source review | — |
-
-需要你确认的测试决定：agentred 的 `service` 命令与平台实现是否接受「接口 + 注入 fake 的单元测试为主、真实系统服务本机手测、其余平台 review」这一组合；安装脚本无法做自动化单测、只做 wrap-up 手动验证是否可以接受。
+| 发布流水线 | source review + 机械检查 agentred 六平台矩阵、依赖关系、资产名、两个 checksum 名、install 脚本与完整 ldflag 路径；不实际发布 Release | 现有 `release.yml` / `nightly.yml` |
+| 真实后台服务管理 | 自动测试保护 manifest/命令参数；wrap-up 在 macOS 真机验证 LaunchAgent install/start/status/restart/stop/uninstall；Linux systemd 与 Windows 计划任务由对应 CI runner/接口测试补充，手测仅补充、不替代 RED | — |
 
 ## Open questions
 

--- a/docs/specs/2026-08-12-agentred-service-runtime-fixes.md
+++ b/docs/specs/2026-08-12-agentred-service-runtime-fixes.md
@@ -1,0 +1,93 @@
+# agentred 后台服务与验收隔离修复
+
+<!-- File: docs/specs/2026-08-12-agentred-service-runtime-fixes.md -->
+
+> Status: Approved
+> Owner: cmd/agentred + desktop e2e/bootstrap
+> Last updated: 2026-08-12
+
+**Objective:** 修复 macOS 用户级 agentred 服务启动/重启不可靠与桌面 e2e keychain 装配分叉，使 reviewed agentred 在真实 macOS、Linux 用户级服务环境中都能完成生命周期，并使真实桌面配对后的 watcher 稳定在线。
+
+**Hard invariant:** Linux `systemd --user` 已通过的生命周期、agentred 持久化运行配置、生产 system keychain、6 位一次性配对码、TOFU 指纹、设备 token、现有 Wails 配对流程和 watcher 在线状态协议不得回归；e2e 运行不得读取、覆盖或删除任何生产 system keychain 条目。
+
+## Problem
+
+1. **macOS LaunchAgent 的启动结果存在竞态，`install --start` 会在 daemon 尚未就绪时返回错误状态。** 在 macOS 14.8.7 arm64 上，reviewed HEAD `afe73523` 的真实运行中，`agentred service install --start` 首先输出 `Daemon stopped`；稍后 `launchctl` 显示进程 running，但本地状态 socket 尚不存在。当前 `Start` 在 `bootstrap` 后只做一次 `launchctl print`，没有等待 daemon 与本地 IPC 就绪（`cmd/agentred/service_launchd.go`）。
+2. **macOS LaunchAgent 的 restart 使用 `bootout → bootstrap`，会撞上 launchd 注销竞态。** 同一真实运行中，`agentred service restart` 返回 `Bootstrap failed: 5: Input/output error`。当前 `Restart` 无条件先 `bootout` 再立即 `bootstrap`，而 launchd 提供了对已加载 job 的原生 kickstart/restart 路径。
+3. **e2e keychain 覆盖发生得太晚，Remote Device Add 与 watcher 可能使用不同后端。** `bootstrap.Init` 先执行 `InitServer` 与 `InitRemoteDevice`，令 Remote Device 服务捕获 system keychain；随后 `main.go` 才调用 `fakes.Install`，其中 `installE2EKeychainOverride` 把全局默认值改为 file keychain。真实验收因此出现 Add 写 system keychain、watcher 读 file keychain并报 `unauthorized` 的假阴性。
+4. **上述 e2e 分叉会污染真实凭据。** 隔离 e2e 数据库从设备 ID 1 开始，而 token account 名只含设备 ID；验收曾覆盖真实 `agentre-daemon-token-1`。这违反 e2e 隔离边界，即使测试数据库、端口与文件目录均已隔离也不安全。
+5. **平台生命周期不能只由 mock、交叉编译或接口测试宣称成功。** 当前 Linux 在 `coding.local` Debian 12 amd64 上已真实通过，macOS 未通过。用户要求本修正轮交付前至少在可用的真实 macOS 与 Linux 设备上分别跑通。
+
+## Actors and user stories
+
+1. 作为 macOS 用户，我希望 `service install --start` 和 `service restart` 只在 daemon 真正可用后报告成功，以便关闭终端后仍能稳定使用远端设备。
+2. 作为 Linux 用户，我希望修复 macOS 时不破坏已经工作的 `systemd --user` 生命周期与持久化配置。
+3. 作为维护者，我希望 e2e 配对从进程初始化开始就使用隔离 keychain，以便验收既能观察真实 Wails/daemon 行为，又不会触碰我的生产凭据。
+4. 作为发布负责人，我希望 macOS 与 Linux 都留下真机命令、退出码、监听状态与清理证据，以便平台支持结论可复现。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | macOS 对已加载 LaunchAgent 使用 launchd 原生启动/重启操作；只有未加载 job 才执行 bootstrap。 | 避免 `bootout → bootstrap` 的异步注销竞态，同时保留 LaunchAgent 用户级边界。Rejected: 在 bootout 后盲加固定 sleep — 依赖机器速度，仍可能偶发失败。 |
+| 2 | start/restart 成功必须经过有界就绪等待：launchd job 为 running，且 agentred 本地状态端点可读取；超时返回非零并保留可执行诊断信息。 | “launchd 有进程”不等于 daemon 已可用；原故障正是两者时间窗口不同。Rejected: 继续只检查一次 `launchctl print` — 会误报 stopped 或提前成功。 |
+| 3 | stop/uninstall 继续使用 bootout，但操作完成后必须观察 job 已卸载/停止；missing service 保持幂等成功。 | 停止与卸载需要明确终态，且不能把正常的 missing service 当故障。Rejected: 所有动作都改为 kickstart — kickstart 不负责卸载。 |
+| 4 | `AGENTRE_E2E_KEYCHAIN_DIR` 在 bootstrap 创建任何依赖 keychain 的服务之前生效；同一进程内 Server、Remote Device、ConnPool、watcher 与 e2e seeding 必须捕获同一个 file keychain。 | 从生产者边界消除 split-brain，而不是在 watcher 处增加缺 token fallback。Rejected: 配对后再次重装 Remote Device 服务 — 已创建对象仍可能持有旧实例，且掩盖初始化顺序错误。 |
+| 5 | e2e keychain 隔离失败时启动直接失败，不得静默退回 system keychain。 | silent fallback 会再次污染真实凭据。Rejected: 只给 e2e 设备 ID 加大偏移 — 仍然触碰生产 keychain，不能构成安全隔离。 |
+| 6 | 本轮以真实 macOS + `opsctl local-coding` Linux 双平台运行作为交付硬门；两端都必须使用 reviewed HEAD 构建并完成清理。 | 用户明确要求至少跑通两种现有真实设备。Rejected: Linux 只跑单测或交叉构建 — 不能观察 systemd、linger、进程与 socket。 |
+
+## macOS LaunchAgent 生命周期
+
+当用户已通过前台 `agentred run` 保存 host、port、TLS、Relay server 或自定义数据目录后，执行 `agentred service install --start` 必须安装/更新当前用户的 LaunchAgent，并等待同一数据目录下的 daemon 本地状态可读。成功输出首行必须为 `Daemon running`，后续 `agentred service status` 必须显示注入的版本、持久化监听地址与可读本地状态，不得出现 `Local status unavailable`。
+
+当已安装的 LaunchAgent 正在运行时，执行 `agentred service restart` 必须通过 launchd 的已加载 job 重启路径完成，不得先注销再立即注册。命令成功返回时，新 daemon PID 已建立、本地状态可读、原持久化配置不变。若 job 文件存在但尚未加载，start/restart 可以重新 bootstrap；若 launchd 或 daemon 在有界等待内未就绪，命令退出码非 0，错误包含失败阶段、launchctl 目标以及用户可直接执行的诊断/恢复命令。
+
+`service stop` 成功后必须显示 `Daemon stopped`，job 不再运行且本地 socket/监听端口不可用；`service start` 能从这一状态恢复到可读本地状态。`service uninstall` 必须停止 job、移除 plist，并保持重复执行幂等。所有命令仍为当前用户 LaunchAgent，不请求管理员权限或创建系统级 daemon。
+
+## Linux systemd 回归边界
+
+Linux 继续使用 `systemd --user` 与用户级 unit。修复共享就绪逻辑后，`install --start`、status、restart、stop、start、uninstall 的稳定首行和退出码保持不变。前台显式保存的 host/port/TLS/Relay server 与解析后的 `AGENTRED_DATA_DIR` 必须由后台 unit 恢复。
+
+若 `loginctl enable-linger` 被策略拒绝，install 仍安装 unit，并输出当前已有的明确修复命令；若 linger 已启用，完整生命周期不得出现额外警告。不得触碰同机已有的其他 agentred 二进制、数据目录、进程或端口；真机验收使用唯一 `/tmp` 路径与非默认端口。
+
+## E2E keychain 初始化与安全边界
+
+带 `e2e` build tag 且设置 `AGENTRE_E2E_KEYCHAIN_DIR` 时，应用必须在 bootstrap 装配 Server 和 Remote Device 之前建立 file keychain。目录必须是隔离、当前用户可写的 0700 目录，secret 文件使用 0600。Server、Remote Device Add、ConnPool、watcher 和 e2e login seed 读取到同一实例/同一目录。
+
+如果变量存在但目录缺失、权限不安全或无法初始化，e2e 应在启动阶段以明确错误终止；不得回退 `NewSystem()`。未设置该变量的生产构建继续使用平台 system keychain，行为不变。
+
+一次真实 e2e 配对必须把 device fingerprint 与设备 token 写入隔离目录，watcher 使用同一凭据后变为 online。运行前后检查生产 system keychain，不得新增、修改或删除 `agentre-daemon-token-*` 或 `agentre-device-fingerprint`。验收脚本也不得依靠高位设备 ID 规避碰撞；隔离必须由 keychain backend 边界保证。
+
+## Failure handling and cleanup
+
+- launchctl/systemctl 命令失败必须保留原始原因，并输出可直接执行的诊断命令；不得把权限错误当作 stopped。
+- 就绪等待必须有上限并尊重 context 取消，不能无限阻塞 CLI。
+- daemon 在等待期间退出时，返回失败而不是继续轮询到一个模糊 timeout。
+- 真机验收只创建本轮命名的临时二进制、数据目录、plist/unit 和端口；结束时无论成功失败都执行 stop/uninstall 与残留检查。
+- 用户已授权停止的旧 `/tmp/agentred-pr20 run` 保持停止；本轮不得删除其二进制或数据，除非用户另行授权。
+
+## Out of scope
+
+- Windows named pipe、计划任务和 PowerShell installer 的新增修复；现有单元测试与交叉构建不得回归。
+- 账号服务器登录、版本登记与旧 daemon 兼容性的新增实现。
+- Remote Devices 初始加载错误 UI 的新注入接口或行为变更。
+- Relay/TLS/provider/account 功能扩展。
+- 恢复已在先前验收中被覆盖且无法取回的旧 `agentre-daemon-token-1`；该真实设备只能通过新配对码重新配对。
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| launchd manager unit tests | loaded/unloaded 分支；start/restart 不再无条件 bootout；running 与 missing/permission failure 分类；有界轮询的成功、timeout、context cancel | `cmd/agentred/service_launchd_test.go` |
+| service command tests | install --start、start、restart 只在本地状态可读后成功；失败输出稳定且非零；Linux/macOS 共用就绪边界不改变首行 | `cmd/agentred/service_test.go` |
+| bootstrap/e2e keychain tests | 设置 e2e dir 时，keychain 在 Remote Device 装配前确定；Add 与 watcher 读写同一 file backend；初始化失败不回退 system keychain | `e2e/fakes/keychain_test.go`、`internal/bootstrap/*_test.go` |
+| focused Go tests + full suite | launchd/systemd/service/bootstrap 回归；Windows 构建不回归；`GOWORK=off make check` 全绿 | 现有 Makefile 与 package tests |
+| 真实 macOS 运行 | reviewed HEAD 构建在隔离目录完成前台配置 → install --start → status → restart → stop → start → uninstall；每步记录退出码、PID/socket/端口/plist，且最终无残留 | `docs/verification.md` |
+| 真实 Linux 运行 | 通过 `opsctl local-coding` 在 Debian 12 amd64 完成同一生命周期，检查 systemd user unit、linger、状态、监听地址和清理 | `docs/verification.md` |
+| 真实生产 Wails → Linux daemon | 非 mock pairing code、Wails Add、隔离 keychain、watcher `1 paired · 1 online`、Agent Backends 跳转；运行前后证明 system keychain 未改变 | `e2e/README.md` scratch harness conventions |
+
+自动测试不能替代两台真实设备的生命周期观察。交付验收必须同时满足：macOS 生命周期 holds、Linux 生命周期 holds、生产 Wails 到 Linux daemon 配对后 watcher online、system keychain 无新增/修改/删除、所有本轮服务/进程/端口/临时目录均已清理。任一项失败则 verification 保持 reported/does not hold，不得自动接受。
+
+## Open questions
+
+（空）

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,6 +48,7 @@ Playwright drives its **own** chromium against `:34216`. The native webview wind
 | Env | Effect |
 |---|---|
 | `AGENTRE_DATA_DIR=<tmp>/agentre-e2e-data` | DB / config / logs under a throwaway dir — the highest-precedence data-root override (`internal/pkg/paths/paths.go`), so it never collides with your real DB or the `make dev` root |
+| `AGENTRE_E2E_KEYCHAIN_DIR=<tmp>/agentre-e2e-keychain` | device tokens, fingerprint, and e2e login secrets use an isolated 0700 file-keychain directory instead of the production system keychain; bootstrap rejects a missing or unsafe directory |
 | `AGENTRE_ENV=test` | quiet logger level (`internal/bootstrap/cago.go` `appEnv()`) |
 | `AGENTRE_PROXY_PORT=0` | bind the local HTTP gateway to an OS-chosen **free** port instead of the fixed default 52401 (`internal/bootstrap/cago.go` `loadProxyAddr` → `proxyPortFromEnv`). The fixed port is **not** data-dir-scoped, so a running real Agentre already holds 52401; without this override the e2e gateway fails to bind → `BaseURL()` is empty → every gateway round-trip (MCP tool calls, hooks, LLM forward) silently dies. `BaseURL()` reports the real bound port via the listener, so nothing hardcodes 52401 |
 
@@ -85,6 +86,10 @@ A run is fully hermetic, and in particular **a running Agentre does not interfer
 - **Data** — DB / config / logs live under `<tmp>/agentre-e2e-data` (`agentre.db`), removed by
   `run-e2e.mjs` after a **passing** run (kept on failure for debugging — see §7). Your real
   `~/Library/Application Support/agentre` is never touched.
+- **Keychain** — device tokens, fingerprint, and seeded login credentials live under the 0700
+  `<tmp>/agentre-e2e-keychain` file backend. The runner removes it after a passing run and keeps
+  it with other evidence on failure; the e2e process never reads, writes, or deletes production
+  system-keychain entries.
 - **Single-instance lock** — set only when `!isWailsDevMode()` (`main.go`); e2e runs via
   `wails dev` (sets the `devserver` env → dev mode), so the lock is **already skipped**, and its
   id is data-dir-scoped (`singleInstanceUniqueID(dataDir)`) regardless. So an e2e run launches
@@ -133,8 +138,10 @@ Do not hand-start a reusable Wails server against the fixed e2e data directory *
 # 1. start the app once, leave it running (any terminal) — the env overrides are mandatory: they
 #    point the app at the e2e temp data dir (the same ones playwright.config.ts injects), so the
 #    server never touches your real ~/Library/Application Support/agentre:
-mkdir -p "$TMPDIR/agentre-e2e-data"
-AGENTRE_DATA_DIR="$TMPDIR/agentre-e2e-data" AGENTRE_ENV=test AGENTRE_PROXY_PORT=0 \
+mkdir -p "$TMPDIR/agentre-e2e-data" "$TMPDIR/agentre-e2e-keychain"
+chmod 700 "$TMPDIR/agentre-e2e-keychain"
+AGENTRE_DATA_DIR="$TMPDIR/agentre-e2e-data" AGENTRE_ENV=test \
+  AGENTRE_E2E_KEYCHAIN_DIR="$TMPDIR/agentre-e2e-keychain" AGENTRE_PROXY_PORT=0 \
   wails dev -tags e2e -devserver localhost:34216 > "$TMPDIR/agentre-e2e-webserver.log" 2>&1
 # 2. iterate: each run reuses the running app — no rebuild, no data-dir wipe, ~5 s
 cd e2e && AGENTRE_E2E_REUSE=1 pnpm run test:scratch "scratch/<task>/"

--- a/e2e/fakes/install.go
+++ b/e2e/fakes/install.go
@@ -7,8 +7,6 @@ package fakes
 
 import (
 	"context"
-	"os"
-	"strings"
 
 	"github.com/cago-frame/cago/pkg/logger"
 	"go.uber.org/zap"
@@ -18,23 +16,12 @@ import (
 	fakert "github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/fake"
 	"github.com/agentre-ai/agentre/internal/pkg/agentskill"
 	"github.com/agentre-ai/agentre/internal/pkg/agenttool"
-	"github.com/agentre-ai/agentre/internal/pkg/keychain"
 	"github.com/agentre-ai/agentre/internal/repository/agent_backend_repo"
 	"github.com/agentre-ai/agentre/internal/repository/agent_repo"
 	"github.com/agentre-ai/agentre/internal/service/agent_backend_svc"
 	"github.com/agentre-ai/agentre/internal/service/agent_svc"
 	"github.com/agentre-ai/agentre/internal/service/department_svc"
 )
-
-const e2eKeychainDirEnv = "AGENTRE_E2E_KEYCHAIN_DIR"
-
-func installE2EKeychainOverride() {
-	dir := strings.TrimSpace(os.Getenv(e2eKeychainDirEnv))
-	if dir == "" {
-		return
-	}
-	keychain.SetDefault(keychain.NewFile(dir))
-}
 
 type codexSkillDiscoverer struct{}
 
@@ -79,9 +66,11 @@ func (claudeSkillDiscoverer) Discover(context.Context, agentskill.DiscoverQuery)
 //  2. seed 一个本地 claudecode backend 并挂到默认 CEO agent,
 //     让前端"建会话→发消息→看回复"无需真实 CLI 即可跑通。
 //
+// e2e 的隔离 keychain 由 bootstrap(initKeychain,见 internal/bootstrap/
+// keychain_e2e.go)在装配 Server / Remote Device 之前建立,这里不再覆盖。
+//
 // 失败只记日志不 panic:e2e 环境异常应让 Playwright 用例红,而不是让 app 崩。
 func Install(ctx context.Context) {
-	installE2EKeychainOverride()
 	// 先接账号:随后 seed 出来的 backend / agent 才会带着账号进出站队列(R3)。
 	installE2ELoggedInAccount(ctx)
 	agentruntime.RegisterRuntime(agent_backend_entity.TypeClaudeCode, fakert.New())
@@ -214,7 +203,6 @@ func Install(ctx context.Context) {
 // RunParams 里的 backend.type 走 agentruntime.RuntimeFor,这里只注册就够。失败只
 // 记日志不 panic —— e2e 环境异常应让 Playwright 用例红,而不是让 daemon 崩。
 func InstallAgentred(ctx context.Context) {
-	installE2EKeychainOverride()
 	agentruntime.RegisterRuntime(agent_backend_entity.TypeClaudeCode, fakert.New())
 	agentskill.RegisterDiscoverer(agent_backend_entity.TypeClaudeCode, claudeSkillDiscoverer{})
 	logger.Ctx(ctx).Info("e2efakes.InstallAgentred: e2e fake runtime installed for agentred")

--- a/e2e/fakes/keychain_test.go
+++ b/e2e/fakes/keychain_test.go
@@ -3,39 +3,62 @@
 package fakes
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/agentre-ai/agentre/internal/bootstrap"
 	"github.com/agentre-ai/agentre/internal/pkg/keychain"
 )
 
-func TestGivenE2EKeychainDirWhenInstallingOverrideThenSecretsStayInThatDirectory(t *testing.T) {
-	dir := t.TempDir()
-	original := keychain.Default()
-	t.Cleanup(func() { keychain.SetDefault(original) })
-	keychain.SetDefault(keychain.NewMemory())
-	t.Setenv(e2eKeychainDirEnv, dir)
+// e2e keychain 边界(docs/specs/2026-08-12-agentred-service-runtime-fixes.md「E2E
+// keychain 初始化与安全边界」):AGENTRE_E2E_KEYCHAIN_DIR 必须在 bootstrap 装配 Server /
+// Remote Device 之前生效,让 Server Add、ConnPool、watcher 与 e2e seeding 共享同一个
+// file backend;失败则启动直接终止,绝不回退生产 system keychain。keychain 的选择在
+// bootstrap(internal/bootstrap/keychain_e2e.go)完成,这里验证它与 fakes 装配的整合。
 
-	installE2EKeychainOverride()
+func TestGivenE2EKeychainDirWhenBootstrapInitThenSeedingSharesFileBackend(t *testing.T) {
+	dataDir := t.TempDir()
+	// e2e runner 以 0700 预创建隔离目录;测试同样显式建 0700(本机 t.TempDir() 是 0755)。
+	keychainDir := filepath.Join(t.TempDir(), "kc")
+	require.NoError(t, os.MkdirAll(keychainDir, 0o700))
+	t.Setenv("AGENTRE_DATA_DIR", dataDir)
+	t.Setenv("AGENTRE_ENV", "test")
+	t.Setenv(bootstrap.E2EKeychainDirEnv, keychainDir)
 
+	runtime, err := bootstrap.Init(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(runtime.Close)
+
+	// bootstrap.Init 在 InitServer / InitRemoteDevice 之前就选中 file backend:
+	// Add / ConnPool / watcher 构造时捕获的就是它。先做类型断言再 probe,避免后端
+	// 仍是系统 keychain 时误写生产凭据。
+	require.Equal(t, reflect.TypeOf(keychain.NewFile(keychainDir)), reflect.TypeOf(keychain.Default()))
+
+	// fakes 装配(e2e login seed / backend 播种)读到的必须是同一个 file backend:
+	// probe 写入落在隔离目录,而不是生产 system keychain。
+	Install(context.Background())
+	require.Equal(t, reflect.TypeOf(keychain.NewFile(keychainDir)), reflect.TypeOf(keychain.Default()))
 	require.NoError(t, keychain.Default().Set("probe-account", "generated-test-value"))
-	got, err := os.ReadFile(filepath.Join(dir, "probe-account"))
+	got, err := os.ReadFile(filepath.Join(keychainDir, "probe-account"))
 	require.NoError(t, err)
 	assert.Equal(t, "generated-test-value", string(got))
 }
 
-func TestGivenNoE2EKeychainDirWhenInstallingOverrideThenExistingStoreIsPreserved(t *testing.T) {
-	original := keychain.Default()
-	t.Cleanup(func() { keychain.SetDefault(original) })
-	existing := keychain.NewMemory()
-	keychain.SetDefault(existing)
-	t.Setenv(e2eKeychainDirEnv, "")
+func TestGivenE2EKeychainDirUnusableWhenBootstrapInitThenStartupFails(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTRE_DATA_DIR", dataDir)
+	t.Setenv("AGENTRE_ENV", "test")
+	// 目录缺失(e2e runner 预创建 0700 目录才启动;缺失 = 配置错),启动必须失败,
+	// 不得静默回退系统 keychain。
+	t.Setenv(bootstrap.E2EKeychainDirEnv, filepath.Join(t.TempDir(), "does-not-exist"))
 
-	installE2EKeychainOverride()
-
-	assert.Same(t, existing, keychain.Default())
+	_, err := bootstrap.Init(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "e2e keychain")
 }

--- a/e2e/keychain_harness_test.go
+++ b/e2e/keychain_harness_test.go
@@ -1,0 +1,42 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGivenCoreE2EHarnessWhenLaunchingAppThenItProvidesAnIsolatedKeychainDir(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	e2eDir := filepath.Dir(filename)
+	config, err := os.ReadFile(filepath.Join(e2eDir, "playwright.config.ts")) //nolint:gosec // G304: directory comes from this test file; filename is fixed.
+	require.NoError(t, err)
+	source := string(config)
+
+	assert.Contains(t, source, `const keychainDir = join(tmpdir(), "agentre-e2e-keychain");`)
+	assert.Contains(t, source, "mkdirSync(keychainDir, { recursive: true, mode: 0o700 });")
+	assert.Contains(t, source, "AGENTRE_E2E_KEYCHAIN_DIR: keychainDir")
+
+	readme, err := os.ReadFile(filepath.Join(e2eDir, "README.md")) //nolint:gosec // G304: directory comes from this test file; filename is fixed.
+	require.NoError(t, err)
+	assert.Contains(t, string(readme), `AGENTRE_E2E_KEYCHAIN_DIR="$TMPDIR/agentre-e2e-keychain"`)
+}
+
+func TestGivenReusableE2EHarnessWhenPrintingStartupInstructionsThenItRequiresTheSameKeychainOverride(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	runner, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "run-e2e.mjs"))
+	require.NoError(t, err)
+	source := string(runner)
+
+	assert.True(t, strings.Contains(source, "AGENTRE_E2E_KEYCHAIN_DIR=\"${keychainDir}\""),
+		"reuse instructions must not start an e2e app without the isolated keychain override")
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 // per process — the db-oracle worker would then read a file the app (launched by the main
 // process) never wrote.
 const dataDir = join(tmpdir(), "agentre-e2e-data");
+const keychainDir = join(tmpdir(), "agentre-e2e-keychain");
 
 // Keep-alive (fast inner loop) mode: AGENTRE_E2E_REUSE=1 — reuse a hand-started
 // `wails dev -tags e2e` on :34216 and keep the temp data dir that app owns (no wipe, no rebuild,
@@ -23,6 +24,8 @@ const reuseExisting = process.env.AGENTRE_E2E_REUSE === "1";
 if (process.env.TEST_WORKER_INDEX === undefined && !reuseExisting) {
   rmSync(dataDir, { recursive: true, force: true });
   mkdirSync(dataDir, { recursive: true });
+  rmSync(keychainDir, { recursive: true, force: true });
+  mkdirSync(keychainDir, { recursive: true, mode: 0o700 });
 }
 // `wails dev` needs frontend/dist to exist for the //go:embed (mirrors `make dev`). Done here
 // in Node — not via shell `mkdir -p`/`touch` — so the webServer command stays shell-agnostic
@@ -33,6 +36,7 @@ writeFileSync(join(distDir, ".keep"), "");
 
 process.env.AGENTRE_DATA_DIR = dataDir;
 process.env.AGENTRE_ENV = "test";
+process.env.AGENTRE_E2E_KEYCHAIN_DIR = keychainDir;
 
 // Dedicated wails dev server port for e2e (avoids the default 34115 → no collision/false-green
 // against a real `make dev`).
@@ -79,6 +83,7 @@ export default defineConfig({
     env: {
       AGENTRE_DATA_DIR: dataDir,
       AGENTRE_ENV: "test",
+      AGENTRE_E2E_KEYCHAIN_DIR: keychainDir,
       // Bind the local HTTP gateway to an OS-chosen free port (0) instead of the fixed default
       // 52401. A running real Agentre already holds 52401, so without this the e2e gateway fails
       // to bind → BaseURL() empty → group_send (and any gateway round-trip) silently dies. Keeps

--- a/e2e/run-e2e.mjs
+++ b/e2e/run-e2e.mjs
@@ -18,6 +18,7 @@ const here = dirname(fileURLToPath(import.meta.url)); // e2e/
 const repoRoot = join(here, "..");
 // These must match the paths in playwright.config.ts.
 const dataDir = join(tmpdir(), "agentre-e2e-data");
+const keychainDir = join(tmpdir(), "agentre-e2e-keychain");
 const webserverLog = join(tmpdir(), "agentre-e2e-webserver.log");
 const DEVSERVER_PORT = 34216;
 
@@ -60,8 +61,8 @@ async function main() {
             ? `nothing is listening on :${DEVSERVER_PORT}.`
             : `:${DEVSERVER_PORT} is up but '${dbPath}' is missing — the running server is not using the e2e data dir.`) +
           "\nStart it once with the same overrides the harness injects, then iterate:\n" +
-          `  mkdir -p "${dataDir}"\n` +
-          `  AGENTRE_DATA_DIR="${dataDir}" AGENTRE_ENV=test AGENTRE_PROXY_PORT=0 \\` +
+          `  mkdir -p "${dataDir}" "${keychainDir}" && chmod 700 "${keychainDir}"\n` +
+          `  AGENTRE_DATA_DIR="${dataDir}" AGENTRE_ENV=test AGENTRE_E2E_KEYCHAIN_DIR="${keychainDir}" AGENTRE_PROXY_PORT=0 \\` +
           `    wails dev -tags e2e -devserver localhost:${DEVSERVER_PORT} > "${webserverLog}" 2>&1 &\n` +
           "Runs without AGENTRE_E2E_REUSE keep starting (and tearing down) their own fresh server.",
       );
@@ -91,6 +92,7 @@ function cleanup(passed) {
   reapOrphanVite();
   if (passed) {
     rmSync(dataDir, { recursive: true, force: true });
+    rmSync(keychainDir, { recursive: true, force: true });
     rmSync(webserverLog, { force: true });
   }
 }

--- a/frontend/src/components/agentre/remote-devices/add-device-dialog.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/add-device-dialog.test.tsx
@@ -1,12 +1,36 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
+const { copyTextWithToast } = vi.hoisted(() => ({
+  copyTextWithToast: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/clipboard-toast", () => ({
+  copyTextWithToast,
+}));
+
 // Stub out use-remote-devices so the wailsjs transitive import is avoided.
 vi.mock("./use-remote-devices", () => ({}));
 
 import { AddDeviceDialog } from "./add-device-dialog";
 
 describe("AddDeviceDialog", () => {
+  it("copies the pairing command from the existing add-device flow", () => {
+    render(
+      <AddDeviceDialog open onClose={() => {}} onSubmit={async () => {}} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy agentred pair" }));
+
+    expect(copyTextWithToast).toHaveBeenCalledWith("agentred pair", {
+      successTitle: "Command copied",
+    });
+    expect(screen.getByText("agentred pair")).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
+  });
+
   it("配对 button stays disabled until URL + code are valid", () => {
     render(
       <AddDeviceDialog open onClose={() => {}} onSubmit={async () => {}} />,

--- a/frontend/src/components/agentre/remote-devices/add-device-dialog.tsx
+++ b/frontend/src/components/agentre/remote-devices/add-device-dialog.tsx
@@ -1,6 +1,8 @@
+import { Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
+import { copyTextWithToast } from "@/lib/clipboard-toast";
 
 import { AgentreDialog } from "../app-dialog";
 import {
@@ -19,6 +21,7 @@ type Props = {
 export function AddDeviceDialog({ open, onClose, onSubmit }: Props) {
   const { t } = useTranslation();
   const pairing = useDevicePairingForm({ onSubmit });
+  const pairCommand = t("remoteDevices.onboarding.commands.pair");
 
   const handleClose = () => {
     if (pairing.submitting) return;
@@ -57,12 +60,31 @@ export function AddDeviceDialog({ open, onClose, onSubmit }: Props) {
         </>
       }
     >
-      <div className="rounded-md bg-secondary/50 px-3 py-2 text-xs text-muted-foreground">
-        {t("remoteDevices.add.instructions.prefix")}{" "}
-        <code data-selectable-text="true" className="select-text">
-          {t("remoteDevices.onboarding.commands.pair")}
-        </code>
-        {t("remoteDevices.add.instructions.suffix")}
+      <div className="flex items-center justify-between gap-3 rounded-md bg-secondary/50 px-3 py-2 text-xs text-muted-foreground">
+        <span>
+          {t("remoteDevices.add.instructions.prefix")}{" "}
+          <code data-selectable-text="true" className="select-text">
+            {pairCommand}
+          </code>
+          {t("remoteDevices.add.instructions.suffix")}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="shrink-0"
+          aria-label={t("remoteDevices.onboarding.copyLabel", {
+            label: pairCommand,
+          })}
+          onClick={() => {
+            void copyTextWithToast(pairCommand, {
+              successTitle: t("remoteDevices.onboarding.copySuccess"),
+            });
+          }}
+        >
+          <Copy data-icon="inline-start" aria-hidden="true" />
+          {t("common.copy")}
+        </Button>
       </div>
 
       <DevicePairingFields pairing={pairing} />

--- a/frontend/src/components/agentre/remote-devices/add-device-dialog.tsx
+++ b/frontend/src/components/agentre/remote-devices/add-device-dialog.tsx
@@ -1,28 +1,14 @@
-import { useState } from "react";
-import { ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 
 import { AgentreDialog } from "../app-dialog";
-import { TLSTrustDialog } from "./tls-trust-dialog";
-import { deriveDeviceName } from "./format";
-
-// Local type — mirrors remote_device_svc.AddRequest; avoids transitive wailsjs import.
-type AddRequest = {
-  url: string;
-  pairingCode: string;
-  displayName?: string;
-  tlsMode: string;
-  tlsCertPEM?: string;
-};
-
-const URL_RE = /^wss?:\/\/[^/]+\/rpc$/;
-
-function limitCode(raw: string): string {
-  return raw.toUpperCase().slice(0, 6);
-}
+import {
+  DevicePairingFields,
+  PairingSubmitButton,
+  type AddRequest,
+  useDevicePairingForm,
+} from "./device-pairing-form";
 
 type Props = {
   open: boolean;
@@ -32,170 +18,54 @@ type Props = {
 
 export function AddDeviceDialog({ open, onClose, onSubmit }: Props) {
   const { t } = useTranslation();
-  const [url, setUrl] = useState("");
-  const [code, setCode] = useState("");
-  const [name, setName] = useState("");
-  const [tlsMode, setTlsMode] = useState("default");
-  const [tlsCertPEM, setTlsCertPEM] = useState("");
-  const [tlsOpen, setTlsOpen] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const pairing = useDevicePairingForm({ onSubmit });
 
-  const urlValid = URL_RE.test(url);
-  const codeValid = code.trim().length === 6;
-  const canSubmit = urlValid && codeValid && !submitting;
-
-  const reset = () => {
-    setUrl("");
-    setCode("");
-    setName("");
-    setTlsMode("default");
-    setTlsCertPEM("");
-    setError(null);
-    setSubmitting(false);
-  };
   const handleClose = () => {
-    if (submitting) return;
-    reset();
+    if (pairing.submitting) return;
+    pairing.reset();
     onClose();
   };
 
-  const submit = async () => {
-    setError(null);
-    setSubmitting(true);
-    try {
-      const effectiveName = name.trim() || deriveDeviceName(url, []);
-      await onSubmit({
-        url: url,
-        pairingCode: code.trim(),
-        displayName: effectiveName,
-        tlsMode: tlsMode,
-        tlsCertPEM: tlsCertPEM,
-      });
-      reset();
-    } catch (e: unknown) {
-      const msg =
-        typeof e === "string"
-          ? e
-          : e instanceof Error
-            ? e.message
-            : t("remoteDevices.add.errors.pairFailed");
-      setError(msg);
-      setSubmitting(false);
-    }
-  };
-
   return (
-    <>
-      <AgentreDialog
-        open={open}
-        onOpenChange={(o) => {
-          if (!o) handleClose();
-        }}
-        title={t("remoteDevices.add.title")}
-        description={t("remoteDevices.add.description")}
-        contentClassName="sm:max-w-[540px]"
-        bodyClassName="flex flex-col gap-3.5"
-        footer={
-          <>
-            <Button variant="ghost" onClick={handleClose} disabled={submitting}>
-              {t("common.cancel")}
-            </Button>
-            <Button onClick={submit} disabled={!canSubmit}>
-              {submitting
-                ? t("remoteDevices.add.pairing")
-                : t("remoteDevices.add.pair")}
-            </Button>
-          </>
-        }
-      >
-        <div className="rounded-md bg-secondary/50 px-3 py-2 text-xs text-muted-foreground">
-          {t("remoteDevices.add.instructions.prefix")}{" "}
-          <code>agentred pair</code>
-          {t("remoteDevices.add.instructions.suffix")}
-        </div>
-
-        <label className="flex flex-col gap-1.5">
-          <span className="text-sm font-medium">
-            {t("remoteDevices.add.fields.url")}
-          </span>
-          <Input
-            value={url}
-            onChange={(e) => setUrl(e.target.value.trim())}
-            placeholder="ws://192.168.1.100:7456/rpc"
-            disabled={submitting}
-            aria-invalid={url.length > 0 && !urlValid}
+    <AgentreDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) handleClose();
+      }}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void pairing.submit();
+      }}
+      title={t("remoteDevices.add.title")}
+      description={t("remoteDevices.add.description")}
+      contentClassName="sm:max-w-[540px]"
+      bodyClassName="flex flex-col gap-3.5"
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleClose}
+            disabled={pairing.submitting}
+          >
+            {t("common.cancel")}
+          </Button>
+          <PairingSubmitButton
+            canSubmit={pairing.canSubmit}
+            submitting={pairing.submitting}
           />
-          {url.length > 0 && !urlValid ? (
-            <span className="text-xs text-destructive">
-              {t("remoteDevices.add.fields.urlInvalid")}
-            </span>
-          ) : null}
-        </label>
+        </>
+      }
+    >
+      <div className="rounded-md bg-secondary/50 px-3 py-2 text-xs text-muted-foreground">
+        {t("remoteDevices.add.instructions.prefix")}{" "}
+        <code data-selectable-text="true" className="select-text">
+          {t("remoteDevices.onboarding.commands.pair")}
+        </code>
+        {t("remoteDevices.add.instructions.suffix")}
+      </div>
 
-        <label className="flex flex-col gap-1.5">
-          <span className="text-sm font-medium">
-            {t("remoteDevices.add.fields.pairingCode")}
-          </span>
-          <Input
-            value={code}
-            onChange={(e) => setCode(limitCode(e.target.value))}
-            placeholder="ABC2DE"
-            maxLength={6}
-            disabled={submitting}
-            className="font-mono tracking-widest text-center text-lg"
-          />
-          <span className="text-xs text-muted-foreground">
-            {t("remoteDevices.add.fields.pairingCodeHint")}
-          </span>
-          {code.length > 0 && codeValid === false ? (
-            <span className="text-xs text-destructive">
-              {t("remoteDevices.add.fields.codeInvalid")}
-            </span>
-          ) : null}
-        </label>
-
-        <label className="flex flex-col gap-1.5">
-          <span className="text-sm font-medium">
-            {t("remoteDevices.add.fields.displayName")}
-          </span>
-          <Input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder={t("remoteDevices.add.fields.displayNamePlaceholder")}
-            disabled={submitting}
-          />
-        </label>
-
-        <button
-          type="button"
-          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground self-start"
-          onClick={() => setTlsOpen(true)}
-          disabled={submitting}
-        >
-          <ChevronRight className="h-4 w-4" />
-          {t("remoteDevices.add.advancedTls", {
-            mode:
-              tlsMode === "default"
-                ? t("remoteDevices.tls.modes.default.label")
-                : tlsMode,
-          })}
-        </button>
-
-        {error ? <div className="text-sm text-destructive">{error}</div> : null}
-      </AgentreDialog>
-
-      <TLSTrustDialog
-        open={tlsOpen}
-        initialMode={tlsMode}
-        initialPEM={tlsCertPEM}
-        onClose={() => setTlsOpen(false)}
-        onApply={(mode, pem) => {
-          setTlsMode(mode);
-          setTlsCertPEM(pem);
-          setTlsOpen(false);
-        }}
-      />
-    </>
+      <DevicePairingFields pairing={pairing} />
+    </AgentreDialog>
   );
 }

--- a/frontend/src/components/agentre/remote-devices/agentred-onboarding.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/agentred-onboarding.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentredOnboarding } from "./agentred-onboarding";
+
+describe("AgentredOnboarding", () => {
+  it("moves through install, background service, and shared pairing form actions", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<AgentredOnboarding onSubmit={onSubmit} />);
+
+    expect(
+      screen.getByRole("link", { name: "Manual installation" }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/agentre-ai/agentre/releases/latest",
+    );
+    await user.click(screen.getByRole("button", { name: "Installed, next" }));
+
+    expect(
+      screen
+        .getAllByText("agentred service status")
+        .every((element) => element.dataset.selectableText === "true"),
+    ).toBe(true);
+    expect(screen.getByText("agentred service restart")).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
+    expect(screen.getByText(/ws:\/\/…:7456\/rpc/)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Service is running" }),
+    );
+    await user.type(screen.getByLabelText("Address"), "ws://host:7456/rpc");
+    await user.type(screen.getByLabelText("Pairing Code"), "ABC2DE");
+    await user.click(screen.getByRole("button", { name: "Pair and verify" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://host:7456/rpc",
+        pairingCode: "ABC2DE",
+      }),
+    );
+  });
+});

--- a/frontend/src/components/agentre/remote-devices/agentred-onboarding.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/agentred-onboarding.test.tsx
@@ -16,6 +16,10 @@ describe("AgentredOnboarding", () => {
       "href",
       "https://github.com/agentre-ai/agentre/releases/latest",
     );
+    expect(screen.getByText("agentred --version")).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
     await user.click(screen.getByRole("button", { name: "Installed, next" }));
 
     expect(

--- a/frontend/src/components/agentre/remote-devices/agentred-onboarding.tsx
+++ b/frontend/src/components/agentre/remote-devices/agentred-onboarding.tsx
@@ -1,0 +1,394 @@
+import { useState, type ReactNode } from "react";
+import { ArrowRight, Check } from "lucide-react";
+import { Trans, useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+
+import { CommandCard } from "./command-card";
+import { DevicePairingForm, type AddRequest } from "./device-pairing-form";
+
+type RemoteOS = "linux" | "macos" | "windows";
+type RunMode = "background" | "foreground";
+type OnboardingStep = 1 | 2 | 3;
+
+type AgentredOnboardingProps = {
+  onSubmit: (request: AddRequest) => Promise<void>;
+};
+
+const MANUAL_INSTALL_URL =
+  "https://github.com/agentre-ai/agentre/releases/latest";
+
+export function AgentredOnboarding({ onSubmit }: AgentredOnboardingProps) {
+  const { t } = useTranslation();
+  const [step, setStep] = useState<OnboardingStep>(1);
+  const [remoteOS, setRemoteOS] = useState<RemoteOS>("linux");
+  const [runMode, setRunMode] = useState<RunMode>("background");
+
+  const commands = {
+    daemonRunning: t("remoteDevices.onboarding.commands.daemonRunning"),
+    foregroundRun: t("remoteDevices.onboarding.commands.foregroundRun"),
+    installUnix: t("remoteDevices.onboarding.commands.installUnix"),
+    installWindows: t("remoteDevices.onboarding.commands.installWindows"),
+    listenAddress: t("remoteDevices.onboarding.commands.listenAddress"),
+    pair: t("remoteDevices.onboarding.commands.pair"),
+    serviceInstall: t("remoteDevices.onboarding.commands.serviceInstall"),
+    serviceRestart: t("remoteDevices.onboarding.commands.serviceRestart"),
+    serviceStatus: t("remoteDevices.onboarding.commands.serviceStatus"),
+  };
+  const installCommand =
+    remoteOS === "windows" ? commands.installWindows : commands.installUnix;
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-card">
+      <ol className="grid grid-cols-1 border-b border-border bg-muted/50 sm:grid-cols-3">
+        <StepHeader
+          number={1}
+          activeStep={step}
+          title={t("remoteDevices.onboarding.steps.install.title")}
+          subtitle={
+            step > 1
+              ? t("remoteDevices.onboarding.steps.install.done")
+              : t("remoteDevices.onboarding.steps.install.subtitle")
+          }
+        />
+        <StepHeader
+          number={2}
+          activeStep={step}
+          title={t("remoteDevices.onboarding.steps.service.title")}
+          subtitle={
+            step > 2
+              ? t("remoteDevices.onboarding.steps.service.done")
+              : t("remoteDevices.onboarding.steps.service.subtitle")
+          }
+        />
+        <StepHeader
+          number={3}
+          activeStep={step}
+          title={t("remoteDevices.onboarding.steps.pair.title")}
+          subtitle={t("remoteDevices.onboarding.steps.pair.subtitle")}
+        />
+      </ol>
+
+      <div className="flex flex-col gap-5 p-4 sm:p-6">
+        <div className="flex flex-col gap-2">
+          <p className="font-mono text-2xs font-semibold uppercase tracking-[0.1em] text-primary-text">
+            {t("remoteDevices.onboarding.stepLabel", {
+              current: step,
+              total: 3,
+            })}
+          </p>
+          {step === 1 ? (
+            <>
+              <h2 className="text-lg font-semibold">
+                {t("remoteDevices.onboarding.install.title")}
+              </h2>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("remoteDevices.onboarding.install.description")}
+              </p>
+            </>
+          ) : step === 2 ? (
+            <>
+              <h2 className="text-lg font-semibold">
+                {t("remoteDevices.onboarding.service.title")}
+              </h2>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("remoteDevices.onboarding.service.description")}
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="text-lg font-semibold">
+                {t("remoteDevices.onboarding.pair.title")}
+              </h2>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("remoteDevices.onboarding.pair.description")}
+              </p>
+            </>
+          )}
+        </div>
+
+        {step === 1 ? (
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-sm font-medium">
+                  {t("remoteDevices.onboarding.install.osLabel")}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {t("remoteDevices.onboarding.install.archHint")}
+                </span>
+              </div>
+              <ToggleGroup
+                type="single"
+                value={remoteOS}
+                variant="outline"
+                spacing={1}
+                aria-label={t("remoteDevices.onboarding.install.osLabel")}
+                onValueChange={(value) => {
+                  if (value) setRemoteOS(value as RemoteOS);
+                }}
+              >
+                <ToggleGroupItem
+                  value="linux"
+                  aria-label={t("remoteDevices.onboarding.install.linux")}
+                >
+                  {t("remoteDevices.onboarding.install.linux")}
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="macos"
+                  aria-label={t("remoteDevices.onboarding.install.macos")}
+                >
+                  {t("remoteDevices.onboarding.install.macos")}
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="windows"
+                  aria-label={t("remoteDevices.onboarding.install.windows")}
+                >
+                  {t("remoteDevices.onboarding.install.windows")}
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold">
+                {t("remoteDevices.onboarding.install.recommended")}
+              </h3>
+              <CommandCard
+                label={
+                  remoteOS === "windows"
+                    ? t("remoteDevices.onboarding.install.powershell")
+                    : t("remoteDevices.onboarding.install.terminal")
+                }
+                command={installCommand}
+              />
+            </div>
+
+            <Separator />
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <Button variant="link" size="sm" asChild>
+                <a href={MANUAL_INSTALL_URL} target="_blank" rel="noreferrer">
+                  {t("remoteDevices.onboarding.install.manual")}
+                </a>
+              </Button>
+              <Button type="button" onClick={() => setStep(2)}>
+                {t("remoteDevices.onboarding.install.next")}
+                <ArrowRight data-icon="inline-end" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {step === 2 ? (
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-sm font-medium">
+                  {t("remoteDevices.onboarding.service.modeLabel")}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {t("remoteDevices.onboarding.service.modeHint")}
+                </span>
+              </div>
+              <ToggleGroup
+                type="single"
+                value={runMode}
+                variant="outline"
+                spacing={1}
+                aria-label={t("remoteDevices.onboarding.service.modeLabel")}
+                onValueChange={(value) => {
+                  if (value) setRunMode(value as RunMode);
+                }}
+              >
+                <ToggleGroupItem
+                  value="background"
+                  aria-label={t("remoteDevices.onboarding.service.background")}
+                >
+                  {t("remoteDevices.onboarding.service.background")}
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="foreground"
+                  aria-label={t("remoteDevices.onboarding.service.foreground")}
+                >
+                  {t("remoteDevices.onboarding.service.foreground")}
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            {runMode === "background" ? (
+              <div className="flex flex-col gap-4">
+                <CommandCard
+                  label={t("remoteDevices.onboarding.service.installLabel")}
+                  command={commands.serviceInstall}
+                />
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  <CommandCard
+                    label={t("remoteDevices.onboarding.service.statusLabel")}
+                    command={commands.serviceStatus}
+                  />
+                  <CommandCard
+                    label={t("remoteDevices.onboarding.service.restartLabel")}
+                    command={commands.serviceRestart}
+                  />
+                </div>
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold">
+                      {t("remoteDevices.onboarding.service.diagnosticsTitle")}
+                    </h3>
+                    <span className="text-xs text-muted-foreground">
+                      {t("remoteDevices.onboarding.service.diagnosticsHint")}
+                    </span>
+                  </div>
+                  <ol className="flex flex-col gap-2 text-xs leading-relaxed text-muted-foreground">
+                    <DiagnosticItem number={1}>
+                      <Trans
+                        i18nKey="remoteDevices.onboarding.service.diagnostics.first"
+                        values={{
+                          command: commands.serviceStatus,
+                          status: commands.daemonRunning,
+                        }}
+                        components={{
+                          command: (
+                            <code
+                              data-selectable-text="true"
+                              className="select-text font-mono text-foreground"
+                            />
+                          ),
+                          status: (
+                            <code
+                              data-selectable-text="true"
+                              className="select-text font-mono text-foreground"
+                            />
+                          ),
+                        }}
+                      />
+                    </DiagnosticItem>
+                    <DiagnosticItem number={2}>
+                      <Trans
+                        i18nKey="remoteDevices.onboarding.service.diagnostics.second"
+                        values={{ address: commands.listenAddress }}
+                        components={{
+                          address: (
+                            <code
+                              data-selectable-text="true"
+                              className="select-text font-mono text-foreground"
+                            />
+                          ),
+                        }}
+                      />
+                    </DiagnosticItem>
+                    <DiagnosticItem number={3}>
+                      {t("remoteDevices.onboarding.service.diagnostics.third")}
+                    </DiagnosticItem>
+                  </ol>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <CommandCard
+                  label={t("remoteDevices.onboarding.install.terminal")}
+                  command={commands.foregroundRun}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("remoteDevices.onboarding.service.foregroundDescription")}
+                </p>
+              </div>
+            )}
+
+            <Separator />
+            <div className="flex justify-end">
+              <Button type="button" onClick={() => setStep(3)}>
+                {t("remoteDevices.onboarding.service.next")}
+                <ArrowRight data-icon="inline-end" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {step === 3 ? (
+          <div className="flex flex-col gap-4">
+            <CommandCard
+              label={t("remoteDevices.onboarding.pair.commandLabel")}
+              command={commands.pair}
+            />
+            <div className="rounded-lg border border-border bg-muted/30 p-4">
+              <DevicePairingForm
+                actionsClassName="justify-between"
+                cancelLabel={t("remoteDevices.onboarding.pair.back")}
+                onCancel={() => setStep(2)}
+                onSubmit={onSubmit}
+                submitLabel={t("remoteDevices.onboarding.pair.submit")}
+              />
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function StepHeader({
+  activeStep,
+  number,
+  subtitle,
+  title,
+}: {
+  activeStep: OnboardingStep;
+  number: OnboardingStep;
+  subtitle: string;
+  title: string;
+}) {
+  const complete = number < activeStep;
+  const active = number === activeStep;
+
+  return (
+    <li
+      aria-current={active ? "step" : undefined}
+      className="flex min-w-0 items-start gap-3 border-b border-border p-4 last:border-b-0 sm:border-b-0 sm:border-r sm:last:border-r-0"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-full bg-muted font-mono text-2xs font-semibold text-muted-foreground",
+          active && "bg-primary text-primary-foreground",
+          complete && "bg-status-running-bg text-status-running",
+        )}
+      >
+        {complete ? (
+          <Check className="size-3" />
+        ) : (
+          String(number).padStart(2, "0")
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-xs font-semibold">{title}</span>
+        <span className="mt-0.5 block truncate text-2xs text-muted-foreground">
+          {subtitle}
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function DiagnosticItem({
+  children,
+  number,
+}: {
+  children: ReactNode;
+  number: number;
+}) {
+  return (
+    <li className="flex items-start gap-2">
+      <span
+        aria-hidden="true"
+        className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted font-mono text-2xs text-muted-foreground"
+      >
+        {number}
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}

--- a/frontend/src/components/agentre/remote-devices/agentred-onboarding.tsx
+++ b/frontend/src/components/agentre/remote-devices/agentred-onboarding.tsx
@@ -37,6 +37,7 @@ export function AgentredOnboarding({ onSubmit }: AgentredOnboardingProps) {
     serviceInstall: t("remoteDevices.onboarding.commands.serviceInstall"),
     serviceRestart: t("remoteDevices.onboarding.commands.serviceRestart"),
     serviceStatus: t("remoteDevices.onboarding.commands.serviceStatus"),
+    version: t("remoteDevices.onboarding.commands.version"),
   };
   const installCommand =
     remoteOS === "windows" ? commands.installWindows : commands.installUnix;
@@ -163,6 +164,10 @@ export function AgentredOnboarding({ onSubmit }: AgentredOnboardingProps) {
                     : t("remoteDevices.onboarding.install.terminal")
                 }
                 command={installCommand}
+              />
+              <CommandCard
+                label={t("remoteDevices.onboarding.install.verify")}
+                command={commands.version}
               />
             </div>
 

--- a/frontend/src/components/agentre/remote-devices/command-card.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/command-card.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { copyTextWithToast } = vi.hoisted(() => ({
+  copyTextWithToast: vi.fn(),
+}));
+
+vi.mock("@/lib/clipboard-toast", () => ({
+  copyTextWithToast,
+}));
+
+import en from "../../../i18n/locales/en/common.json";
+import zhCN from "../../../i18n/locales/zh-CN/common.json";
+import { CommandCard } from "./command-card";
+
+describe("CommandCard", () => {
+  beforeEach(() => {
+    copyTextWithToast.mockReset();
+    copyTextWithToast.mockResolvedValue(true);
+  });
+
+  it("renders selectable command text and copies the exact command through the shared toast helper", () => {
+    const command = "agentred service status";
+    render(<CommandCard command={command} label="Check status" />);
+
+    const region = screen.getByRole("group", { name: "Check status" });
+    expect(within(region).getByText(command)).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
+
+    fireEvent.click(
+      within(region).getByRole("button", { name: "Copy Check status" }),
+    );
+    expect(copyTextWithToast).toHaveBeenCalledWith(command, {
+      successTitle: "Command copied",
+    });
+  });
+
+  it("keeps every static onboarding command identical in both locales", () => {
+    expect(zhCN.remoteDevices.onboarding.commands).toEqual(
+      en.remoteDevices.onboarding.commands,
+    );
+  });
+});

--- a/frontend/src/components/agentre/remote-devices/command-card.tsx
+++ b/frontend/src/components/agentre/remote-devices/command-card.tsx
@@ -1,0 +1,46 @@
+import { Copy } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { copyTextWithToast } from "@/lib/clipboard-toast";
+
+type CommandCardProps = {
+  command: string;
+  label: string;
+};
+
+export function CommandCard({ command, label }: CommandCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="overflow-hidden rounded-lg border border-border bg-code-surface"
+    >
+      <div className="flex min-h-8 items-center justify-between gap-3 border-b border-border px-3 py-1 text-2xs text-code-muted-foreground">
+        <span>{label}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          aria-label={t("remoteDevices.onboarding.copyLabel", { label })}
+          onClick={() => {
+            void copyTextWithToast(command, {
+              successTitle: t("remoteDevices.onboarding.copySuccess"),
+            });
+          }}
+        >
+          <Copy data-icon="inline-start" aria-hidden="true" />
+          {t("common.copy")}
+        </Button>
+      </div>
+      <code
+        data-selectable-text="true"
+        className="block select-text whitespace-pre-wrap break-words px-3 py-3 font-mono text-xs leading-relaxed text-code-foreground"
+      >
+        {command}
+      </code>
+    </div>
+  );
+}

--- a/frontend/src/components/agentre/remote-devices/device-pairing-form.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/device-pairing-form.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DevicePairingForm } from "./device-pairing-form";
+
+function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
+  render(
+    <DevicePairingForm
+      cancelLabel="Back to service"
+      onCancel={() => {}}
+      onSubmit={onSubmit}
+      submitLabel="Pair and verify"
+    />,
+  );
+  return onSubmit;
+}
+
+describe("DevicePairingForm", () => {
+  it("reuses the existing URL, code, derived-name, and TLS request contract", async () => {
+    const user = userEvent.setup();
+    const onSubmit = renderForm();
+    const submit = screen.getByRole("button", { name: "Pair and verify" });
+
+    expect(submit).toBeDisabled();
+    await user.type(screen.getByLabelText("Address"), "ws://host:7456/rpc");
+    await user.type(screen.getByLabelText("Pairing Code"), "abc2def");
+    expect(screen.getByLabelText("Pairing Code")).toHaveValue("ABC2DE");
+    expect(submit).toBeEnabled();
+
+    await user.click(submit);
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        url: "ws://host:7456/rpc",
+        pairingCode: "ABC2DE",
+        displayName: "host",
+        tlsMode: "default",
+        tlsCertPEM: "",
+      }),
+    );
+  });
+
+  it("shows the concrete submit error and retains every entered value", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue(new Error("Pairing code expired"));
+    renderForm(onSubmit);
+
+    await user.type(screen.getByLabelText("Address"), "wss://host:7456/rpc");
+    await user.type(screen.getByLabelText("Pairing Code"), "ABC2DE");
+    await user.type(
+      screen.getByLabelText("Display Name (optional)"),
+      "Build box",
+    );
+    await user.click(screen.getByRole("button", { name: "Pair and verify" }));
+
+    expect(await screen.findByText("Pairing code expired")).toBeInTheDocument();
+    expect(screen.getByLabelText("Address")).toHaveValue("wss://host:7456/rpc");
+    expect(screen.getByLabelText("Pairing Code")).toHaveValue("ABC2DE");
+    expect(screen.getByLabelText("Display Name (optional)")).toHaveValue(
+      "Build box",
+    );
+  });
+});

--- a/frontend/src/components/agentre/remote-devices/device-pairing-form.tsx
+++ b/frontend/src/components/agentre/remote-devices/device-pairing-form.tsx
@@ -1,0 +1,308 @@
+import { useId, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+import { deriveDeviceName } from "./format";
+import { TLSTrustDialog } from "./tls-trust-dialog";
+
+// Local type — mirrors remote_device_svc.AddRequest; avoids transitive wailsjs import.
+export type AddRequest = {
+  url: string;
+  pairingCode: string;
+  displayName?: string;
+  tlsMode: string;
+  tlsCertPEM?: string;
+};
+
+export const URL_RE = /^wss?:\/\/[^/]+\/rpc$/;
+
+function limitCode(raw: string): string {
+  return raw.toUpperCase().slice(0, 6);
+}
+
+type UseDevicePairingFormOptions = {
+  onSubmit: (req: AddRequest) => Promise<void>;
+  onSubmittingChange?: (submitting: boolean) => void;
+};
+
+export function useDevicePairingForm({
+  onSubmit,
+  onSubmittingChange,
+}: UseDevicePairingFormOptions) {
+  const { t } = useTranslation();
+  const [url, setUrl] = useState("");
+  const [code, setCode] = useState("");
+  const [name, setName] = useState("");
+  const [tlsMode, setTlsMode] = useState("default");
+  const [tlsCertPEM, setTlsCertPEM] = useState("");
+  const [tlsOpen, setTlsOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const urlValid = URL_RE.test(url);
+  const codeValid = code.trim().length === 6;
+  const canSubmit = urlValid && codeValid && !submitting;
+
+  const reset = () => {
+    setUrl("");
+    setCode("");
+    setName("");
+    setTlsMode("default");
+    setTlsCertPEM("");
+    setTlsOpen(false);
+    setError(null);
+    setSubmitting(false);
+    onSubmittingChange?.(false);
+  };
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+    onSubmittingChange?.(true);
+    try {
+      await onSubmit({
+        url,
+        pairingCode: code.trim(),
+        displayName: name.trim() || deriveDeviceName(url, []),
+        tlsMode,
+        tlsCertPEM,
+      });
+      reset();
+    } catch (submitError: unknown) {
+      const message =
+        typeof submitError === "string"
+          ? submitError
+          : submitError instanceof Error
+            ? submitError.message
+            : t("remoteDevices.add.errors.pairFailed");
+      setError(message);
+      setSubmitting(false);
+      onSubmittingChange?.(false);
+    }
+  };
+
+  return {
+    canSubmit,
+    code,
+    codeValid,
+    error,
+    name,
+    reset,
+    setCode: (value: string) => setCode(limitCode(value)),
+    setName,
+    setTLSCertPEM: setTlsCertPEM,
+    setTLSMode: setTlsMode,
+    setTLSOpen: setTlsOpen,
+    setURL: (value: string) => setUrl(value.trim()),
+    submit,
+    submitting,
+    tlsCertPEM,
+    tlsMode,
+    tlsOpen,
+    url,
+    urlValid,
+  };
+}
+
+type DevicePairingController = ReturnType<typeof useDevicePairingForm>;
+
+type DevicePairingFieldsProps = {
+  pairing: DevicePairingController;
+};
+
+export function DevicePairingFields({ pairing }: DevicePairingFieldsProps) {
+  const { t } = useTranslation();
+  const fieldId = useId();
+  const urlId = `${fieldId}-url`;
+  const codeId = `${fieldId}-code`;
+  const nameId = `${fieldId}-name`;
+
+  return (
+    <>
+      <FieldGroup className="gap-4">
+        <Field data-invalid={pairing.url.length > 0 && !pairing.urlValid}>
+          <FieldLabel htmlFor={urlId}>
+            {t("remoteDevices.add.fields.url")}
+          </FieldLabel>
+          <Input
+            id={urlId}
+            value={pairing.url}
+            onChange={(event) => pairing.setURL(event.target.value)}
+            placeholder="ws://192.168.1.100:7456/rpc"
+            disabled={pairing.submitting}
+            aria-invalid={pairing.url.length > 0 && !pairing.urlValid}
+          />
+          {pairing.url.length > 0 && !pairing.urlValid ? (
+            <FieldError>{t("remoteDevices.add.fields.urlInvalid")}</FieldError>
+          ) : null}
+        </Field>
+
+        <Field data-invalid={pairing.code.length > 0 && !pairing.codeValid}>
+          <FieldLabel htmlFor={codeId}>
+            {t("remoteDevices.add.fields.pairingCode")}
+          </FieldLabel>
+          <Input
+            id={codeId}
+            value={pairing.code}
+            onChange={(event) => pairing.setCode(event.target.value)}
+            placeholder="ABC2DE"
+            maxLength={6}
+            disabled={pairing.submitting}
+            aria-invalid={pairing.code.length > 0 && !pairing.codeValid}
+            className="text-center font-mono text-lg tracking-widest"
+          />
+          <FieldDescription className="text-xs">
+            {t("remoteDevices.add.fields.pairingCodeHint")}
+          </FieldDescription>
+          {pairing.code.length > 0 && !pairing.codeValid ? (
+            <FieldError>{t("remoteDevices.add.fields.codeInvalid")}</FieldError>
+          ) : null}
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor={nameId}>
+            {t("remoteDevices.add.fields.displayName")}
+          </FieldLabel>
+          <Input
+            id={nameId}
+            value={pairing.name}
+            onChange={(event) => pairing.setName(event.target.value)}
+            placeholder={t("remoteDevices.add.fields.displayNamePlaceholder")}
+            disabled={pairing.submitting}
+          />
+        </Field>
+      </FieldGroup>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start"
+        onClick={() => pairing.setTLSOpen(true)}
+        disabled={pairing.submitting}
+      >
+        <ChevronRight data-icon="inline-start" aria-hidden="true" />
+        {t("remoteDevices.add.advancedTls", {
+          mode:
+            pairing.tlsMode === "default"
+              ? t("remoteDevices.tls.modes.default.label")
+              : pairing.tlsMode,
+        })}
+      </Button>
+
+      {pairing.error ? (
+        <div role="alert" className="text-sm text-destructive">
+          {pairing.error}
+        </div>
+      ) : null}
+
+      <TLSTrustDialog
+        open={pairing.tlsOpen}
+        initialMode={pairing.tlsMode}
+        initialPEM={pairing.tlsCertPEM}
+        onClose={() => pairing.setTLSOpen(false)}
+        onApply={(mode, pem) => {
+          pairing.setTLSMode(mode);
+          pairing.setTLSCertPEM(pem);
+          pairing.setTLSOpen(false);
+        }}
+      />
+    </>
+  );
+}
+
+type DevicePairingFormProps = UseDevicePairingFormOptions & {
+  actionsClassName?: string;
+  cancelLabel?: string;
+  className?: string;
+  onCancel?: () => void;
+  submitLabel?: string;
+};
+
+export function DevicePairingForm({
+  actionsClassName,
+  cancelLabel,
+  className,
+  onCancel,
+  onSubmit,
+  onSubmittingChange,
+  submitLabel,
+}: DevicePairingFormProps) {
+  const { t } = useTranslation();
+  const pairing = useDevicePairingForm({ onSubmit, onSubmittingChange });
+
+  return (
+    <form
+      className={cn("flex flex-col gap-4", className)}
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault();
+        void pairing.submit();
+      }}
+    >
+      <DevicePairingFields pairing={pairing} />
+
+      <div className={cn("flex items-center gap-2", actionsClassName)}>
+        {onCancel ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              if (pairing.submitting) return;
+              pairing.reset();
+              onCancel();
+            }}
+            disabled={pairing.submitting}
+          >
+            {cancelLabel ?? t("common.cancel")}
+          </Button>
+        ) : null}
+        <PairingSubmitButton
+          canSubmit={pairing.canSubmit}
+          submitting={pairing.submitting}
+          submitLabel={submitLabel}
+        />
+      </div>
+    </form>
+  );
+}
+
+export function PairingSubmitButton({
+  canSubmit,
+  submitLabel,
+  submitting,
+}: {
+  canSubmit: boolean;
+  submitLabel?: string;
+  submitting: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Button type="submit" disabled={!canSubmit}>
+      {submitting ? (
+        <Spinner
+          data-icon="inline-start"
+          aria-label={t("remoteDevices.add.pairing")}
+          className="motion-reduce:animate-none"
+        />
+      ) : null}
+      {submitting
+        ? t("remoteDevices.add.pairing")
+        : (submitLabel ?? t("remoteDevices.add.pair"))}
+    </Button>
+  );
+}

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
@@ -46,6 +46,7 @@ vi.mock("../../../../wailsjs/runtime/runtime", () => ({
 
 import {
   RemoteDeviceList,
+  RemoteDeviceAdd,
   RemoteDeviceRemove,
   RemoteDeviceRename,
   ServerListDevices,
@@ -59,6 +60,7 @@ import { RemoteDevicesPanel } from "./remote-devices-panel";
 import type { DeviceView } from "./use-remote-devices";
 
 const mockList = RemoteDeviceList as unknown as ReturnType<typeof vi.fn>;
+const mockAdd = RemoteDeviceAdd as unknown as ReturnType<typeof vi.fn>;
 const mockRemove = RemoteDeviceRemove as unknown as ReturnType<typeof vi.fn>;
 const mockRename = RemoteDeviceRename as unknown as ReturnType<typeof vi.fn>;
 const mockServerList = ServerListDevices as unknown as ReturnType<typeof vi.fn>;
@@ -73,6 +75,7 @@ const mockLogout = ServerLogout as unknown as ReturnType<typeof vi.fn>;
 describe("RemoteDevicesPanel", () => {
   beforeEach(() => {
     mockList.mockReset();
+    mockAdd.mockReset();
     mockServerList.mockReset();
     mockServerList.mockRejectedValue(new Error("not logged in"));
     mockGetState.mockReset();
@@ -94,11 +97,11 @@ describe("RemoteDevicesPanel", () => {
       screen.getByRole("status", { name: "Loading remote devices" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/No agentred devices paired/),
+      screen.queryByRole("heading", { name: "Install agentred" }),
     ).not.toBeInTheDocument();
   });
 
-  it("shows an initial load error instead of the empty state and retries", async () => {
+  it("shows an initial load error instead of the onboarding and retries", async () => {
     const user = userEvent.setup();
     mockList.mockRejectedValueOnce(new Error("list unavailable"));
 
@@ -108,26 +111,140 @@ describe("RemoteDevicesPanel", () => {
     expect(alert).toHaveTextContent("Couldn't load remote devices");
     expect(alert).toHaveClass("border-status-error/40", "bg-destructive-soft");
     expect(
-      screen.queryByText(/No agentred devices paired/),
+      screen.queryByRole("heading", { name: "Install agentred" }),
     ).not.toBeInTheDocument();
 
     mockList.mockResolvedValueOnce([]);
     await user.click(screen.getByRole("button", { name: "Retry" }));
 
     expect(
-      await screen.findByText(/No agentred devices paired/),
+      await screen.findByRole("heading", { name: "Install agentred" }),
     ).toBeInTheDocument();
     expect(mockList).toHaveBeenCalledTimes(2);
   });
 
-  it("shows empty state when no devices", async () => {
+  it("shows the three-step agentred onboarding when the ready device list is empty", async () => {
     mockList.mockResolvedValueOnce([]);
+
     render(<RemoteDevicesPanel />);
-    await waitFor(() =>
-      expect(
-        screen.getByText(/No agentred devices paired/),
-      ).toBeInTheDocument(),
+
+    expect(
+      await screen.findByRole("heading", { name: "Install agentred" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Start the remote service")).toBeInTheDocument();
+    expect(screen.getByText("Pair and verify")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh",
+      ),
+    ).toHaveAttribute("data-selectable-text", "true");
+  });
+
+  it("switches installer and service commands through the approved three-step flow", async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValueOnce([]);
+
+    render(<RemoteDevicesPanel />);
+    await screen.findByRole("heading", { name: "Install agentred" });
+
+    await user.click(screen.getByRole("radio", { name: "macOS" }));
+    expect(
+      screen.getByText(
+        "curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh",
+      ),
+    ).toHaveAttribute("data-selectable-text", "true");
+
+    await user.click(screen.getByRole("radio", { name: "Windows" }));
+    expect(
+      screen.getByText(
+        "irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex",
+      ),
+    ).toHaveAttribute("data-selectable-text", "true");
+
+    await user.click(screen.getByRole("button", { name: "Installed, next" }));
+    expect(
+      screen.getByText("agentred service install --start"),
+    ).toHaveAttribute("data-selectable-text", "true");
+    expect(screen.getByText("Daemon running")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("radio", { name: "Temporary foreground" }),
     );
+    expect(screen.getByText("agentred run")).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Service is running" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Connect this remote machine" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("agentred pair")).toHaveAttribute(
+      "data-selectable-text",
+      "true",
+    );
+  });
+
+  it("keeps pairing input and shows the concrete error when onboarding pairing fails", async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValueOnce([]);
+    mockAdd.mockRejectedValueOnce(new Error("Pairing code expired"));
+
+    render(<RemoteDevicesPanel />);
+    await screen.findByRole("heading", { name: "Install agentred" });
+    await user.click(screen.getByRole("button", { name: "Installed, next" }));
+    await user.click(
+      screen.getByRole("button", { name: "Service is running" }),
+    );
+    await user.type(
+      screen.getByLabelText("Address"),
+      "ws://linux-srv.local:7456/rpc",
+    );
+    await user.type(screen.getByLabelText("Pairing Code"), "abc2de");
+    await user.click(screen.getByRole("button", { name: "Pair and verify" }));
+
+    expect(await screen.findByText("Pairing code expired")).toBeInTheDocument();
+    expect(screen.getByLabelText("Address")).toHaveValue(
+      "ws://linux-srv.local:7456/rpc",
+    );
+    expect(screen.getByLabelText("Pairing Code")).toHaveValue("ABC2DE");
+  });
+
+  it("keeps the device list and opens Agent Backends after onboarding pairing succeeds", async () => {
+    const user = userEvent.setup();
+    const onOpenAgentBackends = vi.fn();
+    mockList.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "linux-srv",
+        url: "ws://linux-srv.local:7456/rpc",
+        tlsMode: "default",
+        online: true,
+        lastSeenAt: Date.now(),
+      },
+    ] as Partial<DeviceView>[]);
+    mockAdd.mockResolvedValueOnce(undefined);
+
+    render(<RemoteDevicesPanel onOpenAgentBackends={onOpenAgentBackends} />);
+    await screen.findByRole("heading", { name: "Install agentred" });
+    await user.click(screen.getByRole("button", { name: "Installed, next" }));
+    await user.click(
+      screen.getByRole("button", { name: "Service is running" }),
+    );
+    await user.type(
+      screen.getByLabelText("Address"),
+      "ws://linux-srv.local:7456/rpc",
+    );
+    await user.type(screen.getByLabelText("Pairing Code"), "ABC2DE");
+    await user.click(screen.getByRole("button", { name: "Pair and verify" }));
+
+    expect(await screen.findByTestId("device-row")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Configure Agent Backends" }),
+    );
+    expect(onOpenAgentBackends).toHaveBeenCalledOnce();
   });
 
   it("renders a row per device + counters", async () => {

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
@@ -85,6 +85,41 @@ describe("RemoteDevicesPanel", () => {
     mockLogout.mockResolvedValue(undefined);
   });
 
+  it("shows an accessible loading state instead of a blank page", () => {
+    mockList.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<RemoteDevicesPanel />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading remote devices" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No agentred devices paired/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an initial load error instead of the empty state and retries", async () => {
+    const user = userEvent.setup();
+    mockList.mockRejectedValueOnce(new Error("list unavailable"));
+
+    render(<RemoteDevicesPanel />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Couldn't load remote devices");
+    expect(alert).toHaveClass("border-status-error/40", "bg-destructive-soft");
+    expect(
+      screen.queryByText(/No agentred devices paired/),
+    ).not.toBeInTheDocument();
+
+    mockList.mockResolvedValueOnce([]);
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      await screen.findByText(/No agentred devices paired/),
+    ).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+
   it("shows empty state when no devices", async () => {
     mockList.mockResolvedValueOnce([]);
     render(<RemoteDevicesPanel />);

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { Plus, Server } from "lucide-react";
+import { ArrowRight, CircleCheck, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 
 import { AddDeviceDialog } from "./add-device-dialog";
+import { AgentredOnboarding } from "./agentred-onboarding";
 import { DeviceRow } from "./device-row";
 import { hostOf } from "./format";
 import { LoginDialog } from "./login-dialog";
@@ -65,7 +67,13 @@ function AccountStatus({
   );
 }
 
-export function RemoteDevicesPanel() {
+export type RemoteDevicesPanelProps = {
+  onOpenAgentBackends?: () => void;
+};
+
+export function RemoteDevicesPanel({
+  onOpenAgentBackends = () => {},
+}: RemoteDevicesPanelProps) {
   const { t } = useTranslation();
   const {
     devices,
@@ -80,6 +88,7 @@ export function RemoteDevicesPanel() {
   const serverLogin = useServerLogin();
   const [now, setNow] = useState(() => Date.now());
   const [addOpen, setAddOpen] = useState(false);
+  const [showBackendGuide, setShowBackendGuide] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [editTLSFor, setEditTLSFor] = useState<DeviceRowModel | null>(null);
   const [removeFor, setRemoveFor] = useState<DeviceRowModel | null>(null);
@@ -132,7 +141,7 @@ export function RemoteDevicesPanel() {
 
   return (
     <div className="flex flex-col gap-4">
-      <header className="flex items-start justify-between gap-4">
+      <header className="flex flex-col items-start justify-between gap-4 sm:flex-row">
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-semibold">
             {t("remoteDevices.panel.title")}
@@ -149,7 +158,7 @@ export function RemoteDevicesPanel() {
             </p>
           ) : null}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <AccountStatus
             loading={serverLogin.loading}
             loggedIn={serverLogin.loggedIn}
@@ -167,34 +176,61 @@ export function RemoteDevicesPanel() {
             }}
           />
           <Button onClick={() => setAddOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />{" "}
+            <Plus data-icon="inline-start" aria-hidden="true" />
             {t("remoteDevices.actions.addAgentred")}
           </Button>
         </div>
       </header>
 
       {devices.length === 0 ? (
-        <EmptyState onAdd={() => setAddOpen(true)} />
+        <AgentredOnboarding
+          onSubmit={async (request) => {
+            await add(request);
+            setShowBackendGuide(true);
+          }}
+        />
       ) : (
-        <div className="flex flex-col gap-2">
-          {devices.map((d) => (
-            <DeviceRow
-              key={d.id}
-              device={d}
-              now={now}
-              onRefresh={() => void refresh(d.id)}
-              onRename={() => setRenameFor({ id: d.id, draft: d.name })}
-              onEditTLS={() => setEditTLSFor(d)}
-              onRemove={() => setRemoveFor(d)}
-            />
-          ))}
-          <button
+        <div className="flex flex-col gap-3">
+          {showBackendGuide ? (
+            <Alert className="border-primary/30 bg-primary-soft">
+              <CircleCheck aria-hidden="true" />
+              <AlertTitle>
+                {t("remoteDevices.onboarding.complete.title")}
+              </AlertTitle>
+              <AlertDescription className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+                <span>
+                  {t("remoteDevices.onboarding.complete.description")}
+                </span>
+                <Button type="button" size="sm" onClick={onOpenAgentBackends}>
+                  {t("remoteDevices.onboarding.complete.action")}
+                  <ArrowRight data-icon="inline-end" aria-hidden="true" />
+                </Button>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          <div className="flex flex-col gap-2">
+            {devices.map((d) => (
+              <DeviceRow
+                key={d.id}
+                device={d}
+                now={now}
+                onRefresh={() => void refresh(d.id)}
+                onRename={() => setRenameFor({ id: d.id, draft: d.name })}
+                onEditTLS={() => setEditTLSFor(d)}
+                onRemove={() => setRemoveFor(d)}
+              />
+            ))}
+          </div>
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             onClick={() => setAddOpen(true)}
-            className="text-sm text-muted-foreground hover:text-foreground self-start"
+            className="self-start"
           >
+            <Plus data-icon="inline-start" aria-hidden="true" />
             {t("remoteDevices.actions.continueAddLan")}
-          </button>
+          </Button>
         </div>
       )}
 
@@ -332,28 +368,6 @@ export function RemoteDevicesPanel() {
         pollLoginToken={serverLogin.pollLoginToken}
         cancelLogin={serverLogin.cancelLogin}
       />
-    </div>
-  );
-}
-
-function EmptyState({ onAdd }: { onAdd: () => void }) {
-  const { t } = useTranslation();
-
-  return (
-    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed py-12 px-6 text-center">
-      <Server className="h-10 w-10 text-muted-foreground" />
-      <div className="text-base font-medium">
-        {t("remoteDevices.empty.title")}
-      </div>
-      <div className="text-sm text-muted-foreground max-w-md">
-        {t("remoteDevices.empty.prefix")} <code>agentred run</code>
-        {t("remoteDevices.empty.middle")} <code>agentred pair</code>{" "}
-        {t("remoteDevices.empty.suffix")}
-      </div>
-      <Button onClick={onAdd}>
-        <Plus className="mr-2 h-4 w-4" />{" "}
-        {t("remoteDevices.actions.addAgentred")}
-      </Button>
     </div>
   );
 }

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 
 import { AddDeviceDialog } from "./add-device-dialog";
 import { DeviceRow } from "./device-row";
@@ -66,8 +67,16 @@ function AccountStatus({
 
 export function RemoteDevicesPanel() {
   const { t } = useTranslation();
-  const { devices, loading, add, remove, updateTLS, rename, refresh, reload } =
-    useRemoteDevices();
+  const {
+    devices,
+    loadState,
+    add,
+    remove,
+    updateTLS,
+    rename,
+    refresh,
+    reload,
+  } = useRemoteDevices();
   const serverLogin = useServerLogin();
   const [now, setNow] = useState(() => Date.now());
   const [addOpen, setAddOpen] = useState(false);
@@ -85,8 +94,41 @@ export function RemoteDevicesPanel() {
   }, []);
 
   const onlineCount = devices.filter((d) => d.online).length;
+  const reloadInBackground = () => {
+    void reload().catch(() => {});
+  };
 
-  if (loading) return null;
+  if (loadState === "loading") {
+    return (
+      <div className="flex min-h-48 items-center justify-center">
+        <Spinner
+          className="size-5"
+          aria-label={t("remoteDevices.load.loading")}
+        />
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-start gap-3 rounded-lg border border-status-error/40 bg-destructive-soft p-4"
+      >
+        <div className="flex flex-col gap-1">
+          <p className="font-medium text-status-error">
+            {t("remoteDevices.load.errorTitle")}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {t("remoteDevices.load.errorDescription")}
+          </p>
+        </div>
+        <Button variant="outline" onClick={reloadInBackground}>
+          {t("common.retry")}
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -121,7 +163,7 @@ export function RemoteDevicesPanel() {
               void serverLogin
                 .logout()
                 .catch(() => {})
-                .finally(() => reload());
+                .finally(reloadInBackground);
             }}
           />
           <Button onClick={() => setAddOpen(true)}>
@@ -283,7 +325,7 @@ export function RemoteDevicesPanel() {
           // reflect the newly-claimed account without waiting for a window
           // focus event.
           void serverLogin.refresh();
-          void reload();
+          reloadInBackground();
         }}
         checkURL={serverLogin.checkURL}
         startLogin={serverLogin.startLogin}

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
@@ -193,10 +193,43 @@ describe("mergeDeviceSources (R15)", () => {
 });
 
 describe("useRemoteDevices", () => {
+  it("moves an initial load failure to error and a successful retry to ready", async () => {
+    mockList.mockRejectedValueOnce(new Error("list unavailable"));
+    const { result } = renderHook(() => useRemoteDevices());
+
+    await waitFor(() => expect(result.current.loadState).toBe("error"));
+    expect(result.current.devices).toEqual([]);
+
+    mockList.mockResolvedValueOnce([lanDevice()]);
+    await act(async () => {
+      await result.current.reload();
+    });
+
+    expect(result.current.loadState).toBe("ready");
+    expect(result.current.devices).toHaveLength(1);
+  });
+
+  it("keeps existing devices ready when a background focus reload fails", async () => {
+    mockList.mockResolvedValueOnce([lanDevice()]);
+    const { result } = renderHook(() => useRemoteDevices());
+    await waitFor(() => expect(result.current.loadState).toBe("ready"));
+
+    mockList.mockRejectedValueOnce(new Error("refresh unavailable"));
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+
+    expect(result.current.loadState).toBe("ready");
+    expect(result.current.devices).toHaveLength(1);
+    expect(result.current.devices[0].name).toBe("linux-srv");
+  });
+
   it("loads devices on mount", async () => {
     mockList.mockResolvedValueOnce([{ id: 1, name: "a" }]);
     const { result } = renderHook(() => useRemoteDevices());
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.loadState).toBe("ready"));
     expect(result.current.devices[0].name).toBe("a");
     // 未登录 → 无账号来源,单行只有 LAN 直连路径。
     expect(result.current.devices[0].paths).toEqual([
@@ -220,7 +253,7 @@ describe("useRemoteDevices", () => {
     mockList.mockResolvedValue([]);
     mockAdd.mockResolvedValueOnce({ id: 3, name: "c" });
     const { result } = renderHook(() => useRemoteDevices());
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.loadState).toBe("ready"));
     await act(async () => {
       await result.current.add({
         url: "ws://h/rpc",
@@ -248,7 +281,7 @@ describe("useRemoteDevices", () => {
     );
 
     const { result } = renderHook(() => useRemoteDevices());
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.loadState).toBe("ready"));
 
     await act(async () => {
       handlers["remote.device.state"]({
@@ -283,7 +316,7 @@ describe("useRemoteDevices", () => {
       },
     );
     const { result } = renderHook(() => useRemoteDevices());
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.loadState).toBe("ready"));
     await act(async () => {
       handlers["remote.device.state"]({
         id: 999,

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
@@ -226,6 +226,33 @@ describe("useRemoteDevices", () => {
     expect(result.current.devices[0].name).toBe("linux-srv");
   });
 
+  it("keeps the newest result when overlapping reloads finish out of order", async () => {
+    let resolveInitial!: (devices: DeviceView[]) => void;
+    mockList
+      .mockImplementationOnce(
+        () =>
+          new Promise<DeviceView[]>((resolve) => {
+            resolveInitial = resolve;
+          }),
+      )
+      .mockResolvedValueOnce([lanDevice({ id: 2, name: "newest" })]);
+
+    const { result } = renderHook(() => useRemoteDevices());
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(result.current.devices[0].name).toBe("newest");
+
+    await act(async () => {
+      resolveInitial([lanDevice({ name: "stale" })]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.devices[0].name).toBe("newest");
+  });
+
   it("loads devices on mount", async () => {
     mockList.mockResolvedValueOnce([{ id: 1, name: "a" }]);
     const { result } = renderHook(() => useRemoteDevices());

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   RemoteDeviceList,
@@ -99,13 +99,16 @@ type StateEvent = {
 
 const EVENT_NAME = "remote.device.state";
 
+export type RemoteDevicesLoadState = "loading" | "error" | "ready";
+
 export function useRemoteDevices() {
   const [lanDevices, setLanDevices] = useState<DeviceView[]>([]);
   const [account, setAccount] = useState<AccountSource>({
     known: false,
     devices: [],
   });
-  const [loading, setLoading] = useState(true);
+  const [loadState, setLoadState] = useState<RemoteDevicesLoadState>("loading");
+  const hasLoaded = useRef(false);
 
   // 合并后的行 = LAN 来源 + 账号来源。在线态事件只改 LAN 来源,merge 重算路径。
   const devices = useMemo(
@@ -114,22 +117,31 @@ export function useRemoteDevices() {
   );
 
   const reload = useCallback(async () => {
-    const list = (await RemoteDeviceList()) ?? [];
-    setLanDevices(list);
-    // 账号来源:未登录时 ServerListDevices 本地即返回 ErrNotLoggedIn(known=false,
-    // 不判未认领);已登录但拉取失败(服务器离线)同样 known=false,不把每台都误标未认领。
-    let acc: AccountSource;
+    if (!hasLoaded.current) setLoadState("loading");
+
     try {
-      const accountList = (await ServerListDevices()) ?? [];
-      acc = { known: true, devices: accountList };
-    } catch {
-      acc = { known: false, devices: [] };
+      const list = (await RemoteDeviceList()) ?? [];
+      setLanDevices(list);
+      // 账号来源:未登录时 ServerListDevices 本地即返回 ErrNotLoggedIn(known=false,
+      // 不判未认领);已登录但拉取失败(服务器离线)同样 known=false,不把每台都误标未认领。
+      let acc: AccountSource;
+      try {
+        const accountList = (await ServerListDevices()) ?? [];
+        acc = { known: true, devices: accountList };
+      } catch {
+        acc = { known: false, devices: [] };
+      }
+      setAccount(acc);
+      hasLoaded.current = true;
+      setLoadState("ready");
+    } catch (error) {
+      if (!hasLoaded.current) setLoadState("error");
+      throw error;
     }
-    setAccount(acc);
   }, []);
 
   useEffect(() => {
-    void reload().finally(() => setLoading(false));
+    void reload().catch(() => {});
   }, [reload]);
 
   useEffect(() => {
@@ -150,7 +162,7 @@ export function useRemoteDevices() {
       );
     });
     const onFocus = () => {
-      void reload();
+      void reload().catch(() => {});
     };
     window.addEventListener("focus", onFocus);
     return () => {
@@ -161,7 +173,7 @@ export function useRemoteDevices() {
 
   return {
     devices,
-    loading,
+    loadState,
     reload,
     add: async (req: AddRequest) => {
       await RemoteDeviceAdd(req);

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
@@ -109,6 +109,7 @@ export function useRemoteDevices() {
   });
   const [loadState, setLoadState] = useState<RemoteDevicesLoadState>("loading");
   const hasLoaded = useRef(false);
+  const reloadSequence = useRef(0);
 
   // 合并后的行 = LAN 来源 + 账号来源。在线态事件只改 LAN 来源,merge 重算路径。
   const devices = useMemo(
@@ -117,11 +118,11 @@ export function useRemoteDevices() {
   );
 
   const reload = useCallback(async () => {
+    const sequence = ++reloadSequence.current;
     if (!hasLoaded.current) setLoadState("loading");
 
     try {
       const list = (await RemoteDeviceList()) ?? [];
-      setLanDevices(list);
       // 账号来源:未登录时 ServerListDevices 本地即返回 ErrNotLoggedIn(known=false,
       // 不判未认领);已登录但拉取失败(服务器离线)同样 known=false,不把每台都误标未认领。
       let acc: AccountSource;
@@ -131,11 +132,15 @@ export function useRemoteDevices() {
       } catch {
         acc = { known: false, devices: [] };
       }
+      if (sequence !== reloadSequence.current) return;
+      setLanDevices(list);
       setAccount(acc);
       hasLoaded.current = true;
       setLoadState("ready");
     } catch (error) {
-      if (!hasLoaded.current) setLoadState("error");
+      if (sequence === reloadSequence.current && !hasLoaded.current) {
+        setLoadState("error");
+      }
       throw error;
     }
   }, []);

--- a/frontend/src/components/agentre/settings.test.tsx
+++ b/frontend/src/components/agentre/settings.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-chat-agents", () => ({
+  useChatAgents: () => ({ agents: [] }),
+}));
+
+vi.mock("./sync", () => ({
+  SyncPanel: () => null,
+  useSyncStatus: () => ({ loading: false, status: null }),
+}));
+
+vi.mock("./agent-backends", () => ({
+  AgentBackendsPanel: () => null,
+}));
+
+vi.mock("./remote-devices/remote-devices-panel", () => ({
+  RemoteDevicesPanel: ({
+    onOpenAgentBackends,
+  }: {
+    onOpenAgentBackends: () => void;
+  }) => (
+    <button type="button" onClick={onOpenAgentBackends}>
+      Configure Agent Backends
+    </button>
+  ),
+}));
+
+import { SettingsPage } from "./settings";
+
+describe("SettingsPage remote-device onboarding navigation", () => {
+  it("opens Agent Backends from the Remote Devices completion action", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: "/settings", state: { settingsPage: "remote-devices" } },
+        ]}
+      >
+        <SettingsPage
+          effectiveTheme="light"
+          onThemePreferenceChange={() => {}}
+          themePreference="system"
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Configure Agent Backends" }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Agent Backends" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/agentre/settings.tsx
+++ b/frontend/src/components/agentre/settings.tsx
@@ -682,7 +682,9 @@ function SettingsPage({
       <main className="min-w-0 flex-1 overflow-auto bg-background">
         <div className="flex min-h-full w-full min-w-0 max-w-[1180px] flex-col gap-6 px-4 py-5 sm:px-6 lg:gap-8 lg:px-10 lg:py-8">
           {activePage === "remote-devices" ? (
-            <RemoteDevicesPanel />
+            <RemoteDevicesPanel
+              onOpenAgentBackends={() => setActivePage("agent-backend")}
+            />
           ) : activePage === "appearance" ? (
             <AppearanceSettings
               effectiveTheme={effectiveTheme}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1915,6 +1915,84 @@
     "truncated": "Some items are not listed. Use the filter to narrow the folder."
   },
   "remoteDevices": {
+    "onboarding": {
+      "commands": {
+        "daemonRunning": "Daemon running",
+        "foregroundRun": "agentred run",
+        "installUnix": "curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh",
+        "installWindows": "irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex",
+        "listenAddress": "ws://…:7456/rpc",
+        "pair": "agentred pair",
+        "serviceInstall": "agentred service install --start",
+        "serviceRestart": "agentred service restart",
+        "serviceStatus": "agentred service status"
+      },
+      "complete": {
+        "action": "Configure Agent Backends",
+        "description": "Choose Claude Code, Codex, or Pi on this device.",
+        "title": "Remote connected"
+      },
+      "copyLabel": "Copy {{label}}",
+      "copySuccess": "Command copied",
+      "install": {
+        "archHint": "Architecture is detected automatically",
+        "description": "Choose the remote operating system, then run the install command in its terminal.",
+        "linux": "Linux",
+        "macos": "macOS",
+        "manual": "Manual installation",
+        "next": "Installed, next",
+        "osLabel": "Remote operating system",
+        "powershell": "PowerShell",
+        "recommended": "Recommended install command",
+        "terminal": "Remote terminal",
+        "windows": "Windows",
+        "title": "Install agentred"
+      },
+      "pair": {
+        "back": "Back to service",
+        "commandLabel": "Get pairing information",
+        "description": "Run the pairing command on the remote machine, then enter its address and one-time code.",
+        "submit": "Pair and verify",
+        "title": "Connect this remote machine"
+      },
+      "service": {
+        "background": "Background service (recommended)",
+        "description": "Use the background service for a machine that should stay available.",
+        "diagnostics": {
+          "first": "Run <command>{{command}}</command> and confirm <status>{{status}}</status> appears.",
+          "second": "Confirm the listen address includes <address>{{address}}</address>.",
+          "third": "Keep the service running, then continue to pairing."
+        },
+        "diagnosticsHint": "Run these checks in the remote terminal",
+        "diagnosticsTitle": "Confirm the service is running",
+        "foreground": "Temporary foreground",
+        "foregroundDescription": "Keep this terminal open; closing it stops agentred.",
+        "installLabel": "Install and start service",
+        "modeHint": "Background service is recommended",
+        "modeLabel": "Run mode",
+        "next": "Service is running",
+        "restartLabel": "Restart service",
+        "statusLabel": "Check status",
+        "title": "Start the remote service"
+      },
+      "stepLabel": "Step {{current}} of {{total}}",
+      "steps": {
+        "install": {
+          "done": "Complete",
+          "subtitle": "About 1 minute",
+          "title": "Install agentred"
+        },
+        "pair": {
+          "subtitle": "One-time code",
+          "title": "Pair and verify"
+        },
+        "service": {
+          "done": "Running",
+          "subtitle": "Stay online",
+          "title": "Start the remote service"
+        }
+      }
+    },
     "actions": {
       "addAgentred": "Add agentred",
       "continueAddLan": "+ Add another agentred (LAN)",
@@ -1947,12 +2025,6 @@
       "pair": "Pair",
       "pairing": "Pairing...",
       "title": "Add agentred Device"
-    },
-    "empty": {
-      "middle": ", then run",
-      "prefix": "Run",
-      "suffix": "to get a 6-character pairing code, then return here and choose Add agentred.",
-      "title": "No agentred devices paired"
     },
     "errors": {
       "dialFailed": "Connection failed: {{message}}",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1925,7 +1925,8 @@
         "pair": "agentred pair",
         "serviceInstall": "agentred service install --start",
         "serviceRestart": "agentred service restart",
-        "serviceStatus": "agentred service status"
+        "serviceStatus": "agentred service status",
+        "version": "agentred --version"
       },
       "complete": {
         "action": "Configure Agent Backends",
@@ -1945,6 +1946,7 @@
         "powershell": "PowerShell",
         "recommended": "Recommended install command",
         "terminal": "Remote terminal",
+        "verify": "Verify installation",
         "windows": "Windows",
         "title": "Install agentred"
       },

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1959,6 +1959,11 @@
       "tofuMismatch": "The server identity fingerprint changed. Verify it is safe, then pair again.",
       "unauthorized": "Credentials expired. Pair again."
     },
+    "load": {
+      "errorDescription": "Check the connection and try again.",
+      "errorTitle": "Couldn't load remote devices",
+      "loading": "Loading remote devices"
+    },
     "login": {
       "actions": {
         "connecting": "Connecting...",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1915,6 +1915,84 @@
     "truncated": "还有未列出的项，请用筛选缩小范围"
   },
   "remoteDevices": {
+    "onboarding": {
+      "commands": {
+        "daemonRunning": "Daemon running",
+        "foregroundRun": "agentred run",
+        "installUnix": "curl -fsSL https://github.com/agentre-ai/agentre/releases/latest/download/install.sh | sh",
+        "installWindows": "irm https://github.com/agentre-ai/agentre/releases/latest/download/install.ps1 | iex",
+        "listenAddress": "ws://…:7456/rpc",
+        "pair": "agentred pair",
+        "serviceInstall": "agentred service install --start",
+        "serviceRestart": "agentred service restart",
+        "serviceStatus": "agentred service status"
+      },
+      "complete": {
+        "action": "配置 Agent 后端",
+        "description": "选择这台设备上的 Claude Code、Codex 或 Pi。",
+        "title": "远端已连接"
+      },
+      "copyLabel": "复制{{label}}",
+      "copySuccess": "命令已复制",
+      "install": {
+        "archHint": "架构将自动识别",
+        "description": "选择远端操作系统，然后在它的终端中运行安装命令。",
+        "linux": "Linux",
+        "macos": "macOS",
+        "manual": "手动安装",
+        "next": "我已安装，下一步",
+        "osLabel": "远端操作系统",
+        "powershell": "PowerShell",
+        "recommended": "推荐安装命令",
+        "terminal": "远端终端",
+        "windows": "Windows",
+        "title": "安装 agentred"
+      },
+      "pair": {
+        "back": "返回服务",
+        "commandLabel": "获取配对信息",
+        "description": "在远端运行配对命令，然后填写连接地址和一次性配对码。",
+        "submit": "配对并验证",
+        "title": "连接这台远端机器"
+      },
+      "service": {
+        "background": "后台服务（推荐）",
+        "description": "需要长期在线的机器建议使用后台服务。",
+        "diagnostics": {
+          "first": "运行 <command>{{command}}</command>，确认出现 <status>{{status}}</status>。",
+          "second": "确认监听地址包含 <address>{{address}}</address>。",
+          "third": "保持服务运行，然后继续配对。"
+        },
+        "diagnosticsHint": "在远端终端执行",
+        "diagnosticsTitle": "确认服务已运行",
+        "foreground": "前台临时运行",
+        "foregroundDescription": "保持终端开启；关闭终端会停止 agentred。",
+        "installLabel": "安装并启动服务",
+        "modeHint": "建议使用后台服务",
+        "modeLabel": "运行方式",
+        "next": "服务已运行",
+        "restartLabel": "重启服务",
+        "statusLabel": "查看状态",
+        "title": "启动远端服务"
+      },
+      "stepLabel": "步骤 {{current}} / {{total}}",
+      "steps": {
+        "install": {
+          "done": "已完成",
+          "subtitle": "约 1 分钟",
+          "title": "安装 agentred"
+        },
+        "pair": {
+          "subtitle": "一次性验证码",
+          "title": "配对并验证"
+        },
+        "service": {
+          "done": "正在运行",
+          "subtitle": "保持在线",
+          "title": "启动远端服务"
+        }
+      }
+    },
     "actions": {
       "addAgentred": "添加 agentred",
       "continueAddLan": "+ 继续添加 agentred（LAN）",
@@ -1947,12 +2025,6 @@
       "pair": "配对",
       "pairing": "配对中…",
       "title": "添加 agentred 设备"
-    },
-    "empty": {
-      "middle": "，再执行",
-      "prefix": "在远程机器执行",
-      "suffix": "拿 6 位配对码，回到这里点「添加 agentred」输入。",
-      "title": "尚未配对任何 agentred"
     },
     "errors": {
       "dialFailed": "连接失败：{{message}}",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1925,7 +1925,8 @@
         "pair": "agentred pair",
         "serviceInstall": "agentred service install --start",
         "serviceRestart": "agentred service restart",
-        "serviceStatus": "agentred service status"
+        "serviceStatus": "agentred service status",
+        "version": "agentred --version"
       },
       "complete": {
         "action": "配置 Agent 后端",
@@ -1945,6 +1946,7 @@
         "powershell": "PowerShell",
         "recommended": "推荐安装命令",
         "terminal": "远端终端",
+        "verify": "验证安装",
         "windows": "Windows",
         "title": "安装 agentred"
       },

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1959,6 +1959,11 @@
       "tofuMismatch": "服务端身份指纹已变化，请确认安全后重新配对",
       "unauthorized": "凭据已失效，请重新配对"
     },
+    "load": {
+      "errorDescription": "请检查连接后重试。",
+      "errorTitle": "无法加载远端设备",
+      "loading": "正在加载远端设备"
+    },
     "login": {
       "actions": {
         "connecting": "连接中…",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/Microsoft/go-winio v0.6.1
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/cago-frame/agents v0.0.0-20260727021936-d7bfede861b9
 	github.com/cago-frame/cago v0.0.0-20260609091633-ba2f550b2729
@@ -22,6 +23,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/sys v0.43.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/gorm v1.25.12
 )
@@ -153,9 +155,9 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.12.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251029180050-ab9386a59fda // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0/go.mod h1:D56Cl9r8M5i3UwAchE+LlLc5hPN3kJtdZNVJn06lSHU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
+github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
 github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=

--- a/internal/bootstrap/cago.go
+++ b/internal/bootstrap/cago.go
@@ -150,7 +150,14 @@ func Init(ctx context.Context) (*Runtime, error) {
 	// 启动时按持久化的开关恢复 Debug 日志级别（取代旧 AGENTRE_DEBUG 环境变量）。
 	applyDebugLoggingOnBoot(ctx)
 
-	// Server 接入：注册 keychain + server_state_repo + server_svc 默认实现。
+	// 在装配 Server / Remote Device 之前确立 keychain 后端:e2e 构建设置
+	// AGENTRE_E2E_KEYCHAIN_DIR 时在这里建立 file keychain,失败直接终止,绝不回退
+	// 生产 system keychain(见 keychain.go / keychain_e2e.go)。
+	if err := initKeychain(ctx); err != nil {
+		return nil, fmt.Errorf("init keychain: %w", err)
+	}
+
+	// Server 接入：注册 server_state_repo + server_svc 默认实现。
 	// server_svc 此时的 emit 为 nil；app.go.startup 在 wails ctx 就绪后调 SetEmitter 绑定事件源。
 	if err := InitServer(ctx); err != nil {
 		return nil, fmt.Errorf("init server: %w", err)

--- a/internal/bootstrap/keychain.go
+++ b/internal/bootstrap/keychain.go
@@ -1,0 +1,17 @@
+//go:build !e2e
+
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/agentre-ai/agentre/internal/pkg/keychain"
+)
+
+// initKeychain 在 bootstrap 装配任何依赖 keychain 的服务之前确立默认 keychain 后端。
+// 生产构建固定用平台 system keychain(NewSystem),行为与历史一致;e2e 构建在
+// keychain_e2e.go 覆盖这个实现。
+func initKeychain(context.Context) error {
+	keychain.SetDefault(keychain.NewSystem())
+	return nil
+}

--- a/internal/bootstrap/keychain_e2e.go
+++ b/internal/bootstrap/keychain_e2e.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/agentre-ai/agentre/internal/pkg/keychain"
+)
+
+// E2EKeychainDirEnv 是 e2e 构建专用的隔离 keychain 目录环境变量。带 e2e build tag 且
+// 设置它时,bootstrap 在装配 Server / Remote Device 之前就建立 file keychain,让
+// Server Add、ConnPool、watcher 与 e2e seeding 共享同一个后端,生产 system keychain
+// 永远不是 fallback。
+const E2EKeychainDirEnv = "AGENTRE_E2E_KEYCHAIN_DIR"
+
+// initKeychain 覆盖生产默认:设置 E2EKeychainDirEnv 时建立并校验 file keychain;
+// 目录缺失 / 权限不安全 / 不可写都会让启动失败,绝不回退 NewSystem()。
+// 未设置时与生产构建一致,继续使用平台 system keychain。
+func initKeychain(_ context.Context) error {
+	dir := strings.TrimSpace(os.Getenv(E2EKeychainDirEnv))
+	if dir == "" {
+		keychain.SetDefault(keychain.NewSystem())
+		return nil
+	}
+	if err := keychain.ValidateFileDir(dir); err != nil {
+		return fmt.Errorf("e2e keychain dir not usable: %w", err)
+	}
+	keychain.SetDefault(keychain.NewFile(dir))
+	return nil
+}

--- a/internal/bootstrap/server.go
+++ b/internal/bootstrap/server.go
@@ -10,22 +10,23 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/agentre-ai/agentre/internal/model/entity/server_state_entity"
-	"github.com/agentre-ai/agentre/internal/pkg/keychain"
 	"github.com/agentre-ai/agentre/internal/repository/server_state_repo"
 	"github.com/agentre-ai/agentre/internal/repository/syncstate_repo"
 	"github.com/agentre-ai/agentre/internal/service/server_svc"
 	"github.com/agentre-ai/agentre/internal/service/sync_svc"
 )
 
-// InitServer wires the desktop's keychain + server_state_repo + server_svc defaults.
+// InitServer wires the server_state_repo + server_svc defaults.
 // The server_svc starts WITHOUT a wails event emitter; app.go.startup binds it
 // later via server_svc.Server().SetEmitter(...).
+//
+// The keychain backend is established earlier in Init (initKeychain), before any
+// keychain-dependent service is assembled; InitServer must not reset it.
 //
 // Reads the persisted server_url to point the http client at the right host;
 // when no row exists yet, the client base URL is empty and StartLogin will
 // rebuild it from the user-supplied URL anyway.
 func InitServer(ctx context.Context) error {
-	keychain.SetDefault(keychain.NewSystem())
 	server_state_repo.RegisterServerState(server_state_repo.NewServerState())
 
 	row, _ := server_state_repo.ServerState().Get(ctx)

--- a/internal/bootstrap/server_test.go
+++ b/internal/bootstrap/server_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentre-ai/agentre/internal/pkg/keychain"
+)
+
+// initKeychain 是 bootstrap 在装配 Server / Remote Device 之前选择 keychain 后端的
+// 接缝(见 keychain_e2e.go)。这些用例钉死 e2e 的 keychain 边界
+// (docs/specs/2026-08-12-agentred-service-runtime-fixes.md「E2E keychain 初始化与
+// 安全边界」):设置 AGENTRE_E2E_KEYCHAIN_DIR 时必须在 Server / Remote Device 装配前
+// 建立 file keychain;目录缺失 / 权限不安全 / 不可写 → 启动失败,绝不回退系统 keychain。
+
+func TestInitKeychainGivenE2EKeychainDirSelectsFileBackend(t *testing.T) {
+	// e2e runner 用 mkdirSync(…, {mode: 0o700}) 预创建隔离目录;测试同样显式建 0700
+	// (本机 t.TempDir() 是 0755,不能直接当 keychain 目录)。
+	dir := filepath.Join(t.TempDir(), "kc")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	original := keychain.Default()
+	t.Cleanup(func() { keychain.SetDefault(original) })
+	t.Setenv(E2EKeychainDirEnv, dir)
+
+	require.NoError(t, initKeychain(context.Background()))
+
+	// 先断言后端类型,再 probe —— 后端仍是系统 keychain 时不得误写生产凭据。
+	require.Equal(t, reflect.TypeOf(keychain.NewFile(dir)), reflect.TypeOf(keychain.Default()))
+	require.NoError(t, keychain.Default().Set("probe-account", "generated-test-value"))
+	got, err := os.ReadFile(filepath.Join(dir, "probe-account"))
+	require.NoError(t, err)
+	assert.Equal(t, "generated-test-value", string(got))
+}
+
+func TestInitKeychainGivenMissingDirFailsWithoutSwappingBackend(t *testing.T) {
+	original := keychain.Default()
+	t.Cleanup(func() { keychain.SetDefault(original) })
+	sentinel := keychain.NewMemory()
+	keychain.SetDefault(sentinel)
+	t.Setenv(E2EKeychainDirEnv, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	err := initKeychain(context.Background())
+	require.Error(t, err)
+	// 失败不得偷偷换后端(file 或 system):调用方应终止启动,而不是继续跑。
+	assert.Same(t, sentinel, keychain.Default())
+}
+
+func TestInitKeychainGivenUnsafePermsFails(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "kc")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	t.Setenv(E2EKeychainDirEnv, dir)
+
+	err := initKeychain(context.Background())
+	require.Error(t, err)
+}
+
+func TestInitKeychainGivenNoEnvKeepsSystemKeychain(t *testing.T) {
+	original := keychain.Default()
+	t.Cleanup(func() { keychain.SetDefault(original) })
+	t.Setenv(E2EKeychainDirEnv, "")
+
+	require.NoError(t, initKeychain(context.Background()))
+	assert.Equal(t, reflect.TypeOf(keychain.NewSystem()), reflect.TypeOf(keychain.Default()))
+}
+
+// TestInitGivenE2EKeychainDirSelectsFileBackendBeforeServerWiring 验证真实启动顺序里
+// (e2e dir → Init → InitServer → InitRemoteDevice)file keychain 在 Server / Remote
+// Device 装配之前确定,而且 InitServer 不会把它覆盖回系统 keychain —— ConnPool /
+// watcher / Add 构造时捕获的就是同一个 file backend。
+func TestInitGivenE2EKeychainDirSelectsFileBackendBeforeServerWiring(t *testing.T) {
+	dataDir := t.TempDir()
+	keychainDir := filepath.Join(t.TempDir(), "kc")
+	require.NoError(t, os.MkdirAll(keychainDir, 0o700))
+	t.Setenv("AGENTRE_DATA_DIR", dataDir)
+	t.Setenv("AGENTRE_ENV", "test")
+	t.Setenv(E2EKeychainDirEnv, keychainDir)
+
+	runtime, err := Init(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(runtime.Close)
+
+	require.Equal(t, reflect.TypeOf(keychain.NewFile(keychainDir)), reflect.TypeOf(keychain.Default()))
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cago-frame/cago/configs"
+
 	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/client"
 	"github.com/agentre-ai/agentre/internal/daemon/handlers"
@@ -34,7 +36,6 @@ import (
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/capability"
 	piagentrt "github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/piagent"
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/remote/wire"
-	"github.com/cago-frame/cago/configs"
 )
 
 // TestDaemon_OpensOwnDatabaseAndRunsMigrations 覆盖任务目标的第一句:agentred

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,6 +31,7 @@ import (
 	"github.com/agentre-ai/agentre/internal/daemon/rpc"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
 	"github.com/agentre-ai/agentre/internal/model/entity/agent_backend_entity"
+	"github.com/agentre-ai/agentre/internal/pkg/agentredipc"
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime"
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/capability"
 	piagentrt "github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/piagent"
@@ -1006,6 +1006,22 @@ func TestDaemon_TwoConnectionsKeepTerminalHandlersIsolated(t *testing.T) {
 	require.ErrorIs(t, err, rpc.ErrMethodNotFound, "bindConn must not mutate the bootstrap registry")
 }
 
+func localIPCClient(dataDir string) *http.Client {
+	return &http.Client{Transport: &http.Transport{DialContext: agentredipc.DialContext(dataDir)}}
+}
+
+func waitForLocalIPC(t *testing.T, client *http.Client) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		response, err := client.Get("http://daemon/local/status")
+		if err != nil {
+			return false
+		}
+		_ = response.Body.Close()
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 func TestGivenRunningDaemonWhenReadingIPCStatusThenReportsIdentityAndPairing(t *testing.T) {
 	previousVersion, previousCommit := configs.Version, buildinfo.CommitID
 	configs.Version, buildinfo.CommitID = "v1.2.3", "abcdef1234567890"
@@ -1026,15 +1042,8 @@ func TestGivenRunningDaemonWhenReadingIPCStatusThenReportsIdentityAndPairing(t *
 	defer cancel()
 	errCh := make(chan error, 1)
 	go func() { errCh <- d.Run(ctx) }()
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(d.SocketPath())
-		return err == nil
-	}, 2*time.Second, 10*time.Millisecond)
-
-	tr := &http.Transport{DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-		return net.Dial("unix", d.SocketPath())
-	}}
-	c := &http.Client{Transport: tr}
+	c := localIPCClient(dir)
+	waitForLocalIPC(t, c)
 
 	resp, err := c.Get("http://daemon/local/status")
 	require.NoError(t, err)
@@ -1073,15 +1082,8 @@ func TestDaemon_IPCStatus_ReportsDatabasePathAndSize(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = d.Run(ctx) }()
-	require.Eventually(t, func() bool {
-		_, statErr := os.Stat(d.SocketPath())
-		return statErr == nil
-	}, 2*time.Second, 10*time.Millisecond)
-
-	tr := &http.Transport{DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-		return net.Dial("unix", d.SocketPath())
-	}}
-	client := &http.Client{Transport: tr}
+	client := localIPCClient(dir)
+	waitForLocalIPC(t, client)
 	status := func() map[string]any {
 		t.Helper()
 		resp, getErr := client.Get("http://daemon/local/status")
@@ -1128,15 +1130,8 @@ func TestDaemon_IPCStatus_CountsSessionsRunningRightNow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = d.Run(ctx) }()
-	require.Eventually(t, func() bool {
-		_, statErr := os.Stat(d.SocketPath())
-		return statErr == nil
-	}, 2*time.Second, 10*time.Millisecond)
-
-	tr := &http.Transport{DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-		return net.Dial("unix", d.SocketPath())
-	}}
-	client := &http.Client{Transport: tr}
+	client := localIPCClient(dir)
+	waitForLocalIPC(t, client)
 	activeSessions := func() float64 {
 		t.Helper()
 		resp, getErr := client.Get("http://daemon/local/status")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/client"
 	"github.com/agentre-ai/agentre/internal/daemon/handlers"
 	"github.com/agentre-ai/agentre/internal/daemon/notifier"
@@ -33,6 +34,7 @@ import (
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/capability"
 	piagentrt "github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/piagent"
 	"github.com/agentre-ai/agentre/internal/pkg/agentruntime/runtimes/remote/wire"
+	"github.com/cago-frame/cago/configs"
 )
 
 // TestDaemon_OpensOwnDatabaseAndRunsMigrations 覆盖任务目标的第一句:agentred
@@ -1003,8 +1005,16 @@ func TestDaemon_TwoConnectionsKeepTerminalHandlersIsolated(t *testing.T) {
 	require.ErrorIs(t, err, rpc.ErrMethodNotFound, "bindConn must not mutate the bootstrap registry")
 }
 
-func TestDaemon_IPCStatus(t *testing.T) {
-	dir := t.TempDir()
+func TestGivenRunningDaemonWhenReadingIPCStatusThenReportsIdentityAndPairing(t *testing.T) {
+	previousVersion, previousCommit := configs.Version, buildinfo.CommitID
+	configs.Version, buildinfo.CommitID = "v1.2.3", "abcdef1234567890"
+	t.Cleanup(func() {
+		configs.Version, buildinfo.CommitID = previousVersion, previousCommit
+	})
+
+	dir, err := os.MkdirTemp("", "agentred-ipc")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	d, err := New(Options{
 		DataDir: dir,
 		LANHost: "127.0.0.1",
@@ -1032,6 +1042,7 @@ func TestDaemon_IPCStatus(t *testing.T) {
 	var v map[string]any
 	require.NoError(t, json.Unmarshal(body, &v))
 	assert.NotEmpty(t, v["daemonUUID"])
+	assert.Equal(t, "v1.2.3 (abcdef1)", v["version"])
 	assert.NotContains(t, v, "keyStorage")
 
 	resp2, err := c.Get("http://daemon/local/pair")

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -12,10 +12,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/cago-frame/cago/configs"
+
 	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/handlers"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
-	"github.com/cago-frame/cago/configs"
 )
 
 const ipcSocketName = "agentred.sock"

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -12,11 +12,18 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/handlers"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
+	"github.com/cago-frame/cago/configs"
 )
 
 const ipcSocketName = "agentred.sock"
+
+// BuildIdentity returns the version and commit injected into the agentred binary.
+func BuildIdentity() string {
+	return configs.Version + " (" + buildinfo.ShortCommitID() + ")"
+}
 
 // startIPC binds a unix-domain socket under <DataDir>/agentred.sock and
 // serves a minimal HTTP API for the local CLI (status / pair / llm).
@@ -79,6 +86,7 @@ func (d *Daemon) ipcStatus(w http.ResponseWriter, r *http.Request) {
 	dbStat := d.DBStat()
 	writeJSON(w, map[string]any{
 		"pid":              os.Getpid(),
+		"version":          BuildIdentity(),
 		"daemonUUID":       snap.DaemonInstanceUUID,
 		"listenURLs":       lanURLs(d),
 		"socketPath":       d.SocketPath(),

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -3,13 +3,9 @@ package daemon
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
-	"net"
 	"net/http"
 	"os"
-	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/cago-frame/cago/configs"
@@ -17,33 +13,19 @@ import (
 	"github.com/agentre-ai/agentre/internal/buildinfo"
 	"github.com/agentre-ai/agentre/internal/daemon/handlers"
 	"github.com/agentre-ai/agentre/internal/daemon/state"
+	"github.com/agentre-ai/agentre/internal/pkg/agentredipc"
 )
-
-const ipcSocketName = "agentred.sock"
 
 // BuildIdentity returns the version and commit injected into the agentred binary.
 func BuildIdentity() string {
 	return configs.Version + " (" + buildinfo.ShortCommitID() + ")"
 }
 
-// startIPC binds a unix-domain socket under <DataDir>/agentred.sock and
-// serves a minimal HTTP API for the local CLI (status / pair / llm).
-// Returns the server so daemon.Run can call Shutdown on ctx cancel.
-//
-// Windows is not yet wired (would need named pipe); returns an error so the
-// daemon refuses to start on Windows until we add platform support.
+// startIPC serves the local status / pair / llm HTTP API over the
+// platform-local endpoint owned by agentredipc.
 func (d *Daemon) startIPC(ctx context.Context) (*http.Server, error) {
-	if runtime.GOOS == "windows" {
-		return nil, errors.New("ipc: windows named pipe path not yet wired")
-	}
-	path := d.SocketPath()
-	_ = os.Remove(path)
-	ln, err := net.Listen("unix", path)
+	ln, err := agentredipc.Listen(d.opts.DataDir)
 	if err != nil {
-		return nil, err
-	}
-	if err := os.Chmod(path, 0o600); err != nil {
-		_ = ln.Close()
 		return nil, err
 	}
 	mux := http.NewServeMux()
@@ -55,16 +37,16 @@ func (d *Daemon) startIPC(ctx context.Context) (*http.Server, error) {
 	go func() {
 		<-ctx.Done()
 		_ = srv.Shutdown(context.Background())
-		_ = os.Remove(path)
+		_ = agentredipc.Cleanup(d.opts.DataDir)
 	}()
 	go func() { _ = srv.Serve(ln) }()
 	return srv, nil
 }
 
-// SocketPath returns the absolute path of the daemon's IPC unix socket.
-// Tests use this to dial without going through paths.AgentredDataDir().
+// SocketPath returns the daemon's platform-local IPC endpoint. The method name
+// remains stable for existing status JSON and Unix callers.
 func (d *Daemon) SocketPath() string {
-	return filepath.Join(d.opts.DataDir, ipcSocketName)
+	return agentredipc.Endpoint(d.opts.DataDir)
 }
 
 func (d *Daemon) ipcPair(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/state/types.go
+++ b/internal/daemon/state/types.go
@@ -8,6 +8,7 @@ import "sync"
 type State struct {
 	SchemaVersion            int                        `json:"schemaVersion"`
 	DaemonInstanceUUID       string                     `json:"daemonInstanceUUID"`
+	HubServerURL             string                     `json:"hubServerURL,omitempty"`
 	Listen                   ListenPrefs                `json:"listen"`
 	PairedPeers              map[string]PairedPeer      `json:"pairedPeers"`
 	LLMProviders             map[string]LLMProviderMeta `json:"llmProviders"`

--- a/internal/daemon/state/types_test.go
+++ b/internal/daemon/state/types_test.go
@@ -13,6 +13,7 @@ func TestState_JSONRoundTrip(t *testing.T) {
 	in := &State{
 		SchemaVersion:      1,
 		DaemonInstanceUUID: "8f3a9c2b",
+		HubServerURL:       "https://hub.example",
 		Listen: ListenPrefs{
 			LanHost:     "0.0.0.0",
 			LanPort:     7456,
@@ -99,6 +100,7 @@ func TestState_DefaultsAreSane(t *testing.T) {
 	assert.Equal(t, "uuid-x", s.DaemonInstanceUUID)
 	assert.Equal(t, "0.0.0.0", s.Listen.LanHost)
 	assert.Equal(t, 7456, s.Listen.LanPort)
+	assert.Empty(t, s.HubServerURL)
 	assert.Equal(t, "info", s.Preferences.LogLevel)
 	assert.Equal(t, 300, s.Preferences.PairingCodeTTLSeconds)
 	assert.Equal(t, 3, s.Preferences.PairingRateLimit.MaxAttemptsPerIP)

--- a/internal/pkg/agentredipc/endpoint.go
+++ b/internal/pkg/agentredipc/endpoint.go
@@ -1,0 +1,31 @@
+// Package agentredipc owns the local daemon endpoint shared by agentred and
+// its CLI. Platform transports live behind build tags so callers cannot drift
+// on endpoint naming or dialing behavior.
+package agentredipc
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+)
+
+const unixSocketName = "agentred.sock"
+
+// UnixSocketPath preserves the existing local IPC path on Unix platforms.
+func UnixSocketPath(dataDir string) string {
+	return filepath.Join(dataDir, unixSocketName)
+}
+
+// WindowsPipePath derives an opaque, stable pipe name from the data directory.
+// The digest prevents usernames and directory layout from leaking through the
+// globally visible named-pipe namespace.
+func WindowsPipePath(dataDir string) string {
+	normalized := strings.ToLower(strings.TrimRight(strings.ReplaceAll(dataDir, "/", `\`), `\`))
+	digest := sha256.Sum256([]byte(normalized))
+	return `\\.\pipe\agentred-` + hex.EncodeToString(digest[:16])
+}
+
+func securityDescriptorForSID(sid string) string {
+	return "D:P(A;;GA;;;" + sid + ")"
+}

--- a/internal/pkg/agentredipc/endpoint_test.go
+++ b/internal/pkg/agentredipc/endpoint_test.go
@@ -1,0 +1,30 @@
+package agentredipc
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGivenDataDirectoryWhenDerivingEndpointsThenUnixPathIsPreservedAndWindowsPipeIsOpaque(t *testing.T) {
+	dataDir := filepath.Join("tmp", "agentred", "alice-private")
+
+	assert.Equal(t, filepath.Join(dataDir, "agentred.sock"), UnixSocketPath(dataDir))
+
+	first := WindowsPipePath(`C:\Users\Alice\AppData\Roaming\agentred`)
+	second := WindowsPipePath(`c:/users/alice/appdata/roaming/agentred/`)
+	require.Equal(t, first, second, "equivalent Windows data-directory spellings must address the same daemon")
+	assert.True(t, strings.HasPrefix(first, `\\.\pipe\agentred-`))
+	assert.NotContains(t, strings.ToLower(first), "alice")
+	assert.NotContains(t, strings.ToLower(first), "appdata")
+	assert.NotEqual(t, first, WindowsPipePath(`C:\Users\Alice\AppData\Roaming\agentred-other`))
+}
+
+func TestGivenCurrentUserSIDWhenBuildingPipeACLThenOnlyThatSIDGetsFullAccess(t *testing.T) {
+	sid := "S-1-5-21-111-222-333-1001"
+
+	assert.Equal(t, "D:P(A;;GA;;;"+sid+")", securityDescriptorForSID(sid))
+}

--- a/internal/pkg/agentredipc/transport_unix.go
+++ b/internal/pkg/agentredipc/transport_unix.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package agentredipc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+)
+
+// Endpoint returns the unchanged Unix-domain socket path.
+func Endpoint(dataDir string) string {
+	return UnixSocketPath(dataDir)
+}
+
+// Listen creates the current-user-only Unix-domain socket used by agentred.
+func Listen(dataDir string) (net.Listener, error) {
+	path := Endpoint(dataDir)
+	_ = os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+	return listener, nil
+}
+
+// DialContext returns an HTTP transport dialer for the local Unix socket.
+func DialContext(dataDir string) func(context.Context, string, string) (net.Conn, error) {
+	path := Endpoint(dataDir)
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, "unix", path)
+	}
+}
+
+// Cleanup removes the socket after shutdown.
+func Cleanup(dataDir string) error {
+	err := os.Remove(Endpoint(dataDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/internal/pkg/agentredipc/transport_unix_test.go
+++ b/internal/pkg/agentredipc/transport_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package agentredipc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGivenUnixDataDirectoryWhenServingLocalHTTPThenSocketModeAndRoundTripStayCompatible(t *testing.T) {
+	dataDir, err := os.MkdirTemp("", "agentred-ipc-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dataDir) })
+	listener, err := Listen(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = Cleanup(dataDir)
+	})
+
+	info, err := os.Stat(UnixSocketPath(dataDir))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+
+	client := &http.Client{Transport: &http.Transport{DialContext: DialContext(dataDir)}}
+	response, err := client.Get("http://daemon/local/status")
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+}

--- a/internal/pkg/agentredipc/transport_windows.go
+++ b/internal/pkg/agentredipc/transport_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package agentredipc
+
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+// Endpoint returns the current data directory's opaque named-pipe path.
+func Endpoint(dataDir string) string {
+	return WindowsPipePath(dataDir)
+}
+
+// Listen creates a named pipe whose protected DACL grants full access only to
+// the Windows identity running agentred.
+func Listen(dataDir string) (net.Listener, error) {
+	securityDescriptor, err := currentUserSecurityDescriptor()
+	if err != nil {
+		return nil, err
+	}
+	return winio.ListenPipe(Endpoint(dataDir), &winio.PipeConfig{
+		SecurityDescriptor: securityDescriptor,
+	})
+}
+
+// DialContext returns an HTTP transport dialer for the local named pipe.
+func DialContext(dataDir string) func(context.Context, string, string) (net.Conn, error) {
+	path := Endpoint(dataDir)
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return winio.DialPipeContext(ctx, path)
+	}
+}
+
+// Cleanup is a no-op because closing the final named-pipe listener removes it.
+func Cleanup(string) error {
+	return nil
+}
+
+func currentUserSecurityDescriptor() (string, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+	return securityDescriptorForSID(user.User.Sid.String()), nil
+}

--- a/internal/pkg/agentredipc/transport_windows_test.go
+++ b/internal/pkg/agentredipc/transport_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package agentredipc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestGivenCurrentWindowsIdentityWhenCreatingPipeACLThenDescriptorNamesThatSIDOnly(t *testing.T) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	require.NoError(t, err)
+
+	descriptor, err := currentUserSecurityDescriptor()
+	require.NoError(t, err)
+	assert.Equal(t, securityDescriptorForSID(user.User.Sid.String()), descriptor)
+}
+
+func TestGivenWindowsDataDirectoryWhenServingLocalHTTPThenNamedPipeRoundTrips(t *testing.T) {
+	dataDir := t.TempDir()
+	listener, err := Listen(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+
+	client := &http.Client{Transport: &http.Transport{DialContext: DialContext(dataDir)}}
+	response, err := client.Get("http://daemon/local/status")
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+}

--- a/internal/pkg/keychain/file.go
+++ b/internal/pkg/keychain/file.go
@@ -40,11 +40,21 @@ func ValidateFileDir(dir string) error {
 	if perm := info.Mode().Perm(); perm != 0o700 {
 		return fmt.Errorf("keychain dir %q permissions %#o are not isolated; want 0700", dir, perm)
 	}
-	probe := filepath.Join(dir, ".keychain-probe")
-	if err := os.WriteFile(probe, []byte("probe"), 0o600); err != nil {
+	probe, err := os.CreateTemp(dir, ".keychain-probe-")
+	if err != nil {
 		return fmt.Errorf("keychain dir %q not writable: %w", dir, err)
 	}
-	if err := os.Remove(probe); err != nil {
+	probePath := probe.Name()
+	if err := probe.Chmod(0o600); err != nil {
+		_ = probe.Close()
+		_ = os.Remove(probePath)
+		return fmt.Errorf("keychain dir %q probe permissions: %w", dir, err)
+	}
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(probePath)
+		return fmt.Errorf("keychain dir %q probe close: %w", dir, err)
+	}
+	if err := os.Remove(probePath); err != nil {
 		return fmt.Errorf("keychain dir %q probe cleanup: %w", dir, err)
 	}
 	return nil

--- a/internal/pkg/keychain/file.go
+++ b/internal/pkg/keychain/file.go
@@ -65,7 +65,11 @@ func (f *fileKC) Set(account, secret string) error {
 	if err := os.MkdirAll(f.dir, 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(f.path(account), []byte(secret), 0o600)
+	path := f.path(account)
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func (f *fileKC) Delete(account string) error {

--- a/internal/pkg/keychain/file.go
+++ b/internal/pkg/keychain/file.go
@@ -2,6 +2,7 @@ package keychain
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -20,6 +21,33 @@ func NewFile(dir string) Keychain { return &fileKC{dir: dir} }
 
 func (f *fileKC) path(account string) string {
 	return filepath.Join(f.dir, account)
+}
+
+// ValidateFileDir 校验一个可作为 file keychain 存储目录的安全边界:
+//   - 必须已存在且是目录(e2e runner 以 0700 预创建;缺失 = 配置错误);
+//   - 权限必须严格 0700 —— 任何 group/other 位都视为不安全;
+//   - 当前用户必须可写(真写一发 probe 再删,当场暴露只读挂载 / 他人属主 / 只读目录)。
+//
+// 任何一项失败都返回错误:调用方(e2e bootstrap)应直接终止启动,而不是回退其他后端。
+func ValidateFileDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("keychain dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("keychain dir %q is not a directory", dir)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		return fmt.Errorf("keychain dir %q permissions %#o are not isolated; want 0700", dir, perm)
+	}
+	probe := filepath.Join(dir, ".keychain-probe")
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err != nil {
+		return fmt.Errorf("keychain dir %q not writable: %w", dir, err)
+	}
+	if err := os.Remove(probe); err != nil {
+		return fmt.Errorf("keychain dir %q probe cleanup: %w", dir, err)
+	}
+	return nil
 }
 
 func (f *fileKC) Get(account string) (string, error) {

--- a/internal/pkg/keychain/file.go
+++ b/internal/pkg/keychain/file.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 type fileKC struct {
@@ -37,7 +38,7 @@ func ValidateFileDir(dir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("keychain dir %q is not a directory", dir)
 	}
-	if perm := info.Mode().Perm(); perm != 0o700 {
+	if perm := info.Mode().Perm(); !fileDirPermissionsAreIsolated(perm, runtime.GOOS) {
 		return fmt.Errorf("keychain dir %q permissions %#o are not isolated; want 0700", dir, perm)
 	}
 	probe, err := os.CreateTemp(dir, ".keychain-probe-")
@@ -58,6 +59,14 @@ func ValidateFileDir(dir string) error {
 		return fmt.Errorf("keychain dir %q probe cleanup: %w", dir, err)
 	}
 	return nil
+}
+
+func fileDirPermissionsAreIsolated(perm fs.FileMode, goos string) bool {
+	// Windows does not expose POSIX mode bits or a meaningful umask through
+	// os.Stat, so mkdir commonly reports 0777 even though access is governed by
+	// the directory ACL. The writability probe remains the portable startup
+	// validation there; Unix-like platforms additionally enforce owner-only bits.
+	return goos == "windows" || perm == 0o700
 }
 
 func (f *fileKC) Get(account string) (string, error) {

--- a/internal/pkg/keychain/file_permissions_test.go
+++ b/internal/pkg/keychain/file_permissions_test.go
@@ -1,0 +1,19 @@
+package keychain
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGivenPlatformDirectoryModesWhenValidatingFileKeychainThenOnlyMeaningfulPermissionBitsAreEnforced(t *testing.T) {
+	t.Run("Unix rejects group or other access", func(t *testing.T) {
+		assert.False(t, fileDirPermissionsAreIsolated(fs.FileMode(0o755), "linux"))
+		assert.True(t, fileDirPermissionsAreIsolated(fs.FileMode(0o700), "darwin"))
+	})
+
+	t.Run("Windows does not reject its synthetic permission bits", func(t *testing.T) {
+		assert.True(t, fileDirPermissionsAreIsolated(fs.FileMode(0o777), "windows"))
+	})
+}

--- a/internal/pkg/keychain/keychain_test.go
+++ b/internal/pkg/keychain/keychain_test.go
@@ -54,6 +54,17 @@ func TestFile(t *testing.T) {
 		So(v, ShouldEqual, "secret")
 	})
 
+	Convey("overwriting an existing secret repairs its permissions to 0600", t, func() {
+		dir := t.TempDir()
+		secretPath := filepath.Join(dir, "acc")
+		So(os.WriteFile(secretPath, []byte("old"), 0o644), ShouldBeNil)
+		So(keychain.NewFile(dir).Set("acc", "secret"), ShouldBeNil)
+
+		info, err := os.Stat(secretPath)
+		So(err, ShouldBeNil)
+		So(info.Mode().Perm(), ShouldEqual, os.FileMode(0o600))
+	})
+
 	Convey("Get on a missing account returns ErrNotFound", t, func() {
 		dir := t.TempDir()
 		_, err := keychain.NewFile(dir).Get("missing")

--- a/internal/pkg/keychain/keychain_test.go
+++ b/internal/pkg/keychain/keychain_test.go
@@ -106,6 +106,19 @@ func TestValidateFileDir(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 
+	Convey("an existing probe-named file is preserved", t, func() {
+		dir := filepath.Join(t.TempDir(), "kc")
+		So(os.MkdirAll(dir, 0o700), ShouldBeNil)
+		probe := filepath.Join(dir, ".keychain-probe")
+		So(os.WriteFile(probe, []byte("existing"), 0o600), ShouldBeNil)
+
+		err := keychain.ValidateFileDir(dir)
+		So(err, ShouldBeNil)
+		got, readErr := os.ReadFile(probe) //nolint:gosec // G304: probe is assembled under the test's temporary directory.
+		So(readErr, ShouldBeNil)
+		So(string(got), ShouldEqual, "existing")
+	})
+
 	Convey("a directory without owner write fails", t, func() {
 		if os.Geteuid() == 0 {
 			t.Skip("running as root; permission bits do not gate writes")

--- a/internal/pkg/keychain/keychain_test.go
+++ b/internal/pkg/keychain/keychain_test.go
@@ -68,3 +68,42 @@ func TestFile(t *testing.T) {
 		So(k.Delete("acc"), ShouldEqual, keychain.ErrNotFound)
 	})
 }
+
+func TestValidateFileDir(t *testing.T) {
+	Convey("an existing 0700 directory passes", t, func() {
+		dir := filepath.Join(t.TempDir(), "kc")
+		So(os.MkdirAll(dir, 0o700), ShouldBeNil)
+		So(keychain.ValidateFileDir(dir), ShouldBeNil)
+	})
+
+	Convey("a missing directory fails", t, func() {
+		err := keychain.ValidateFileDir(filepath.Join(t.TempDir(), "does-not-exist"))
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("a file path fails", t, func() {
+		f := filepath.Join(t.TempDir(), "file")
+		So(os.WriteFile(f, []byte("x"), 0o600), ShouldBeNil)
+		err := keychain.ValidateFileDir(f)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("a group/other-accessible directory fails", t, func() {
+		dir := filepath.Join(t.TempDir(), "kc")
+		So(os.MkdirAll(dir, 0o755), ShouldBeNil)
+		err := keychain.ValidateFileDir(dir)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("a directory without owner write fails", t, func() {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root; permission bits do not gate writes")
+		}
+		dir := filepath.Join(t.TempDir(), "kc")
+		So(os.MkdirAll(dir, 0o700), ShouldBeNil)
+		So(os.Chmod(dir, 0o500), ShouldBeNil)
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+		err := keychain.ValidateFileDir(dir)
+		So(err, ShouldNotBeNil)
+	})
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,76 @@
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    throw "agentred installer: $Message"
+}
+
+$ReleaseBaseUrl = if ($env:AGENTRED_RELEASE_BASE_URL) {
+    $env:AGENTRED_RELEASE_BASE_URL.TrimEnd('/')
+} else {
+    "https://github.com/agentre-ai/agentre/releases/latest/download"
+}
+$Arch = switch ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
+    "X64" { "amd64" }
+    "Arm64" { "arm64" }
+    default { Fail "unsupported architecture: $_" }
+}
+if (-not $env:LOCALAPPDATA -and -not $env:AGENTRED_INSTALL_DIR) {
+    Fail "LOCALAPPDATA is required for user-level installation"
+}
+$InstallDir = if ($env:AGENTRED_INSTALL_DIR) {
+    $env:AGENTRED_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA "Programs\agentred"
+}
+
+$WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) ("agentred-install-" + [guid]::NewGuid())
+try {
+    New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+    $ChecksumsPath = Join-Path $WorkDir "SHA256SUMS"
+    Invoke-WebRequest -UseBasicParsing -Uri "$ReleaseBaseUrl/SHA256SUMS" -OutFile $ChecksumsPath
+
+    $AssetPattern = "^([0-9a-fA-F]{64})\s+\*?(agentred-.*-windows-$Arch\.zip)$"
+    $Checksum = $null
+    $Asset = $null
+    foreach ($Line in Get-Content -LiteralPath $ChecksumsPath) {
+        if ($Line -match $AssetPattern) {
+            $Checksum = $Matches[1].ToLowerInvariant()
+            $Asset = $Matches[2]
+            break
+        }
+    }
+    if (-not $Asset) { Fail "SHA256SUMS does not contain an agentred archive for windows/$Arch" }
+
+    $ArchivePath = Join-Path $WorkDir $Asset
+    Invoke-WebRequest -UseBasicParsing -Uri "$ReleaseBaseUrl/$Asset" -OutFile $ArchivePath
+    $Actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $ArchivePath).Hash.ToLowerInvariant()
+    if ($Actual -ne $Checksum) { Fail "SHA256 checksum mismatch for $Asset" }
+
+    $ExtractDir = Join-Path $WorkDir "extracted"
+    Expand-Archive -LiteralPath $ArchivePath -DestinationPath $ExtractDir
+    $ExtractedBinary = Join-Path $ExtractDir "agentred.exe"
+    if (-not (Test-Path -LiteralPath $ExtractedBinary -PathType Leaf)) { Fail "archive does not contain agentred.exe" }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $InstalledBinary = Join-Path $InstallDir "agentred.exe"
+    Copy-Item -LiteralPath $ExtractedBinary -Destination $InstalledBinary -Force
+
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $UserEntries = if ($UserPath) { $UserPath -split ';' } else { @() }
+    if ($UserEntries -notcontains $InstallDir) {
+        $UpdatedUserPath = if ($UserPath) { "$UserPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable("Path", $UpdatedUserPath, "User")
+    }
+    if (($env:Path -split ';') -notcontains $InstallDir) {
+        $env:Path = "$InstallDir;$env:Path"
+    }
+
+    $Identity = (& $InstalledBinary --version | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) { Fail "installed binary failed --version confirmation" }
+    if ($Identity -notlike "agentred *") { Fail "installed binary returned an unexpected version: $Identity" }
+    Write-Output "Installed agentred to $InstalledBinary"
+    Write-Output $Identity
+    Write-Output "Added $InstallDir to the user PATH. Open a new terminal to use agentred."
+} finally {
+    Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+set -eu
+
+release_base_url=${AGENTRED_RELEASE_BASE_URL:-https://github.com/agentre-ai/agentre/releases/latest/download}
+system_install_dir=${AGENTRED_SYSTEM_INSTALL_DIR:-/usr/local/bin}
+
+die() {
+  printf 'agentred installer: %s\n' "$*" >&2
+  exit 1
+}
+
+download() {
+  url=$1
+  output=$2
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$output" "$url"
+  else
+    die "curl or wget is required"
+  fi
+}
+
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  *) die "unsupported operating system: $(uname -s)" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=amd64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) die "unsupported architecture: $(uname -m)" ;;
+esac
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/agentred-install.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+checksums="$work_dir/SHA256SUMS"
+download "$release_base_url/SHA256SUMS" "$checksums"
+
+asset=$(awk -v pattern="^agentred-.*-${os}-${arch}\\.tar\\.gz$" '
+  {
+    name=$2
+    sub(/^\*/, "", name)
+    if (name ~ pattern) {
+      print name
+      exit
+    }
+  }
+' "$checksums")
+[ -n "$asset" ] || die "SHA256SUMS does not contain an agentred archive for ${os}/${arch}"
+archive="$work_dir/$asset"
+download "$release_base_url/$asset" "$archive"
+
+expected=$(awk -v wanted="$asset" '
+  {
+    name=$2
+    sub(/^\*/, "", name)
+    if (name == wanted) {
+      print tolower($1)
+      exit
+    }
+  }
+' "$checksums")
+[ -n "$expected" ] || die "SHA256 checksum is missing for $asset"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$archive" | awk '{print tolower($1)}')
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "$archive" | awk '{print tolower($1)}')
+else
+  die "sha256sum or shasum is required"
+fi
+[ "$actual" = "$expected" ] || die "SHA256 checksum mismatch for $asset"
+
+fallback=false
+if [ -n "${AGENTRED_INSTALL_DIR:-}" ]; then
+  install_dir=$AGENTRED_INSTALL_DIR
+elif { [ -d "$system_install_dir" ] && [ -w "$system_install_dir" ]; } || \
+     { [ ! -e "$system_install_dir" ] && [ -w "$(dirname "$system_install_dir")" ]; }; then
+  install_dir=$system_install_dir
+else
+  install_dir=${HOME:?HOME is required for user-level installation}/.local/bin
+  fallback=true
+fi
+mkdir -p "$install_dir"
+[ -d "$install_dir" ] && [ -w "$install_dir" ] || die "install directory is not writable: $install_dir"
+
+extract_dir="$work_dir/extracted"
+mkdir -p "$extract_dir"
+tar -xzf "$archive" -C "$extract_dir"
+[ -f "$extract_dir/agentred" ] || die "archive does not contain agentred"
+cp "$extract_dir/agentred" "$install_dir/agentred.tmp"
+chmod 755 "$install_dir/agentred.tmp"
+mv "$install_dir/agentred.tmp" "$install_dir/agentred"
+
+identity=$($install_dir/agentred --version) || die "installed binary failed --version confirmation"
+case "$identity" in
+  "agentred "*) ;;
+  *) die "installed binary returned an unexpected version: $identity" ;;
+esac
+printf 'Installed agentred to %s\n' "$install_dir/agentred"
+printf '%s\n' "$identity"
+if [ "$fallback" = true ]; then
+  printf 'Add %s to PATH, for example: export PATH="%s:$PATH"\n' "$install_dir" "$install_dir"
+fi

--- a/scripts/test-install.ps1
+++ b/scripts/test-install.ps1
@@ -1,0 +1,91 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Installer = Join-Path $PSScriptRoot "install.ps1"
+if (-not (Test-Path -LiteralPath $Installer -PathType Leaf)) {
+    throw "missing installer: $Installer"
+}
+
+$Version = "v9.8.7"
+$Commit = "abcdef1234567890"
+$Identity = "agentred $Version (abcdef1)"
+$GoArch = switch ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
+    "X64" { "amd64" }
+    "Arm64" { "arm64" }
+    default { throw "unsupported test architecture: $_" }
+}
+$Asset = "agentred-$Version-windows-$GoArch.zip"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("agentred-installer-test-" + [guid]::NewGuid())
+$ReleaseDir = Join-Path $TempRoot "release"
+$ArchiveDir = Join-Path $TempRoot "archive"
+$OriginalUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$Server = $null
+
+try {
+    New-Item -ItemType Directory -Force -Path $ReleaseDir, $ArchiveDir | Out-Null
+    $FixtureBinary = Join-Path $ArchiveDir "agentred.exe"
+    Push-Location $RepoRoot
+    try {
+        & go build "-ldflags=-s -w -X github.com/cago-frame/cago/configs.Version=$Version -X github.com/agentre-ai/agentre/internal/buildinfo.CommitID=$Commit" -o $FixtureBinary ./cmd/agentred
+        if ($LASTEXITCODE -ne 0) { throw "fixture agentred build failed" }
+    } finally {
+        Pop-Location
+    }
+
+    $Archive = Join-Path $ReleaseDir $Asset
+    Compress-Archive -LiteralPath $FixtureBinary -DestinationPath $Archive
+    $Digest = (Get-FileHash -Algorithm SHA256 -LiteralPath $Archive).Hash.ToLowerInvariant()
+    Set-Content -LiteralPath (Join-Path $ReleaseDir "SHA256SUMS") -Value "$Digest  $Asset" -Encoding ascii
+
+    $Listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $Listener.Start()
+    $Port = ([System.Net.IPEndPoint]$Listener.LocalEndpoint).Port
+    $Listener.Stop()
+    $Server = Start-Process -FilePath python -ArgumentList @("-m", "http.server", "$Port", "--bind", "127.0.0.1") -WorkingDirectory $ReleaseDir -PassThru -WindowStyle Hidden
+    $BaseUrl = "http://127.0.0.1:$Port"
+    $Ready = $false
+    foreach ($Attempt in 1..50) {
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/SHA256SUMS" | Out-Null
+            $Ready = $true
+            break
+        } catch {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    if (-not $Ready) { throw "fixture HTTP server did not start" }
+
+    $env:AGENTRED_RELEASE_BASE_URL = $BaseUrl
+    $env:LOCALAPPDATA = Join-Path $TempRoot "LocalAppData"
+    Remove-Item Env:AGENTRED_INSTALL_DIR -ErrorAction SilentlyContinue
+    $Output = (& $Installer 2>&1 | Out-String)
+    $InstalledDir = Join-Path $env:LOCALAPPDATA "Programs\agentred"
+    $InstalledBinary = Join-Path $InstalledDir "agentred.exe"
+    if (-not (Test-Path -LiteralPath $InstalledBinary -PathType Leaf)) { throw "agentred.exe was not installed to the user-level destination" }
+    $Reported = (& $InstalledBinary --version | Out-String).Trim()
+    if ($Reported -ne $Identity) { throw "unexpected installed identity: $Reported" }
+    if (-not $Output.Contains($Identity)) { throw "installer did not confirm --version output" }
+    $UpdatedUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (($UpdatedUserPath -split ';') -notcontains $InstalledDir) { throw "installer did not add its user-level destination to user PATH" }
+
+    Set-Content -LiteralPath (Join-Path $ReleaseDir "SHA256SUMS") -Value (('0' * 64) + "  $Asset") -Encoding ascii
+    $env:AGENTRED_INSTALL_DIR = Join-Path $TempRoot "mismatch-bin"
+    $Rejected = $false
+    try {
+        & $Installer *> (Join-Path $TempRoot "mismatch.out")
+    } catch {
+        $Rejected = $_.Exception.Message -match "checksum|SHA-?256"
+    }
+    if (-not $Rejected) { throw "installer did not reject a checksum mismatch with a checksum error" }
+    if (Test-Path -LiteralPath (Join-Path $env:AGENTRED_INSTALL_DIR "agentred.exe")) { throw "mismatched binary was installed" }
+
+    Write-Output "install.ps1 fixture tests passed"
+} finally {
+    [Environment]::SetEnvironmentVariable("Path", $OriginalUserPath, "User")
+    if ($null -ne $Server -and -not $Server.HasExited) {
+        Stop-Process -Id $Server.Id -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item Env:AGENTRED_RELEASE_BASE_URL -ErrorAction SilentlyContinue
+    Remove-Item Env:AGENTRED_INSTALL_DIR -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+installer="$repo_root/scripts/install.sh"
+if [[ ! -f "$installer" ]]; then
+  echo "missing installer: $installer" >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  Darwin) goos=darwin ;;
+  Linux) goos=linux ;;
+  *) echo "unsupported test host: $(uname -s)" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) goarch=amd64 ;;
+  arm64|aarch64) goarch=arm64 ;;
+  *) echo "unsupported test architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+version=v9.8.7
+commit=abcdef1234567890
+identity="agentred $version (abcdef1)"
+asset="agentred-$version-$goos-$goarch.tar.gz"
+tmp=$(mktemp -d)
+server_pid=
+cleanup() {
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp/release"
+(
+  cd "$repo_root"
+  make agentred-package \
+    VERSION="$version" \
+    COMMIT_ID="$commit" \
+    AGENTRED_GOOS="$goos" \
+    AGENTRED_GOARCH="$goarch" \
+    AGENTRED_DIST_DIR="$tmp/release"
+)
+if command -v sha256sum >/dev/null 2>&1; then
+  digest=$(sha256sum "$tmp/release/$asset" | awk '{print $1}')
+else
+  digest=$(shasum -a 256 "$tmp/release/$asset" | awk '{print $1}')
+fi
+printf '%s  %s\n' "$digest" "$asset" > "$tmp/release/SHA256SUMS"
+
+port=$(python3 - <<'PY'
+import socket
+with socket.socket() as s:
+    s.bind(('127.0.0.1', 0))
+    print(s.getsockname()[1])
+PY
+)
+python3 -m http.server "$port" --bind 127.0.0.1 --directory "$tmp/release" >"$tmp/http.log" 2>&1 &
+server_pid=$!
+base_url="http://127.0.0.1:$port"
+for _ in $(seq 1 50); do
+  if curl -fsS "$base_url/SHA256SUMS" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+curl -fsS "$base_url/SHA256SUMS" >/dev/null
+
+explicit_dir="$tmp/explicit-bin"
+explicit_output=$(AGENTRED_RELEASE_BASE_URL="$base_url" AGENTRED_INSTALL_DIR="$explicit_dir" sh "$installer")
+[[ -x "$explicit_dir/agentred" ]]
+[[ "$($explicit_dir/agentred --version)" == "$identity" ]]
+grep -F "$identity" <<<"$explicit_output" >/dev/null
+
+home_dir="$tmp/home"
+unwritable_candidate="$tmp/not-a-directory"
+printf 'occupied' > "$unwritable_candidate"
+fallback_output=$(HOME="$home_dir" AGENTRED_RELEASE_BASE_URL="$base_url" \
+  AGENTRED_SYSTEM_INSTALL_DIR="$unwritable_candidate" sh "$installer")
+fallback_binary="$home_dir/.local/bin/agentred"
+[[ -x "$fallback_binary" ]]
+[[ "$($fallback_binary --version)" == "$identity" ]]
+grep -F "$home_dir/.local/bin" <<<"$fallback_output" >/dev/null
+
+printf '%064d  %s\n' 0 "$asset" > "$tmp/release/SHA256SUMS"
+mismatch_dir="$tmp/mismatch-bin"
+if AGENTRED_RELEASE_BASE_URL="$base_url" AGENTRED_INSTALL_DIR="$mismatch_dir" sh "$installer" >"$tmp/mismatch.out" 2>&1; then
+  echo "installer accepted a checksum mismatch" >&2
+  exit 1
+fi
+[[ ! -e "$mismatch_dir/agentred" ]]
+grep -Ei 'checksum|sha-?256' "$tmp/mismatch.out" >/dev/null
+
+echo "install.sh fixture tests passed"

--- a/scripts/test-release-workflows.py
+++ b/scripts/test-release-workflows.py
@@ -73,6 +73,10 @@ def main() -> None:
     for token in ("scripts/test-install.sh", "scripts/test-install.ps1", "scripts/test-release-workflows.py"):
         if token not in ci:
             raise AssertionError(f"CI does not run {token}")
+    windows = job_block(ci, "agentred-installer-windows")
+    for package in ("./cmd/agentred", "./internal/pkg/agentredipc"):
+        if package not in windows:
+            raise AssertionError(f"Windows CI does not run the platform tests in {package}")
 
     print("release workflow contract tests passed")
 

--- a/scripts/test-release-workflows.py
+++ b/scripts/test-release-workflows.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+PLATFORMS = {
+    "darwin-amd64",
+    "darwin-arm64",
+    "linux-amd64",
+    "linux-arm64",
+    "windows-amd64",
+    "windows-arm64",
+}
+def job_block(text: str, name: str) -> str:
+    match = re.search(rf"^  {re.escape(name)}:\n", text, re.MULTILINE)
+    if not match:
+        raise AssertionError(f"missing job {name}")
+    next_job = re.search(r"^  [a-zA-Z0-9_-]+:\n", text[match.end():], re.MULTILINE)
+    end = match.end() + next_job.start() if next_job else len(text)
+    return text[match.start():end]
+
+
+def check_workflow(path: str, prefix: str) -> None:
+    text = (ROOT / path).read_text()
+    if "-X agentre/internal/buildinfo.CommitID" in text:
+        raise AssertionError(f"{path} still uses the abbreviated buildinfo ldflag target")
+
+    build = job_block(text, "build-agentred")
+    found = set(re.findall(r"platform:\s*(darwin|linux|windows)-(amd64|arm64)", build))
+    found = {"-".join(parts) for parts in found}
+    if found != PLATFORMS:
+        raise AssertionError(f"{path} agentred matrix is {sorted(found)}, want {sorted(PLATFORMS)}")
+    for token in (
+        "make agentred-package",
+        "AGENTRED_GOOS=${{ matrix.goos }}",
+        "AGENTRED_GOARCH=${{ matrix.goarch }}",
+        f"name: {prefix}-agentred-${{{{ matrix.platform }}}}",
+        "path: build/agentred-dist/*",
+    ):
+        if token not in build:
+            raise AssertionError(f"{path} build-agentred job missing {token!r}")
+
+    release = job_block(text, "release")
+    for token in (
+        "build-agentred",
+        "scripts/install.sh",
+        "scripts/install.ps1",
+        "> SHA256SUMS",
+        "cp SHA256SUMS SHA256SUMS.txt",
+        "cmp SHA256SUMS SHA256SUMS.txt",
+    ):
+        if token not in release:
+            raise AssertionError(f"{path} release job missing {token!r}")
+    if prefix == "nightly" and "releases/download/nightly" not in release:
+        raise AssertionError(f"{path} nightly installers do not target the nightly release channel")
+
+
+def main() -> None:
+    makefile = (ROOT / "Makefile").read_text()
+    for token in (
+        "BUILDINFO_PKG := github.com/agentre-ai/agentre/internal/buildinfo",
+        "-X $(BUILDINFO_PKG).CommitID=$(COMMIT_ID)",
+        "agentred-package:",
+        "agentred-$(VERSION)-$(AGENTRED_GOOS)-$(AGENTRED_GOARCH)",
+    ):
+        if token not in makefile:
+            raise AssertionError(f"Makefile missing {token!r}")
+
+    check_workflow(".github/workflows/release.yml", "release")
+    check_workflow(".github/workflows/nightly.yml", "nightly")
+
+    ci = (ROOT / ".github/workflows/ci.yml").read_text()
+    for token in ("scripts/test-install.sh", "scripts/test-install.ps1", "scripts/test-release-workflows.py"):
+        if token not in ci:
+            raise AssertionError(f"CI does not run {token}")
+
+    print("release workflow contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更说明 / Summary

完成 agentred 跨平台安装、用户级后台服务和桌面端三步引导，并收尾真实运行中发现的服务生命周期与 e2e 凭据隔离问题。

- 为 macOS LaunchAgent、Linux `systemd --user` 和 Windows Task Scheduler 提供 agentred 用户级服务管理。
- 增加 Unix socket / Windows named pipe 本地状态 IPC、稳定的构建身份与 `--version`。
- 增加 POSIX / PowerShell 安装器、checksum 校验及 release/nightly 资产发布。
- 在 Remote Devices 中增加安装、启动、配对三步引导和错误恢复。
- macOS 已加载 job 使用 launchd 原生 kickstart/restart；启动等待 launchd 与本地 daemon 就绪。
- 将 launchd `xpcproxy` 识别为正常启动过渡态，并忽略活跃启动期间的历史非零 exit code。
- e2e bootstrap 在 Server/Remote Device 装配前选择并验证隔离 file keychain；无效目录 fail closed，不回退生产 system keychain。

## 关联 Issue / Related Issue

无关联 Issue。

## 截图 / Screenshots

真实 Wails e2e 已验证 Remote Devices 配对后显示 `1 paired · 1 online`，并完成 Agent Backends 跳转。验收截图和完整运行记录保存在本地 ignored evidence：

`e2e/scratch/2026-08-12-agentred-service-runtime-fixes/report.md`

## 真机验收 / Runtime verification

最终 reviewed HEAD：`22658f24c95432152589f40bce6337d30687c9f6`

- **macOS LaunchAgent：通过**
  - foreground config → install/start → status → restart → stop → start → uninstall
  - restart PID：`96484 → 96576`
  - 未出现 `Local status unavailable`、`Bootstrap failed: 5` 或 `xpcproxy` false failure
  - plist、job、进程、端口和临时目录已清理
- **Debian 12 amd64 / `local-coding`：通过**
  - 完整 `systemd --user` 生命周期通过
  - restart PID：`569727 → 569765`
  - unit、进程、端口和远端临时目录已清理
- **真实 Wails → Linux daemon 配对：通过**
  - watcher 达到 `1 paired · 1 online`
  - 隔离 keychain 目录 `0700`，secret 文件 `0600`
  - 生产 system keychain 前后 hash diff 为空

## 测试 / Tests

- `GOWORK=off make check`
  - backend tests / lint passed
  - frontend: 245 files, 2566 tests passed
- focused launchd race tests passed
- e2e-tagged bootstrap/keychain/harness tests passed
- Linux amd64 and Windows amd64 cross-compilation passed
- independent spec and code review axes passed with no standing findings

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试
