### PR TITLE
✨ 聊天转录支持会话内本地 Markdown 图片

### DIFF
--- a/docs/specs/2026-08-13-markdown-local-image.md
+++ b/docs/specs/2026-08-13-markdown-local-image.md
@@ -1,0 +1,102 @@
+# 聊天转录 markdown 本地图片渲染
+
+> Status: Draft
+> Owner: chat experience / frontend
+> Last updated: 2026-08-13
+
+**Objective:** 让聊天转录里的 markdown 引用的本地图片（相对 / 绝对 / file:// 路径，落在会话工作目录内）以内联图片渲染出来，复用会话级文件读取；同时**不改变链接白名单的安全边界**。
+
+**Hard invariants:**
+
+1. **链接白名单逐字节不回归。** `href`（链接）的放行规则与今天完全一致：相对 href 仍被剥掉、`javascript:` / `data:` 仍被剥掉。本次只放宽图片 `src`，且必须由 `img` 组件兜住，原始相对 `src` 不得落到 DOM 的 `<img src>` 上。
+2. **自动读取只发生在「本地路径 + 有会话上下文 + 解析后落在 cwd 内 + 图片扩展名 allowlist」四条件同时满足时。** 前端分类只是 UX 预判，真正的边界由后端 `WorkspaceFsReadFile → workspacefs.ReadFile` 强制（cwd 内 + 符号链接防逃逸 + 图片扩展名 allowlist + 10 MiB 上限），前端不可绕过。
+3. **本地图片的「自动读取」与「点击打开」共用同一条 cwd 边界**：落在 cwd 内才允许读、才允许点；越出 cwd 或无法解析（无 cwd + 相对路径）一律不读、不可点。
+4. **无会话上下文的调用点行为不变。** 文件预览面板的 markdown 档、计划卡等不传 `sessionId` 的 `MarkdownText` 用法，本地图片仍不渲染（与今天一致）。
+5. **远程图片现状不变。** `http(s)` / `www.` 图片直接渲染 `<img>`；`data:` 图片维持现状不放开。
+6. **后端 / wire / 迁移零改动。** 本轮是纯前端改动，复用既有 `WorkspaceFsReadFile` 绑定。
+7. **新增 UI 文案走 i18n**，`zh-CN` 与 `en` 双语，由 `frontend/src/__tests__/i18n.test.ts` 守卫；新增渲染组件并入对话流排版护栏的扫描清单。
+
+## Problem
+
+1. **相对路径图片被 URL 白名单剥掉 `src`，导致不渲染。** `frontend/src/components/agentre/markdown-text.tsx:125-143` 的 `whitelistUrl` 只放行 `http/https/mailto/tel/file/www/绝对 POSIX/绝对 Windows`，相对路径返回 `""`；该函数作为 `urlTransform={whitelistUrl}`（`markdown-text.tsx:348`）传给 react-markdown，而 react-markdown v10 会把 `urlTransform` 应用到 `img` 的 `src`（`html-url-attributes` 的 `urlAttributes.src` 包含 `img`）。
+2. **绝对路径 / file:// 图片虽不被剥 `src`，但没有 `img` 渲染组件。** `markdownComponentsStatic` 只定义了 `a`（交给 `RichLink`），没有 `img`，react-markdown 默认渲染 `<img src="/abs/...">`，在 Wails webview 里无法加载本地文件系统路径。
+3. **真实证据：** 会话 sess-2893（`projects.id=2`，cwd=`/Users/codfrm/Code/agentre/agentre`）的 assistant 消息 21064 末段 text block 里含 `![会话右侧文件语言图标 Mockup](.dev-kit/artifacts/2026-08-13-session-file-icons/mockups/Y0cnD.png)`，该文件确实存在，但前端不显示图片。
+
+## Actors and user stories
+
+1. 作为**查看 agent 生成的本地 mockup / 截图引用的用户**，我要在聊天里直接看到图片，而不是一个失效的图片占位。
+2. 作为**agent**，我要能用 markdown 相对路径引用会话工作目录里的图片，并让用户直接看到结果。
+3. 作为**读旧转录的用户**，我要本地图片的显示行为稳定可预期：能显示的显示、不能显示的有明确的「无法预览」兜底，而不是静默消失。
+
+## Design decisions
+
+| # | Decision | Basis and rejected option |
+|---|---|---|
+| 1 | 复用既有 `WorkspaceFsReadFile(sessionId, relPath)` 读取本地图片，转成 `data:${contentType};base64,${content}` 渲染 | 后端已具备完整边界：`workspacefs.ReadFile`（`internal/pkg/workspacefs/readfile.go`）强制 cwd 内 + 符号链接防逃逸 + 图片扩展名 allowlist + 10 MiB 上限；本机 / 远端会话走同一绑定（`App.d.ts:387`），文件预览面板已用它渲染图片（`file-preview-panel.tsx:401`）。Rejected: 直接 `file://` 当 `src` —— webview 加载不了本地路径，且丢失 cwd 边界与远端会话能力；Rejected: 前端新建文件读取绑定 —— 违背「Wails 绑定只做 parse→svc→return」的既有分层 |
+| 2 | 范围仅限聊天转录的 markdown 图片（`sessionId` 存在时）；文件预览 markdown 档、计划卡等不传 `sessionId` 的调用点行为不变 | 本次 bug 在聊天转录。文件预览的 markdown 有自己不同的解析上下文（相对其所在 `.md` 的目录），一并修会扩大范围。Rejected: 顺带修文件预览 markdown 的图片 —— 解析基准不同，是另一个 feature |
+| 3 | 图片按 src 分成四档：`remote`（http/https/www，原样 `<img>`）、`plain`（空 / data: / javascript: / 其它协议，或本地路径但无会话上下文，原样 `<img>` 且 src 剥空）、`fetch`（本地路径 + 有 sessionId + 落在 cwd 内 + 图片扩展名，读取渲染）、`fallback`（本地路径 + 有 sessionId 但越出 cwd / 非图片扩展名 / 无法解析，渲染兜底 chip） | 用户已裁定失败兜底为 chip（选项 A）。分档让「维持现状」与「新增能力」边界清晰。Rejected: 只做 fetch / 其它，不做 fallback —— 失败会静默消失，违背 user story 3 |
+| 4 | `whitelistUrl` 变为按 `key` 区分：仅当 `key === "src"` 时放行相对路径，`href` 分支逐字节不变 | react-markdown 在渲染组件前就地把 `urlTransform` 结果写进 `node.properties.src`，组件拿不到原始相对 src；唯一入口是让 `urlTransform` 对 src 放行。Rejected: 全局放行相对路径 —— 会连带放宽链接（href）并改变其安全边界（Hard invariant 1） |
+| 5 | 图片扩展名 allowlist 复用后端 / 前端已对齐的同一份（`previewKind(path) === "image"`） | 前端 `previewable.ts:107` 的 `previewKind` 与后端 `readfile.go:116` 的 `imageMIME` 是同一份 allowlist（png/jpg/jpeg/gif/webp/avif/bmp/ico/svg），单一事实源，避免前端预判与后端判定分叉 |
+| 6 | 本地图片的读取与点击打开共用 cwd 边界：落在 cwd 内才读、才可点；越出 cwd / 无法解析则不可点 | 与「变动」模式预览按钮的既有边界一致（`previewable.ts:154` `resolvePreviewRelPath`：绝对路径越出 cwd 一律不出预览）。Rejected: 越出 cwd 的绝对路径也可点击打开 —— 用户裁定「越界时不可点」 |
+
+## 本地图片的分类与渲染
+
+markdown 中每个图片，按 `src`（`alt` 作回退文本）分成四档，可观察行为如下：
+
+- **remote**（`http://` / `https://` / `www.`）：原样渲染 `<img src="…" alt="…">`，与今天完全一致。
+- **plain**（`src` 为空，或 `data:` / `javascript:` 等非本地、非 http 协议，或**本地路径但无会话上下文**）：原样渲染 `<img>`，其中本地相对路径的 `src` 保持剥空——即文件预览 markdown 档、计划卡等处的本地图片仍不渲染，与今天一致。
+- **fetch**（本地路径 + 有 `sessionId` + 解析后落在 cwd 内 + 扩展名是图片 allowlist）：调 `WorkspaceFsReadFile(sessionId, relPath)`，成功后渲染 `<img src={`data:${contentType};base64,${content}`} alt="…">`。
+- **fallback**（本地路径 + 有 `sessionId`，但越出 cwd / 非图片扩展名 / 无 cwd 无法解析）：渲染兜底 chip（见下）。
+
+本地路径的识别与解析复用既有规则：`file://` 还原为路径、绝对 POSIX / 绝对 Windows 直接用、相对路径经 cwd 解析（`toRelPath`，`previewable.ts:129`）。非 ASCII / 空格经 markdown 百分号编码时先解码（与 `link-classify.ts` 的 `decodeLocalPath` 同源）。
+
+`fetch` 档的读取中显示 muted 占位（不闪动布局）；读取结果 `tooLarge` 或 `binary` 或读取失败时，不渲染图片，改渲染兜底 chip。
+
+## 失败兜底 chip
+
+不可预览的本地图片渲染为内联 chip，形态对齐现有文件引用 chip：`[文件图标] 文件名 · 无法预览`；`tooLarge` 时状态文本为「图片过大」。可观察行为：
+
+- **可点**：当且仅当路径解析后落在会话 cwd 内（相对路径经 cwd 解析、绝对路径已在 cwd 内、file:// 已在 cwd 内）。点击调 `OpenPath(绝对路径)` 用默认应用打开文件。
+- **不可点**：无 cwd 的相对路径，或绝对路径越出 cwd。chip 退化为纯文本，不响应点击。
+
+「无法预览」与「图片过大」两种原因对用户可区分；文件名来自 src 的 basename，是动态内容，不进 i18n。
+
+## 安全边界
+
+自动读取仅发生在 `fetch` 档。前端分类（`previewKind` + `toRelPath`）只决定「读不读」与「显示哪种兜底」，是 UX 预判；真正不可绕过的边界是后端 `workspacefs.ReadFile`：cwd 内校验（含 `..` / 绝对路径 / 符号链接跟随后的重校验，拒绝为 `ErrPathRefused`）、图片扩展名 allowlist、图片 10 MiB 上限。前端任何路径伪造都会被后端拦下。
+
+`href` 白名单在本轮不变：相对链接、`javascript:`、`data:` 的既有处理原样保留。图片 `src` 的放行只发生在 `urlTransform` 的 `src` 分支，且 `img` 组件恒被注册，原始相对 `src` 不会落到 DOM `<img>` 元素上。
+
+## 可访问性
+
+兜底 chip 可点时是原生 `button`，可 Tab 聚焦、带 `focus-visible` 的既有 ring 样式；不可点时是纯文本，不提供误导性焦点。渲染出的图片保留 `alt`（来自 markdown 图片的 alt 文本）。占位与状态颜色不承载唯一语义（状态有文字冗余）。
+
+## Out of scope
+
+- **`data:` 图片**：维持现状不放开。
+- **http/https 图片**：维持现状直接渲染，不做点击打开、不下载、不代理。
+- **相对链接（href）**：维持现状（被剥掉）。
+- **文件预览面板 markdown 档、计划卡里的图片**：维持现状（不传 `sessionId`，本地图片不渲染）。
+- **点击放大 / 灯箱 / 下载**：渲染出的图片不做交互。
+- **后端 / wire / 迁移**：零改动。
+
+## Testing decisions
+
+| Seam | What it verifies | Prior art |
+|---|---|---|
+| 图片分类纯函数（四档判定） | remote / plain / fetch / fallback 各档命中；相对路径 + cwd + 图片扩展名 → fetch；相对路径 + 非图片扩展名 → fallback（可点）；绝对路径越出 cwd → fallback（不可点）；无 cwd + 相对路径 → fallback（不可点）；`data:` / `javascript:` / 空 → plain；无 sessionId → plain；file:// 还原；非 ASCII 解码 | 无（新增）；解析规则与 `link-classify.test.ts` 同源，可参照 |
+| `whitelistUrl` 回归 | href 相对路径仍剥掉、`javascript:` 仍剥掉、`https` 保留；src 相对路径放行、src `data:` 仍剥掉 | `markdown-text.test.tsx` 的「URL whitelist」describe |
+| `MarkdownText` 组件测试 | 本地图片（mock `WorkspaceFsReadFile`）渲染为 data URL `<img>`；读取失败 / tooLarge / binary 渲染兜底 chip；remote 图片原样 `<img>`；chip 可点 / 不可点与 openPath 一致 | `markdown-text.test.tsx` |
+| i18n 守卫 | 新增「无法预览」「图片过大」zh-CN / en 双语齐全，无硬编码中文 | `frontend/src/__tests__/i18n.test.ts` |
+| 排版守卫 | 新增组件进入 `transcript-typography-guard.test.ts` 的 SCANNED 清单，不引入被 token 取代的字面量 | `frontend/src/components/agentre/__tests__/transcript-typography-guard.test.ts` |
+
+**不适合自动化的部分：** chip 在对话流里的视觉协调、以及真实会话（sess-2893）里 mockup 图片确实渲染出来，由收尾时按 `docs/verification.md` 驱动真实应用观察并留证据；`WorkspaceFsReadFile` 的远端会话路径由既有的后端测试覆盖，本轮不新增。
+
+## Links
+
+- 根因证据（只读排查，非本轮产物）：sess-2893 消息 21064（本地 `agentre.db`，`chat_messages.blocks_json`）
+- 图片读取实现：`internal/pkg/workspacefs/readfile.go`
+- 会话级文件读取绑定：`frontend/wailsjs/go/app/App.d.ts` 的 `WorkspaceFsReadFile`
+- 文件预览图片渲染参考：`frontend/src/components/agentre/file-preview/file-preview-panel.tsx`
+- 路径判定参考：`frontend/src/lib/link-classify.ts`、`frontend/src/components/agentre/chat-context-sidebar/previewable.ts`
+- 前端硬规则：`docs/frontend.md`（shadcn / i18n / lint）

--- a/frontend/src/components/agentre/__tests__/transcript-typography-guard.test.ts
+++ b/frontend/src/components/agentre/__tests__/transcript-typography-guard.test.ts
@@ -34,6 +34,7 @@ export const SCANNED: { file: string; skip?: RuleGroup[] }[] = [
   // 姓名首字母字形,不是正文/元信息文字。那是头像专属尺寸,不归 12px text-meta 管。
   { file: "message-row.tsx", skip: ["type"] },
   { file: "markdown-text.tsx" },
+  { file: "markdown-image.tsx" },
   { file: "code-block.tsx" },
   { file: "thinking-block.tsx" },
   // collapsible-code.tsx 是卡片共用的长内容滚动块。复制角标按钮用 rounded

--- a/frontend/src/components/agentre/markdown-image.test.tsx
+++ b/frontend/src/components/agentre/markdown-image.test.tsx
@@ -103,6 +103,38 @@ describe("classifyMarkdownImage", () => {
     });
   });
 
+  it("resolves file://localhost to a local path", () => {
+    expect(
+      classifyMarkdownImage("file://localhost/proj/a.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "a.png",
+      absolutePath: "/proj/a.png",
+      basename: "a.png",
+    });
+  });
+
+  it("does not treat a file:// URL with a remote host as a local path", () => {
+    expect(
+      classifyMarkdownImage("file://server/share/a.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({ kind: "plain", src: "file://server/share/a.png" });
+  });
+
+  it("classifies a protocol-relative image URL as remote", () => {
+    expect(
+      classifyMarkdownImage("//cdn.example.com/a.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({ kind: "remote", src: "//cdn.example.com/a.png" });
+  });
+
   it("classifies a non-image extension as fallback (clickable inside cwd)", () => {
     expect(
       classifyMarkdownImage("notes.txt", { cwd: "/proj", sessionId: 7 }),
@@ -200,6 +232,28 @@ describe("MarkdownImage", () => {
     );
     const img = await screen.findByRole("img");
     expect(img.getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
+  });
+
+  it("resets to loading when the image relPath changes", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValueOnce({
+      content: "aGVsbG8=",
+      contentType: "image/png",
+    });
+    const { rerender } = render(
+      <MarkdownImage src="a.png" cwd="/proj" sessionId={7} alt="A" />,
+    );
+    await screen.findByRole("img");
+
+    appMocks.WorkspaceFsReadFile.mockResolvedValue({
+      content: "d29ybGQ=",
+      contentType: "image/png",
+    });
+    rerender(<MarkdownImage src="b.png" cwd="/proj" sessionId={7} alt="A" />);
+    expect(screen.queryByRole("img")).toBeNull();
+    await screen.findByRole("img");
+    expect(screen.getByRole("img").getAttribute("src")).toBe(
+      "data:image/png;base64,d29ybGQ=",
+    );
   });
 
   it("renders a tooLarge result as the tooLarge chip", async () => {

--- a/frontend/src/components/agentre/markdown-image.test.tsx
+++ b/frontend/src/components/agentre/markdown-image.test.tsx
@@ -6,6 +6,12 @@ const appMocks = vi.hoisted(() => ({
   OpenPath: vi.fn(),
 }));
 
+const sonnerMocks = vi.hoisted(() => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("sonner", () => sonnerMocks);
+
 vi.mock("@/../wailsjs/go/app/App", () => ({
   WorkspaceFsReadFile: appMocks.WorkspaceFsReadFile,
   OpenPath: appMocks.OpenPath,
@@ -17,6 +23,7 @@ beforeEach(() => {
   appMocks.WorkspaceFsReadFile.mockReset();
   appMocks.OpenPath.mockReset();
   appMocks.OpenPath.mockResolvedValue(undefined);
+  sonnerMocks.toast.error.mockReset();
 });
 
 describe("classifyMarkdownImage", () => {
@@ -61,6 +68,15 @@ describe("classifyMarkdownImage", () => {
     expect(classifyMarkdownImage("/abs/a.png", {})).toEqual({
       kind: "plain",
       src: "/abs/a.png",
+    });
+  });
+
+  it("treats a non-positive sessionId as absent instead of calling the workspace API", () => {
+    expect(
+      classifyMarkdownImage("a.png", { cwd: "/proj", sessionId: 0 }),
+    ).toEqual({
+      kind: "plain",
+      src: undefined,
     });
   });
 
@@ -117,13 +133,41 @@ describe("classifyMarkdownImage", () => {
     });
   });
 
-  it("does not treat a file:// URL with a remote host as a local path", () => {
+  it("strips a file:// URL with a remote host instead of auto-loading a network share", () => {
     expect(
       classifyMarkdownImage("file://server/share/a.png", {
         cwd: "/proj",
         sessionId: 7,
       }),
-    ).toEqual({ kind: "plain", src: "file://server/share/a.png" });
+    ).toEqual({ kind: "plain", src: undefined });
+  });
+
+  it("resolves a localhost file URL with a Windows drive path", () => {
+    expect(
+      classifyMarkdownImage("file://localhost/C:/Users/x/a.png", {
+        cwd: "C:\\Users\\x",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "a.png",
+      absolutePath: "C:/Users/x/a.png",
+      basename: "a.png",
+    });
+  });
+
+  it("matches Windows absolute paths case-insensitively and across slash styles", () => {
+    expect(
+      classifyMarkdownImage("c:/USERS/x/a.png", {
+        cwd: "C:\\Users\\x",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "a.png",
+      absolutePath: "c:/USERS/x/a.png",
+      basename: "a.png",
+    });
   });
 
   it("classifies a protocol-relative image URL as remote", () => {
@@ -198,6 +242,32 @@ describe("classifyMarkdownImage", () => {
       basename: "secret.png",
     });
   });
+
+  it("classifies a Windows rooted path (\\foo) as fallback (not read, not clickable)", () => {
+    expect(
+      classifyMarkdownImage("\\Windows\\a.png", {
+        cwd: "C:\\Users\\x",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "a.png",
+    });
+  });
+
+  it("classifies a UNC path (\\\\server\\share) as fallback (not read, not clickable)", () => {
+    expect(
+      classifyMarkdownImage("\\\\server\\share\\a.png", {
+        cwd: "C:\\Users\\x",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "a.png",
+    });
+  });
 });
 
 describe("MarkdownImage", () => {
@@ -256,6 +326,62 @@ describe("MarkdownImage", () => {
     );
   });
 
+  it("resets to loading when the session changes for the same relPath", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValueOnce({
+      content: "c2Vzc2lvbi03",
+      contentType: "image/png",
+    });
+    const { rerender } = render(
+      <MarkdownImage src="a.png" cwd="/proj" sessionId={7} alt="A" />,
+    );
+    await screen.findByRole("img");
+
+    let resolveSecond:
+      | ((value: { content: string; contentType: string }) => void)
+      | undefined;
+    appMocks.WorkspaceFsReadFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+    );
+    rerender(<MarkdownImage src="a.png" cwd="/proj" sessionId={8} alt="A" />);
+
+    expect(appMocks.WorkspaceFsReadFile).toHaveBeenLastCalledWith(8, "a.png");
+    expect(screen.queryByRole("img")).toBeNull();
+    resolveSecond?.({ content: "c2Vzc2lvbi04", contentType: "image/png" });
+    await screen.findByRole("img");
+    expect(screen.getByRole("img").getAttribute("src")).toBe(
+      "data:image/png;base64,c2Vzc2lvbi04",
+    );
+  });
+
+  it("refetches when cwd changes for the same session and relPath", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValueOnce({
+      content: "cHJvai0x",
+      contentType: "image/png",
+    });
+    const { rerender } = render(
+      <MarkdownImage src="a.png" cwd="/proj-1" sessionId={7} alt="A" />,
+    );
+    await screen.findByRole("img");
+
+    appMocks.WorkspaceFsReadFile.mockResolvedValueOnce({
+      content: "cHJvai0y",
+      contentType: "image/png",
+    });
+    rerender(<MarkdownImage src="a.png" cwd="/proj-2" sessionId={7} alt="A" />);
+
+    await waitFor(() =>
+      expect(appMocks.WorkspaceFsReadFile).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("img").getAttribute("src")).toBe(
+        "data:image/png;base64,cHJvai0y",
+      ),
+    );
+  });
+
   it("renders a tooLarge result as the tooLarge chip", async () => {
     appMocks.WorkspaceFsReadFile.mockResolvedValue({
       content: "",
@@ -297,6 +423,19 @@ describe("MarkdownImage", () => {
     expect(button).toHaveTextContent("Cannot preview");
     fireEvent.click(button);
     expect(appMocks.OpenPath).toHaveBeenCalledWith("/proj/notes.txt");
+  });
+
+  it("reports an OpenPath rejection instead of silently swallowing it", async () => {
+    appMocks.OpenPath.mockRejectedValueOnce(new Error("denied"));
+    render(<MarkdownImage src="notes.txt" cwd="/proj" sessionId={7} alt="A" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() =>
+      expect(sonnerMocks.toast.error).toHaveBeenCalledWith(
+        "Open failed: denied",
+      ),
+    );
   });
 
   it("renders an outside-cwd fallback chip as inert text (no button, no open)", () => {

--- a/frontend/src/components/agentre/markdown-image.test.tsx
+++ b/frontend/src/components/agentre/markdown-image.test.tsx
@@ -140,6 +140,32 @@ describe("classifyMarkdownImage", () => {
       basename: "secret.png",
     });
   });
+
+  it("classifies an absolute path with .. escaping cwd as fallback (not read, not clickable)", () => {
+    expect(
+      classifyMarkdownImage("/proj/../secret.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "secret.png",
+    });
+  });
+
+  it("classifies a file:// path with .. escaping cwd as fallback (not read, not clickable)", () => {
+    expect(
+      classifyMarkdownImage("file:///proj/../secret.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "secret.png",
+    });
+  });
 });
 
 describe("MarkdownImage", () => {
@@ -232,6 +258,21 @@ describe("MarkdownImage", () => {
   it("does not read a .. traversal that escapes cwd (inert chip)", () => {
     const { container } = render(
       <MarkdownImage src="../secret.png" cwd="/proj" sessionId={7} alt="A" />,
+    );
+    expect(container.textContent).toContain("secret.png");
+    expect(container.textContent).toContain("Cannot preview");
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(appMocks.WorkspaceFsReadFile).not.toHaveBeenCalled();
+  });
+
+  it("does not read an absolute path with .. escaping cwd (inert chip)", () => {
+    const { container } = render(
+      <MarkdownImage
+        src="/proj/../secret.png"
+        cwd="/proj"
+        sessionId={7}
+        alt="A"
+      />,
     );
     expect(container.textContent).toContain("secret.png");
     expect(container.textContent).toContain("Cannot preview");

--- a/frontend/src/components/agentre/markdown-image.test.tsx
+++ b/frontend/src/components/agentre/markdown-image.test.tsx
@@ -131,12 +131,11 @@ describe("classifyMarkdownImage", () => {
     });
   });
 
-  it("keeps .. traversal out of the clickable absolutePath (backend rejects the read)", () => {
+  it("classifies .. traversal that escapes cwd as fallback (not read, not clickable)", () => {
     expect(
       classifyMarkdownImage("../secret.png", { cwd: "/proj", sessionId: 7 }),
     ).toEqual({
-      kind: "fetch",
-      relPath: "../secret.png",
+      kind: "fallback",
       absolutePath: null,
       basename: "secret.png",
     });
@@ -228,5 +227,15 @@ describe("MarkdownImage", () => {
     expect(container.textContent).toContain("Cannot preview");
     expect(screen.queryByRole("button")).toBeNull();
     expect(appMocks.OpenPath).not.toHaveBeenCalled();
+  });
+
+  it("does not read a .. traversal that escapes cwd (inert chip)", () => {
+    const { container } = render(
+      <MarkdownImage src="../secret.png" cwd="/proj" sessionId={7} alt="A" />,
+    );
+    expect(container.textContent).toContain("secret.png");
+    expect(container.textContent).toContain("Cannot preview");
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(appMocks.WorkspaceFsReadFile).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/agentre/markdown-image.test.tsx
+++ b/frontend/src/components/agentre/markdown-image.test.tsx
@@ -1,0 +1,232 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appMocks = vi.hoisted(() => ({
+  WorkspaceFsReadFile: vi.fn(),
+  OpenPath: vi.fn(),
+}));
+
+vi.mock("@/../wailsjs/go/app/App", () => ({
+  WorkspaceFsReadFile: appMocks.WorkspaceFsReadFile,
+  OpenPath: appMocks.OpenPath,
+}));
+
+import { classifyMarkdownImage, MarkdownImage } from "./markdown-image";
+
+beforeEach(() => {
+  appMocks.WorkspaceFsReadFile.mockReset();
+  appMocks.OpenPath.mockReset();
+  appMocks.OpenPath.mockResolvedValue(undefined);
+});
+
+describe("classifyMarkdownImage", () => {
+  it("classifies http/https/www as remote", () => {
+    expect(classifyMarkdownImage("https://x/a.png", {})).toEqual({
+      kind: "remote",
+      src: "https://x/a.png",
+    });
+    expect(classifyMarkdownImage("http://x/a.png", {})).toEqual({
+      kind: "remote",
+      src: "http://x/a.png",
+    });
+    expect(classifyMarkdownImage("www.x.com/a.png", {})).toEqual({
+      kind: "remote",
+      src: "www.x.com/a.png",
+    });
+  });
+
+  it("classifies empty, data: and javascript: as plain with no src", () => {
+    expect(classifyMarkdownImage("", {})).toEqual({
+      kind: "plain",
+      src: undefined,
+    });
+    expect(classifyMarkdownImage("data:image/png;base64,xx", {})).toEqual({
+      kind: "plain",
+      src: undefined,
+    });
+    expect(classifyMarkdownImage("javascript:alert(1)", {})).toEqual({
+      kind: "plain",
+      src: undefined,
+    });
+  });
+
+  it("classifies a local path without sessionId as plain with stripped src", () => {
+    expect(classifyMarkdownImage("a.png", { cwd: "/proj" })).toEqual({
+      kind: "plain",
+      src: undefined,
+    });
+  });
+
+  it("keeps an absolute local path without sessionId as plain with its src (today's broken-image behaviour)", () => {
+    expect(classifyMarkdownImage("/abs/a.png", {})).toEqual({
+      kind: "plain",
+      src: "/abs/a.png",
+    });
+  });
+
+  it("classifies relative path + cwd + image extension + sessionId as fetch", () => {
+    expect(
+      classifyMarkdownImage("a.png", { cwd: "/proj", sessionId: 7 }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "a.png",
+      absolutePath: "/proj/a.png",
+      basename: "a.png",
+    });
+  });
+
+  it("decodes percent-encoded non-ASCII relative paths before fetch", () => {
+    expect(
+      classifyMarkdownImage("docs/%E6%9C%AC%E5%9C%B0.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "docs/本地.png",
+      absolutePath: "/proj/docs/本地.png",
+      basename: "本地.png",
+    });
+  });
+
+  it("resolves file:// to a local path", () => {
+    expect(
+      classifyMarkdownImage("file:///proj/a.png", {
+        cwd: "/proj",
+        sessionId: 7,
+      }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "a.png",
+      absolutePath: "/proj/a.png",
+      basename: "a.png",
+    });
+  });
+
+  it("classifies a non-image extension as fallback (clickable inside cwd)", () => {
+    expect(
+      classifyMarkdownImage("notes.txt", { cwd: "/proj", sessionId: 7 }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: "/proj/notes.txt",
+      basename: "notes.txt",
+    });
+  });
+
+  it("classifies an absolute path outside cwd as fallback (not clickable)", () => {
+    expect(
+      classifyMarkdownImage("/etc/passwd", { cwd: "/proj", sessionId: 7 }),
+    ).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "passwd",
+    });
+  });
+
+  it("classifies a relative path without cwd as fallback (not clickable)", () => {
+    expect(classifyMarkdownImage("a.png", { sessionId: 7 })).toEqual({
+      kind: "fallback",
+      absolutePath: null,
+      basename: "a.png",
+    });
+  });
+
+  it("keeps .. traversal out of the clickable absolutePath (backend rejects the read)", () => {
+    expect(
+      classifyMarkdownImage("../secret.png", { cwd: "/proj", sessionId: 7 }),
+    ).toEqual({
+      kind: "fetch",
+      relPath: "../secret.png",
+      absolutePath: null,
+      basename: "secret.png",
+    });
+  });
+});
+
+describe("MarkdownImage", () => {
+  it("renders a remote image unchanged", () => {
+    const { container } = render(
+      <MarkdownImage src="https://x/a.png" alt="A" />,
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("https://x/a.png");
+    expect(img?.getAttribute("alt")).toBe("A");
+  });
+
+  it("renders a local path without sessionId as a plain img with stripped src", () => {
+    const { container } = render(
+      <MarkdownImage src="a.png" cwd="/proj" alt="A" />,
+    );
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBeNull();
+    expect(appMocks.WorkspaceFsReadFile).not.toHaveBeenCalled();
+  });
+
+  it("fetches a local image via WorkspaceFsReadFile and renders a data URL", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValue({
+      content: "aGVsbG8=",
+      contentType: "image/png",
+    });
+    render(<MarkdownImage src="a.png" cwd="/proj" sessionId={7} alt="A" />);
+
+    await waitFor(() =>
+      expect(appMocks.WorkspaceFsReadFile).toHaveBeenCalledWith(7, "a.png"),
+    );
+    const img = await screen.findByRole("img");
+    expect(img.getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
+  });
+
+  it("renders a tooLarge result as the tooLarge chip", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValue({
+      content: "",
+      contentType: "image/png",
+      tooLarge: true,
+    });
+    render(<MarkdownImage src="big.png" cwd="/proj" sessionId={7} alt="A" />);
+
+    expect(await screen.findByText("big.png")).toBeInTheDocument();
+    expect(screen.getByText("Image too large")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders a binary result as the cannot-preview chip", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValue({
+      content: "",
+      contentType: "image/png",
+      binary: true,
+    });
+    render(<MarkdownImage src="b.png" cwd="/proj" sessionId={7} alt="A" />);
+
+    expect(await screen.findByText("b.png")).toBeInTheDocument();
+    expect(screen.getByText("Cannot preview")).toBeInTheDocument();
+  });
+
+  it("renders a read error as the cannot-preview chip", async () => {
+    appMocks.WorkspaceFsReadFile.mockRejectedValue(new Error("nope"));
+    render(<MarkdownImage src="c.png" cwd="/proj" sessionId={7} alt="A" />);
+
+    expect(await screen.findByText("c.png")).toBeInTheDocument();
+    expect(screen.getByText("Cannot preview")).toBeInTheDocument();
+  });
+
+  it("renders an inside-cwd fallback chip as a clickable button that opens the path", () => {
+    render(<MarkdownImage src="notes.txt" cwd="/proj" sessionId={7} alt="A" />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("notes.txt");
+    expect(button).toHaveTextContent("Cannot preview");
+    fireEvent.click(button);
+    expect(appMocks.OpenPath).toHaveBeenCalledWith("/proj/notes.txt");
+  });
+
+  it("renders an outside-cwd fallback chip as inert text (no button, no open)", () => {
+    const { container } = render(
+      <MarkdownImage src="/etc/passwd" cwd="/proj" sessionId={7} alt="A" />,
+    );
+    expect(container.textContent).toContain("passwd");
+    expect(container.textContent).toContain("Cannot preview");
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(appMocks.OpenPath).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/agentre/markdown-image.tsx
+++ b/frontend/src/components/agentre/markdown-image.tsx
@@ -14,6 +14,7 @@ const FILE_PROTOCOL = /^file:\/\//i;
 const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const HTTP_PROTOCOL = /^https?:/i;
 const WWW_PREFIX = /^www\./i;
+const PROTOCOL_RELATIVE = /^\/\//;
 
 function decodeLocalPath(path: string): string {
   try {
@@ -23,14 +24,27 @@ function decodeLocalPath(path: string): string {
   }
 }
 
-function fileURLToPath(href: string): string {
+function fileURLToPath(href: string): string | null {
   // file:///Users/x/a.png → /Users/x/a.png
   // file:///C:/Users/x/a.png → C:/Users/x/a.png
+  // file://localhost/Users/x/a.png → /Users/x/a.png
+  // file://server/share/a.png → null（远端主机,不是本机文件,不该当本地路径处理）
   let path = href.slice("file://".length);
-  if (path.startsWith("/") && /^[A-Za-z]:/.test(path.slice(1))) {
-    path = path.slice(1);
+  if (path.startsWith("/")) {
+    // 空主机段:path 即绝对路径;剥掉 Windows 盘符前的多余 "/"。
+    if (/^[A-Za-z]:/.test(path.slice(1))) path = path.slice(1);
+    return decodeLocalPath(path);
   }
-  return decodeLocalPath(path);
+  if (/^[A-Za-z]:[\\/]/.test(path)) {
+    // file://C:/… 这类缺斜杠的盘符形式。
+    return decodeLocalPath(path);
+  }
+  // 有主机段:host/path。仅空主机 / localhost 视为本机;远端主机不是本机路径。
+  const slash = path.indexOf("/");
+  const host = slash >= 0 ? path.slice(0, slash) : path;
+  if (host !== "" && host.toLowerCase() !== "localhost") return null;
+  const rest = slash >= 0 ? path.slice(slash) : "/";
+  return decodeLocalPath(rest);
 }
 
 function basenameOf(path: string): string {
@@ -82,7 +96,11 @@ export function classifyMarkdownImage(
 ): MarkdownImageClass {
   if (src === "") return { kind: "plain", src: undefined };
 
-  if (HTTP_PROTOCOL.test(src) || WWW_PREFIX.test(src)) {
+  if (
+    HTTP_PROTOCOL.test(src) ||
+    WWW_PREFIX.test(src) ||
+    PROTOCOL_RELATIVE.test(src)
+  ) {
     return { kind: "remote", src };
   }
 
@@ -292,6 +310,7 @@ export function MarkdownImage({
   if (cls.kind === "fetch") {
     return (
       <FetchImage
+        key={cls.relPath}
         relPath={cls.relPath}
         absolutePath={cls.absolutePath}
         basename={cls.basename}

--- a/frontend/src/components/agentre/markdown-image.tsx
+++ b/frontend/src/components/agentre/markdown-image.tsx
@@ -1,0 +1,302 @@
+import * as React from "react";
+import { FileText, Image as ImageIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import {
+  previewKind,
+  toRelPath,
+} from "@/components/agentre/chat-context-sidebar/previewable";
+import { OpenPath, WorkspaceFsReadFile } from "@/../wailsjs/go/app/App";
+
+const ABS_POSIX = /^\//;
+const ABS_WINDOWS = /^[A-Za-z]:[\\/]/;
+const FILE_PROTOCOL = /^file:\/\//i;
+const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const HTTP_PROTOCOL = /^https?:/i;
+const WWW_PREFIX = /^www\./i;
+
+function decodeLocalPath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function fileURLToPath(href: string): string {
+  // file:///Users/x/a.png → /Users/x/a.png
+  // file:///C:/Users/x/a.png → C:/Users/x/a.png
+  let path = href.slice("file://".length);
+  if (path.startsWith("/") && /^[A-Za-z]:/.test(path.slice(1))) {
+    path = path.slice(1);
+  }
+  return decodeLocalPath(path);
+}
+
+function basenameOf(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+function toSlash(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+// 相对路径是否仍落在 cwd 内(不因 ".." 越界)。后端 workspacefs.ReadFile 是权威
+// 边界,这里只是为 chip 可点性做 UX 预判。
+function isRelPathInside(relPath: string): boolean {
+  const parts = relPath.split("/");
+  let depth = 0;
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      depth -= 1;
+      if (depth < 0) return false;
+    } else {
+      depth += 1;
+    }
+  }
+  return true;
+}
+
+export type MarkdownImageClass =
+  | { kind: "remote"; src: string }
+  | { kind: "plain"; src: string | undefined }
+  | {
+      kind: "fetch";
+      relPath: string;
+      absolutePath: string | null;
+      basename: string;
+    }
+  | { kind: "fallback"; absolutePath: string | null; basename: string };
+
+/**
+ * 把 markdown 图片的 src 分成四档:remote(原样 <img>)/ plain(维持现状的 <img>,
+ * 相对本地路径剥空 src)/ fetch(本地路径 + sessionId + cwd 内 + 图片扩展名,读文件
+ * 渲染 data URL)/ fallback(本地路径但不可预览,渲染兜底 chip)。
+ */
+export function classifyMarkdownImage(
+  src: string,
+  opts: { cwd?: string; sessionId?: number },
+): MarkdownImageClass {
+  if (src === "") return { kind: "plain", src: undefined };
+
+  if (HTTP_PROTOCOL.test(src) || WWW_PREFIX.test(src)) {
+    return { kind: "remote", src };
+  }
+
+  let localPath: string | null = null;
+  if (FILE_PROTOCOL.test(src)) {
+    localPath = fileURLToPath(src);
+  } else if (ABS_POSIX.test(src) || ABS_WINDOWS.test(src)) {
+    localPath = decodeLocalPath(src);
+  } else if (!SCHEME.test(src)) {
+    localPath = decodeLocalPath(src);
+  }
+
+  if (localPath !== null) {
+    const basename = basenameOf(localPath);
+    // 无会话上下文时本地图片维持现状:相对路径剥空(今天被 urlTransform 剥掉);
+    // 绝对/file:// 路径原样保留 src(今天的破图行为不变)。
+    if (opts.sessionId === undefined) {
+      const relative =
+        !ABS_POSIX.test(src) &&
+        !ABS_WINDOWS.test(src) &&
+        !FILE_PROTOCOL.test(src);
+      return { kind: "plain", src: relative ? undefined : src };
+    }
+    const resolved = resolveLocalPath(localPath, opts.cwd);
+    if (resolved.relPath !== null && previewKind(localPath) === "image") {
+      return {
+        kind: "fetch",
+        relPath: resolved.relPath,
+        absolutePath: resolved.absolutePath,
+        basename,
+      };
+    }
+    return { kind: "fallback", absolutePath: resolved.absolutePath, basename };
+  }
+
+  if (SCHEME.test(src)) {
+    if (/^(data|javascript):/i.test(src)) {
+      return { kind: "plain", src: undefined };
+    }
+    return { kind: "plain", src };
+  }
+
+  return { kind: "plain", src };
+}
+
+function resolveLocalPath(
+  path: string,
+  cwd: string | undefined,
+): { relPath: string | null; absolutePath: string | null } {
+  if (!cwd) return { relPath: null, absolutePath: null };
+  const relPath = toRelPath(path, cwd);
+  if (ABS_POSIX.test(path) || ABS_WINDOWS.test(path)) {
+    // 绝对路径:落在 cwd 内(toRelPath 成功)才可点。
+    return { relPath, absolutePath: relPath !== null ? path : null };
+  }
+  const slash = toSlash(path);
+  if (!isRelPathInside(slash)) return { relPath, absolutePath: null };
+  const sep = cwd.includes("\\") ? "\\" : "/";
+  const base = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd : `${cwd}${sep}`;
+  return { relPath, absolutePath: base + slash };
+}
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "loaded"; dataUrl: string }
+  | { status: "failed"; reason: "cannot-preview" | "too-large" };
+
+function FetchImage({
+  relPath,
+  absolutePath,
+  basename,
+  alt,
+  sessionId,
+}: {
+  relPath: string;
+  absolutePath: string | null;
+  basename: string;
+  alt?: string;
+  sessionId?: number;
+}) {
+  const [state, setState] = React.useState<FetchState>({ status: "loading" });
+
+  React.useEffect(() => {
+    if (sessionId === undefined) {
+      setState({ status: "failed", reason: "cannot-preview" });
+      return;
+    }
+    let cancelled = false;
+    WorkspaceFsReadFile(sessionId, relPath)
+      .then((view) => {
+        if (cancelled) return;
+        if (view.tooLarge) {
+          setState({ status: "failed", reason: "too-large" });
+          return;
+        }
+        if (view.binary || !view.contentType) {
+          setState({ status: "failed", reason: "cannot-preview" });
+          return;
+        }
+        setState({
+          status: "loaded",
+          dataUrl: `data:${view.contentType};base64,${view.content}`,
+        });
+      })
+      .catch(() => {
+        if (!cancelled)
+          setState({ status: "failed", reason: "cannot-preview" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, relPath]);
+
+  if (state.status === "loading") {
+    return (
+      <span
+        className="inline-flex size-8 items-center justify-center rounded bg-muted align-middle"
+        aria-hidden
+      >
+        <ImageIcon className="size-4 text-muted-foreground" aria-hidden />
+      </span>
+    );
+  }
+  if (state.status === "loaded") {
+    return (
+      <img src={state.dataUrl} alt={alt} className="max-w-full rounded-lg" />
+    );
+  }
+  return (
+    <FallbackChip
+      absolutePath={absolutePath}
+      basename={basename}
+      reason={state.reason}
+    />
+  );
+}
+
+function FallbackChip({
+  absolutePath,
+  basename,
+  reason,
+}: {
+  absolutePath: string | null;
+  basename: string;
+  reason: "cannot-preview" | "too-large";
+}) {
+  const { t } = useTranslation();
+  const label =
+    reason === "too-large"
+      ? t("markdownImage.tooLarge")
+      : t("markdownImage.cannotPreview");
+
+  const content = (
+    <>
+      <FileText className="size-3 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate">{basename}</span>
+      <span aria-hidden>·</span>
+      <span className="shrink-0">{label}</span>
+    </>
+  );
+
+  if (absolutePath !== null) {
+    return (
+      <button
+        type="button"
+        className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-meta text-muted-foreground hover:bg-muted/60"
+        onClick={() => OpenPath(absolutePath).catch(() => {})}
+      >
+        {content}
+      </button>
+    );
+  }
+  return (
+    <span className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-meta text-muted-foreground">
+      {content}
+    </span>
+  );
+}
+
+export function MarkdownImage({
+  src,
+  alt,
+  cwd,
+  sessionId,
+}: {
+  src?: string;
+  alt?: string;
+  cwd?: string;
+  sessionId?: number;
+}) {
+  const cls = classifyMarkdownImage(src ?? "", { cwd, sessionId });
+
+  if (cls.kind === "remote") {
+    return <img src={cls.src} alt={alt} />;
+  }
+  if (cls.kind === "plain") {
+    return <img src={cls.src} alt={alt} />;
+  }
+  if (cls.kind === "fetch") {
+    return (
+      <FetchImage
+        relPath={cls.relPath}
+        absolutePath={cls.absolutePath}
+        basename={cls.basename}
+        alt={alt}
+        sessionId={sessionId}
+      />
+    );
+  }
+  return (
+    <FallbackChip
+      absolutePath={cls.absolutePath}
+      basename={cls.basename}
+      reason="cannot-preview"
+    />
+  );
+}

--- a/frontend/src/components/agentre/markdown-image.tsx
+++ b/frontend/src/components/agentre/markdown-image.tsx
@@ -139,11 +139,15 @@ function resolveLocalPath(
   if (!cwd) return { relPath: null, absolutePath: null };
   const relPath = toRelPath(path, cwd);
   if (ABS_POSIX.test(path) || ABS_WINDOWS.test(path)) {
-    // 绝对路径:落在 cwd 内(toRelPath 成功)才可点。
-    return { relPath, absolutePath: relPath !== null ? path : null };
+    // 绝对路径:落在 cwd 内(toRelPath 成功)且剥出的 relPath 不含越界 ".."
+    // 才可点;越界 ".." 与相对路径同一套判定,不读也不可点。
+    if (relPath !== null && isRelPathInside(relPath)) {
+      return { relPath, absolutePath: path };
+    }
+    return { relPath: null, absolutePath: null };
   }
   const slash = toSlash(path);
-  if (!isRelPathInside(slash)) return { relPath, absolutePath: null };
+  if (!isRelPathInside(slash)) return { relPath: null, absolutePath: null };
   const sep = cwd.includes("\\") ? "\\" : "/";
   const base = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd : `${cwd}${sep}`;
   return { relPath, absolutePath: base + slash };

--- a/frontend/src/components/agentre/markdown-image.tsx
+++ b/frontend/src/components/agentre/markdown-image.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FileText, Image as ImageIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 import {
   previewKind,
@@ -10,6 +11,7 @@ import { OpenPath, WorkspaceFsReadFile } from "@/../wailsjs/go/app/App";
 
 const ABS_POSIX = /^\//;
 const ABS_WINDOWS = /^[A-Za-z]:[\\/]/;
+const ABS_WINDOWS_ROOTED = /^\\/;
 const FILE_PROTOCOL = /^file:\/\//i;
 const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const HTTP_PROTOCOL = /^https?:/i;
@@ -43,7 +45,8 @@ function fileURLToPath(href: string): string | null {
   const slash = path.indexOf("/");
   const host = slash >= 0 ? path.slice(0, slash) : path;
   if (host !== "" && host.toLowerCase() !== "localhost") return null;
-  const rest = slash >= 0 ? path.slice(slash) : "/";
+  let rest = slash >= 0 ? path.slice(slash) : "/";
+  if (/^\/[A-Za-z]:[\\/]/.test(rest)) rest = rest.slice(1);
   return decodeLocalPath(rest);
 }
 
@@ -117,7 +120,7 @@ export function classifyMarkdownImage(
     const basename = basenameOf(localPath);
     // 无会话上下文时本地图片维持现状:相对路径剥空(今天被 urlTransform 剥掉);
     // 绝对/file:// 路径原样保留 src(今天的破图行为不变)。
-    if (opts.sessionId === undefined) {
+    if (opts.sessionId === undefined || opts.sessionId <= 0) {
       const relative =
         !ABS_POSIX.test(src) &&
         !ABS_WINDOWS.test(src) &&
@@ -141,7 +144,7 @@ export function classifyMarkdownImage(
   }
 
   if (SCHEME.test(src)) {
-    if (/^(data|javascript):/i.test(src)) {
+    if (/^(data|javascript|file):/i.test(src)) {
       return { kind: "plain", src: undefined };
     }
     return { kind: "plain", src };
@@ -154,9 +157,19 @@ function resolveLocalPath(
   path: string,
   cwd: string | undefined,
 ): { relPath: string | null; absolutePath: string | null } {
-  if (!cwd) return { relPath: null, absolutePath: null };
-  const relPath = toRelPath(path, cwd);
+  if (!cwd || ABS_WINDOWS_ROOTED.test(path)) {
+    return { relPath: null, absolutePath: null };
+  }
+  let relPath = toRelPath(path, cwd);
   if (ABS_POSIX.test(path) || ABS_WINDOWS.test(path)) {
+    if (ABS_WINDOWS.test(path) && ABS_WINDOWS.test(cwd)) {
+      const normalizedPath = toSlash(path);
+      const normalizedCwd = toSlash(cwd).replace(/\/$/, "");
+      const prefix = `${normalizedCwd}/`;
+      if (normalizedPath.toLowerCase().startsWith(prefix.toLowerCase())) {
+        relPath = normalizedPath.slice(prefix.length);
+      }
+    }
     // 绝对路径:落在 cwd 内(toRelPath 成功)且剥出的 relPath 不含越界 ".."
     // 才可点;越界 ".." 与相对路径同一套判定,不读也不可点。
     if (relPath !== null && isRelPathInside(relPath)) {
@@ -192,7 +205,8 @@ function FetchImage({
   const [state, setState] = React.useState<FetchState>({ status: "loading" });
 
   React.useEffect(() => {
-    if (sessionId === undefined) {
+    setState({ status: "loading" });
+    if (sessionId === undefined || sessionId <= 0) {
       setState({ status: "failed", reason: "cannot-preview" });
       return;
     }
@@ -220,7 +234,7 @@ function FetchImage({
     return () => {
       cancelled = true;
     };
-  }, [sessionId, relPath]);
+  }, [sessionId, relPath, absolutePath]);
 
   if (state.status === "loading") {
     return (
@@ -275,7 +289,15 @@ function FallbackChip({
       <button
         type="button"
         className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-meta text-muted-foreground outline-none transition-colors hover:bg-muted/60 focus-visible:ring-[3px] focus-visible:ring-ring/50"
-        onClick={() => OpenPath(absolutePath).catch(() => {})}
+        onClick={() =>
+          OpenPath(absolutePath).catch((err: unknown) => {
+            toast.error(
+              t("richLink.openFailed", {
+                error: err instanceof Error ? err.message : String(err),
+              }),
+            );
+          })
+        }
       >
         {content}
       </button>

--- a/frontend/src/components/agentre/markdown-image.tsx
+++ b/frontend/src/components/agentre/markdown-image.tsx
@@ -44,7 +44,7 @@ function toSlash(path: string): string {
 }
 
 // 相对路径是否仍落在 cwd 内(不因 ".." 越界)。后端 workspacefs.ReadFile 是权威
-// 边界,这里只是为 chip 可点性做 UX 预判。
+// 边界,这里只做 UX 预判:越界的路径既不该读(fetch/fallback 分档),也不可点。
 function isRelPathInside(relPath: string): boolean {
   const parts = relPath.split("/");
   let depth = 0;
@@ -107,7 +107,11 @@ export function classifyMarkdownImage(
       return { kind: "plain", src: relative ? undefined : src };
     }
     const resolved = resolveLocalPath(localPath, opts.cwd);
-    if (resolved.relPath !== null && previewKind(localPath) === "image") {
+    if (
+      resolved.relPath !== null &&
+      resolved.absolutePath !== null &&
+      previewKind(localPath) === "image"
+    ) {
       return {
         kind: "fetch",
         relPath: resolved.relPath,
@@ -248,7 +252,7 @@ function FallbackChip({
     return (
       <button
         type="button"
-        className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-meta text-muted-foreground hover:bg-muted/60"
+        className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-meta text-muted-foreground outline-none transition-colors hover:bg-muted/60 focus-visible:ring-[3px] focus-visible:ring-ring/50"
         onClick={() => OpenPath(absolutePath).catch(() => {})}
       >
         {content}

--- a/frontend/src/components/agentre/markdown-text.test.tsx
+++ b/frontend/src/components/agentre/markdown-text.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sonnerMocks = vi.hoisted(() => ({
   toast: {
@@ -8,7 +8,17 @@ const sonnerMocks = vi.hoisted(() => ({
   },
 }));
 
+const appMocks = vi.hoisted(() => ({
+  WorkspaceFsReadFile: vi.fn(),
+  OpenPath: vi.fn(),
+}));
+
 vi.mock("sonner", () => sonnerMocks);
+
+vi.mock("@/../wailsjs/go/app/App", () => ({
+  WorkspaceFsReadFile: appMocks.WorkspaceFsReadFile,
+  OpenPath: appMocks.OpenPath,
+}));
 
 import {
   MarkdownText,
@@ -32,6 +42,11 @@ afterEach(() => {
     configurable: true,
     value: originalClipboard,
   });
+});
+
+beforeEach(() => {
+  appMocks.WorkspaceFsReadFile.mockReset();
+  appMocks.OpenPath.mockReset();
 });
 
 describe("MarkdownText", () => {
@@ -158,6 +173,50 @@ describe("MarkdownText URL whitelist", () => {
     );
     const a = container.querySelector("a");
     // After url whitelist strips href, RichLink renders plain anchor with no href.
+    expect(a?.getAttribute("href")).toBeFalsy();
+  });
+});
+
+describe("MarkdownText image src whitelist + local rendering", () => {
+  it("passes a relative image src through and renders a data URL when sessionId is present", async () => {
+    appMocks.WorkspaceFsReadFile.mockResolvedValue({
+      content: "aGVsbG8=",
+      contentType: "image/png",
+    });
+    const { container } = render(
+      <MarkdownText text="![pic](foo.png)" cwd="/proj" sessionId={7} />,
+    );
+
+    await waitFor(() =>
+      expect(appMocks.WorkspaceFsReadFile).toHaveBeenCalledWith(7, "foo.png"),
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
+    expect(img?.getAttribute("alt")).toBe("pic");
+  });
+
+  it("strips a data: image src (img renders without src)", () => {
+    const { container } = render(
+      <MarkdownText text="![d](data:image/png;base64,xx)" />,
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBeNull();
+  });
+
+  it("strips a relative image src when sessionId is absent", () => {
+    const { container } = render(
+      <MarkdownText text="![pic](foo.png)" cwd="/proj" />,
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBeNull();
+    expect(appMocks.WorkspaceFsReadFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps the href whitelist unchanged: a relative link is still stripped", () => {
+    const { container } = render(
+      <MarkdownText text="[rel](relative/path)" cwd="/proj" />,
+    );
+    const a = container.querySelector("a");
     expect(a?.getAttribute("href")).toBeFalsy();
   });
 });

--- a/frontend/src/components/agentre/markdown-text.tsx
+++ b/frontend/src/components/agentre/markdown-text.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { splitStreamingMarkdown } from "@/lib/streaming-markdown";
 
 import { CodeBlock } from "./code-block";
+import { MarkdownImage } from "./markdown-image";
 import { RichLink } from "./rich-link";
 
 type MarkdownElementNode = {
@@ -132,9 +133,14 @@ const SAFE_HREF_PATTERNS: RegExp[] = [
   /^[A-Za-z]:[\\/]/, // Windows 绝对
 ];
 
-function whitelistUrl(url: string): string {
+function whitelistUrl(url: string, key: string): string {
   for (const p of SAFE_HREF_PATTERNS) {
     if (p.test(url)) return url;
+  }
+  // 只对图片 src 放行相对路径(无 scheme);href 分支逐字节不变,相对/危险 scheme
+  // (data: / javascript: / 其它协议)仍剥空。
+  if (key === "src" && url !== "" && !/^[A-Za-z][A-Za-z0-9+.-]*:/.test(url)) {
+    return url;
   }
   return "";
 }
@@ -295,10 +301,12 @@ const markdownRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [
 const MarkdownInner = React.memo(function MarkdownInner({
   text,
   cwd,
+  sessionId,
   decorator,
 }: {
   text: string;
   cwd?: string;
+  sessionId?: number;
   decorator?: MarkdownInlineDecorator;
 }) {
   const components = React.useMemo<Components>(() => {
@@ -313,6 +321,9 @@ const MarkdownInner = React.memo(function MarkdownInner({
           {children}
         </RichLink>
       ),
+      img: ({ node: _node, src, alt }) => (
+        <MarkdownImage src={src} alt={alt} cwd={cwd} sessionId={sessionId} />
+      ),
     };
     if (decorator) {
       // INLINE_TOKEN_TAG 是自定义元素名,不在 JSX.IntrinsicElements 里,
@@ -324,7 +335,7 @@ const MarkdownInner = React.memo(function MarkdownInner({
       }) => (payload ? decorator.render(JSON.parse(payload)) : null);
     }
     return base;
-  }, [cwd, decorator]);
+  }, [cwd, sessionId, decorator]);
 
   const rehypePlugins = React.useMemo<
     ReactMarkdownOptions["rehypePlugins"]
@@ -355,16 +366,23 @@ const MarkdownInner = React.memo(function MarkdownInner({
 export const MarkdownText = React.memo(function MarkdownText({
   text,
   cwd,
+  sessionId,
   decorator,
 }: {
   text: string;
   cwd?: string;
+  sessionId?: number;
   /** 内联装饰器(mention / 命令 / 文件 chip)。调用方须传 useMemo 稳定引用,否则 memo 失效。 */
   decorator?: MarkdownInlineDecorator;
 }) {
   return (
     <div className="markdown-body break-words text-prose">
-      <MarkdownInner text={text} cwd={cwd} decorator={decorator} />
+      <MarkdownInner
+        text={text}
+        cwd={cwd}
+        sessionId={sessionId}
+        decorator={decorator}
+      />
     </div>
   );
 });
@@ -383,9 +401,11 @@ export const MarkdownText = React.memo(function MarkdownText({
 export const StreamingMarkdown = React.memo(function StreamingMarkdown({
   text,
   cwd,
+  sessionId,
 }: {
   text: string;
   cwd?: string;
+  sessionId?: number;
 }) {
   const { committed, tail } = React.useMemo(
     () => splitStreamingMarkdown(text),
@@ -394,9 +414,11 @@ export const StreamingMarkdown = React.memo(function StreamingMarkdown({
   return (
     <div className="markdown-body break-words text-prose">
       {committed.map((segment, i) => (
-        <MarkdownInner key={i} text={segment} cwd={cwd} />
+        <MarkdownInner key={i} text={segment} cwd={cwd} sessionId={sessionId} />
       ))}
-      {tail ? <MarkdownInner key="tail" text={tail} cwd={cwd} /> : null}
+      {tail ? (
+        <MarkdownInner key="tail" text={tail} cwd={cwd} sessionId={sessionId} />
+      ) : null}
     </div>
   );
 });

--- a/frontend/src/components/agentre/transcript-row-view.tsx
+++ b/frontend/src/components/agentre/transcript-row-view.tsx
@@ -576,9 +576,11 @@ function extractAssistantOutputText(
 function MessageBody({
   item,
   cwd,
+  sessionId,
 }: {
   item: Extract<TranscriptRowItem, { type: "text" }>;
   cwd?: string;
+  sessionId?: number;
 }) {
   const { text: mentionText, refs: mentionRefs } = React.useMemo(
     () => prepareMentionText(item.text),
@@ -590,7 +592,12 @@ function MessageBody({
     [mentionRefs],
   );
   return (
-    <MarkdownText cwd={cwd} text={mentionText} decorator={mentionDecorator} />
+    <MarkdownText
+      cwd={cwd}
+      sessionId={sessionId}
+      text={mentionText}
+      decorator={mentionDecorator}
+    />
   );
 }
 
@@ -618,9 +625,13 @@ function RenderItemView({
       return null;
     case "text":
       return item.streaming ? (
-        <StreamingMarkdown cwd={ctx?.cwd} text={item.text} />
+        <StreamingMarkdown
+          cwd={ctx?.cwd}
+          sessionId={ctx?.sessionId}
+          text={item.text}
+        />
       ) : (
-        <MessageBody item={item} cwd={ctx?.cwd} />
+        <MessageBody item={item} cwd={ctx?.cwd} sessionId={ctx?.sessionId} />
       );
     case "plan":
       return (

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,4 +1,8 @@
 {
+  "markdownImage": {
+    "cannotPreview": "Cannot preview",
+    "tooLarge": "Image too large"
+  },
   "notify": {
     "app": "Agentre",
     "body": {

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1,4 +1,8 @@
 {
+  "markdownImage": {
+    "cannotPreview": "无法预览",
+    "tooLarge": "图片过大"
+  },
   "notify": {
     "app": "Agentre",
     "body": {

--- a/internal/daemon/rpc/terminal_protocol_integration_test.go
+++ b/internal/daemon/rpc/terminal_protocol_integration_test.go
@@ -33,20 +33,20 @@ type rpcTrackedTerminalHandle struct {
 	data chan []byte
 	exit chan pty.ExitInfo
 
-	closeOnce  sync.Once
-	closeCalls atomic.Int32
-	dataCalls  atomic.Int32
-	exitCalls  atomic.Int32
+	completeOnce sync.Once
+	closeCalls   atomic.Int32
+	dataCalls    atomic.Int32
+	exitCalls    atomic.Int32
 }
 
 func newRPCFastTerminalHandle(data []byte, exit pty.ExitInfo) *rpcTrackedTerminalHandle {
-	dataCh := make(chan []byte, 1)
-	dataCh <- data
-	close(dataCh)
-	exitCh := make(chan pty.ExitInfo, 1)
-	exitCh <- exit
-	close(exitCh)
-	return &rpcTrackedTerminalHandle{data: dataCh, exit: exitCh}
+	h := &rpcTrackedTerminalHandle{
+		data: make(chan []byte, 1),
+		exit: make(chan pty.ExitInfo, 1),
+	}
+	h.data <- data
+	h.complete(exit)
+	return h
 }
 
 func newRPCLateTerminalHandle() *rpcTrackedTerminalHandle {
@@ -68,12 +68,16 @@ func (h *rpcTrackedTerminalHandle) Exit() <-chan pty.ExitInfo {
 }
 func (h *rpcTrackedTerminalHandle) Close() error {
 	h.closeCalls.Add(1)
-	h.closeOnce.Do(func() {
-		h.exit <- pty.ExitInfo{Code: 137, Reason: "killed"}
+	h.complete(pty.ExitInfo{Code: 137, Reason: "killed"})
+	return nil
+}
+
+func (h *rpcTrackedTerminalHandle) complete(exit pty.ExitInfo) {
+	h.completeOnce.Do(func() {
+		h.exit <- exit
 		close(h.exit)
 		close(h.data)
 	})
-	return nil
 }
 
 type terminalWebSocketHarness struct {
@@ -159,6 +163,19 @@ func dialTerminalRPCClient(t *testing.T, url string) *daemonclient.Client {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 	return client
+}
+
+func TestRPCTrackedTerminalHandle_GivenNaturalCompletionWhenCleanupClosesThenPreservesOutcomeWithoutPanic(t *testing.T) {
+	fastHandle := newRPCFastTerminalHandle([]byte("done"), pty.ExitInfo{Code: 0, Reason: "natural"})
+
+	require.NotPanics(t, func() {
+		require.NoError(t, fastHandle.Close())
+	})
+	require.Equal(t, int32(1), fastHandle.closeCalls.Load())
+	require.Equal(t, []byte("done"), <-fastHandle.Data())
+	outcome, ok := <-fastHandle.Exit()
+	require.True(t, ok)
+	require.Equal(t, pty.ExitInfo{Code: 0, Reason: "natural"}, outcome)
 }
 
 func TestTerminalProtocolRealWebSocket_GivenDataAndExitSentBeforeOpenResponseWhenDesktopPreSubscribesThenCapturesBoth(t *testing.T) {


### PR DESCRIPTION
## 变更说明 / Summary

- 在聊天转录中以内联图片渲染会话 cwd 内的相对路径、绝对路径与 `file://` markdown 图片
- 复用 `WorkspaceFsReadFile`，由后端继续强制 cwd、符号链接、图片扩展名及 10 MiB 边界
- 为读取失败、非图片和超大图片增加可访问的兜底 chip；仅 cwd 内路径允许点击打开
- 保持远程图片、`data:` / `javascript:` src、无 sessionId 调用点及 href 白名单行为不变
- 补齐 Windows 路径、UNC、`file://localhost`、远程 file host、异步会话/cwd 切换等边界测试

## 关联 Issue / Related Issue

无 / N/A

## 截图 / Screenshots

真实 isolated Wails app 验证截图保存在本地 ignored evidence：

- `e2e/scratch/2026-08-13-markdown-local-image/screenshots/01-relative-local.png`
- `e2e/scratch/2026-08-13-markdown-local-image/screenshots/03-fallbacks.png`
- `e2e/scratch/2026-08-13-markdown-local-image/screenshots/07-final-transcript.png`

## 验证 / Verification

- `cd frontend && pnpm test -- --run` — 256 files / 2764 tests passed
- `cd frontend && pnpm exec tsc -b --noEmit` — passed
- Spec review + code review — passed
- Isolated real Wails driven-app verification — 7/7 requirements hold
  - cwd 内相对/绝对/file URL 图片均转为 data URL 并成功加载
  - missing / non-image / too-large chip 与 cwd 点击边界成立
  - remote/data/javascript src 与 href 白名单无回归
  - 无 sessionId 的文件预览 markdown 行为不变

未剩余 blocked task、standing finding 或 unobserved requirement。

## 自检 / Checklist

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试
