### PR TITLE
🐛 修复登录后中转登记不生效与远端面板漏显示设备

### DIFF
--- a/cmd/agentred/login.go
+++ b/cmd/agentred/login.go
@@ -37,6 +37,9 @@ type loginDeps struct {
 	wait        func(time.Duration) error
 	platform    string
 	version     string
+	// hostname 提供设备列表里的显示名。取不到时按空串上报，由服务端回退到指纹
+	// 缩写——一个取不到的显示名不该让整次登录失败。
+	hostname func() (string, error)
 }
 
 type deviceAuthorizeResponse struct {
@@ -80,6 +83,7 @@ func newLoginCmd() *cobra.Command {
 		},
 		platform: runtime.GOOS,
 		version:  agentredBuildIdentity(),
+		hostname: os.Hostname,
 	})
 }
 
@@ -118,6 +122,13 @@ func newLoginCmdWithDeps(deps loginDeps) *cobra.Command {
 
 func login(cmd *cobra.Command, deps loginDeps, st *state.State, serverURL string) error {
 	authorize := deviceAuthorizeResponse{}
+	// 主机名取不到不影响登录：空串上报，服务端回退到指纹缩写。
+	name := ""
+	if deps.hostname != nil {
+		if got, err := deps.hostname(); err == nil {
+			name = got
+		}
+	}
 	if _, err := doLoginJSON(cmd, deps.http, http.MethodPost, serverURL+"/v1/oauth/device/authorize", map[string]any{
 		"device_kind": "agentred",
 		// 账号侧的设备指纹与 auth.pair 交给桌面端做 TOFU 的那一个是同一个东西:
@@ -129,6 +140,9 @@ func login(cmd *cobra.Command, deps loginDeps, st *state.State, serverURL string
 		"fingerprint": rpc.DaemonFingerprint(st.InstanceUUID()),
 		"platform":    deps.platform,
 		"version":     deps.version,
+		// 设备流是账号侧拿到这台机器名字的唯一途径：不带上它，设备列表里每台机器
+		// 都只能叫指纹缩写。
+		"name": name,
 	}, &authorize); err != nil {
 		return fmt.Errorf("authorize device login: %w", err)
 	}

--- a/cmd/agentred/login_test.go
+++ b/cmd/agentred/login_test.go
@@ -41,6 +41,9 @@ func TestLoginCompletesDeviceFlowAndPersistsOpaqueAccountClaim(t *testing.T) {
 			assert.Equal(t, rpc.DaemonFingerprint(st.InstanceUUID()), body["fingerprint"])
 			assert.Equal(t, "linux", body["platform"])
 			assert.Equal(t, "dev", body["version"])
+			// 主机名是设备列表里唯一有意义的名字来源：设备流不带它，服务端只能
+			// 拿指纹缩写当名字，同一个账号下的机器就都长得一样了。
+			assert.Equal(t, "coding", body["name"])
 			// 能力概念已从账号侧移除：授权一台设备拿到的就是账号的完整权限，
 			// 再自报一份服务端不校验、也不据以限制任何事的清单只是噪声。
 			assert.NotContains(t, body, "capabilities")
@@ -74,6 +77,7 @@ func TestLoginCompletesDeviceFlowAndPersistsOpaqueAccountClaim(t *testing.T) {
 		wait:     func(_ time.Duration) error { return nil },
 		platform: "linux",
 		version:  "dev",
+		hostname: func() (string, error) { return "coding", nil },
 	})
 	var out bytes.Buffer
 	cmd.SetOut(&out)

--- a/frontend/src/components/agentre/project-page.tsx
+++ b/frontend/src/components/agentre/project-page.tsx
@@ -1642,7 +1642,13 @@ function useProjectTerminalLocations(projectID: number) {
       setConfigured(new Set((rows ?? []).map((r) => r.deviceId))),
     );
   }, [projectID]);
-  return { devices, configured, loadLocations };
+  // 终端位置按 LAN 配对行的 id 索引（ProjectLocationList.deviceId），账号独有的
+  // 那些机器没有配对行，也就没有可落位的 location，不进这个菜单。
+  const lanDevices = React.useMemo(
+    () => devices.flatMap((d) => (d.lan ? [d.lan] : [])),
+    [devices],
+  );
+  return { devices: lanDevices, configured, loadLocations };
 }
 
 // NewTerminalSubMenu —— ProjectCard「更多操作」里的「新建终端」子菜单。

--- a/frontend/src/components/agentre/remote-devices/device-row.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/device-row.test.tsx
@@ -4,9 +4,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { DeviceRow } from "./device-row";
-import type { DeviceRowModel } from "./use-remote-devices";
+import type { DeviceRowModel, DeviceView } from "./use-remote-devices";
 
-const baseDevice: DeviceRowModel = {
+const baseLan: DeviceView = {
   id: 1,
   name: "linux-srv",
   url: "ws://192.168.1.100:7456/rpc",
@@ -19,22 +19,30 @@ const baseDevice: DeviceRowModel = {
   lastError: "",
   online: false,
   daemonOutdated: false,
+};
+
+const baseDevice: DeviceRowModel = {
+  key: "lan:1",
+  name: "linux-srv",
+  online: false,
+  lastSeenAt: 0,
+  lan: baseLan,
   account: undefined,
   paths: [{ kind: "lan", state: "dead" }],
   unclaimed: false,
   viaRelay: false,
 };
 
+const noopActions = {
+  onRefresh: () => {},
+  onRename: () => {},
+  onEditTLS: () => {},
+  onRemove: () => {},
+};
+
 function renderRow(device: DeviceRowModel) {
   return render(
-    <DeviceRow
-      device={device}
-      now={1_000_000}
-      onRefresh={() => {}}
-      onRename={() => {}}
-      onEditTLS={() => {}}
-      onRemove={() => {}}
-    />,
+    <DeviceRow device={device} now={1_000_000} actions={noopActions} />,
   );
 }
 
@@ -53,7 +61,10 @@ describe("DeviceRow", () => {
     expect(screen.getByText(/Never connected/)).toBeInTheDocument();
   });
   it("renders friendly error for tofu_mismatch in destructive style", () => {
-    const d = { ...baseDevice, lastError: "tofu_mismatch" };
+    const d = {
+      ...baseDevice,
+      lan: { ...baseLan, lastError: "tofu_mismatch" },
+    };
     renderRow(d);
     expect(
       screen.getByText(/identity fingerprint changed/),
@@ -62,7 +73,7 @@ describe("DeviceRow", () => {
   // R18：daemon 版本过旧时，说明落在这台设备自己那一行 —— 它是设备属性，
   // 不是会话事件，也不是浮在聊天上的横幅。
   it("explains an outdated daemon on the device row", () => {
-    const d = { ...baseDevice, daemonOutdated: true };
+    const d = { ...baseDevice, lan: { ...baseLan, daemonOutdated: true } };
     renderRow(d);
     expect(screen.getByText(/Outdated daemon/)).toBeInTheDocument();
   });
@@ -79,10 +90,7 @@ describe("DeviceRow", () => {
       <DeviceRow
         device={baseDevice}
         now={1_000_000}
-        onRefresh={() => {}}
-        onRename={() => {}}
-        onEditTLS={() => {}}
-        onRemove={onRemove}
+        actions={{ ...noopActions, onRemove }}
       />,
     );
     await user.click(screen.getByLabelText("More actions"));
@@ -176,5 +184,63 @@ describe("DeviceRow", () => {
     expect(screen.queryByText(/agentred login/)).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Claim to account" }));
     expect(screen.getByText(/agentred login/)).toBeInTheDocument();
+  });
+
+  // ── 账号独有的一行 ─────────────────────────────────────────────────────────
+  // 这台机器只在账号里,本机没有 paired_agentreds 那一行 —— TLS 徽章 / LAN 地址 /
+  // 那组作用在配对行上的动作(刷新直连、改名、改 TLS、删配对)统统无处落脚。
+  describe("a row with no LAN pairing", () => {
+    const accountOnly: DeviceRowModel = {
+      key: "account:21",
+      name: "cloud-box",
+      online: true,
+      lastSeenAt: 1_700_000_000_000,
+      account: {
+        ID: 21,
+        Name: "cloud-box",
+        Kind: "agentred",
+        Platform: "linux",
+        Version: "0.3.0",
+        Fingerprint: "fp-cloud",
+        LastSeenAt: 1_700_000_000_000,
+        Status: 1,
+        Online: true,
+        IsThisDevice: false,
+      },
+      paths: [{ kind: "relay", state: "in-use" }],
+      unclaimed: false,
+      viaRelay: true,
+    };
+
+    it("names the machine and shows 经中转 in the address slot", () => {
+      render(<DeviceRow device={accountOnly} now={1_700_000_060_000} />);
+      expect(screen.getByText("cloud-box")).toBeInTheDocument();
+      expect(screen.getByText(/Via relay/)).toBeInTheDocument();
+      expect(screen.getByLabelText("Relay · In use")).toBeInTheDocument();
+    });
+
+    it("offers none of the LAN-only affordances", () => {
+      render(<DeviceRow device={accountOnly} now={1_700_000_060_000} />);
+      // TLS 信任模式是配对行上的字段。
+      expect(screen.queryByText("OS Default")).not.toBeInTheDocument();
+      // 刷新直连 / 改名 / 改 TLS / 删配对 全都作用在配对行上。
+      expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument();
+    });
+
+    it("keeps the address slot on the relay even while the relay is unreachable", () => {
+      render(
+        <DeviceRow
+          device={{
+            ...accountOnly,
+            online: false,
+            viaRelay: false,
+            paths: [{ kind: "relay", state: "dead" }],
+          }}
+          now={1_700_000_060_000}
+        />,
+      );
+      expect(screen.getByText(/Via relay/)).toBeInTheDocument();
+      expect(screen.getByText("Relay · Unreachable")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/agentre/remote-devices/device-row.tsx
+++ b/frontend/src/components/agentre/remote-devices/device-row.tsx
@@ -13,13 +13,19 @@ import { DeviceProvidersSync } from "./device-providers-sync";
 import { relativeTime, friendlyLastError } from "./format";
 import type { DevicePath, DeviceRowModel } from "./use-remote-devices";
 
-type Props = {
-  device: DeviceRowModel;
-  now: number;
+/** 作用在 LAN 配对行(paired_agentreds)上的那组动作。 */
+export type DeviceRowActions = {
   onRefresh: () => void;
   onRename: () => void;
   onEditTLS: () => void;
   onRemove: () => void;
+};
+
+type Props = {
+  device: DeviceRowModel;
+  now: number;
+  /** 账号独有的行没有配对行,这组动作无处落脚 —— 不传就不画菜单。 */
+  actions?: DeviceRowActions;
 };
 
 function tlsBadgeVariant(
@@ -46,7 +52,7 @@ function tlsBadgeLabel(mode: string, t: TFunction): string {
 }
 
 function dotColor(device: DeviceRowModel): string {
-  if (device.lastError === "tofu_mismatch") return "bg-destructive";
+  if (device.lan?.lastError === "tofu_mismatch") return "bg-destructive";
   if (device.online) return "bg-status-running";
   return "bg-muted-foreground";
 }
@@ -113,17 +119,12 @@ function UnclaimedNote({ t }: { t: TFunction }) {
   );
 }
 
-export function DeviceRow({
-  device,
-  now,
-  onRefresh,
-  onRename,
-  onEditTLS,
-  onRemove,
-}: Props) {
+export function DeviceRow({ device, now, actions }: Props) {
   const { t } = useTranslation();
-  const friendlyErr = friendlyLastError(device.lastError, t);
-  const isTofu = device.lastError === "tofu_mismatch";
+  // LAN 配对行。undefined = 这一行只来自账号清单,没有本机配对行可依附。
+  const lan = device.lan;
+  const friendlyErr = friendlyLastError(lan?.lastError ?? "", t);
+  const isTofu = lan?.lastError === "tofu_mismatch";
   const [showProviders, setShowProviders] = useState(false);
 
   return (
@@ -148,13 +149,19 @@ export function DeviceRow({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-medium truncate">{device.name}</span>
-            <Badge variant={tlsBadgeVariant(device.tlsMode)}>
-              {tlsBadgeLabel(device.tlsMode, t)}
-            </Badge>
+            {/* TLS 信任模式是配对行上的字段。 */}
+            {lan ? (
+              <Badge variant={tlsBadgeVariant(lan.tlsMode)}>
+                {tlsBadgeLabel(lan.tlsMode, t)}
+              </Badge>
+            ) : null}
           </div>
           <div className="text-xs text-muted-foreground truncate">
-            {/* R15:地址位显示 LAN url,或中转路径在用时的「经中转」。 */}
-            {device.viaRelay ? t("remoteDevices.status.viaRelay") : device.url}
+            {/* R15:地址位显示 LAN url,或中转路径在用时的「经中转」。账号独有的
+                行没有 LAN 地址,中转就是它唯一的地址形态。 */}
+            {lan && !device.viaRelay
+              ? lan.url
+              : t("remoteDevices.status.viaRelay")}
             <span className="mx-2">·</span>
             {device.lastSeenAt > 0
               ? t("remoteDevices.status.lastConnected", {
@@ -170,13 +177,15 @@ export function DeviceRow({
             ))}
           </div>
         ) : null}
-        <DeviceActionMenu
-          onRefresh={onRefresh}
-          onRename={onRename}
-          onEditTLS={onEditTLS}
-          onRemove={onRemove}
-          onToggleProviders={() => setShowProviders((s) => !s)}
-        />
+        {actions ? (
+          <DeviceActionMenu
+            onRefresh={actions.onRefresh}
+            onRename={actions.onRename}
+            onEditTLS={actions.onEditTLS}
+            onRemove={actions.onRemove}
+            onToggleProviders={() => setShowProviders((s) => !s)}
+          />
+        ) : null}
       </div>
       {device.unclaimed ? <UnclaimedNote t={t} /> : null}
       {friendlyErr ? (
@@ -187,12 +196,12 @@ export function DeviceRow({
         </div>
       ) : null}
       {/* R18：daemon 版本过旧是这台设备的固有属性，说明就落在这台设备这一行。 */}
-      {device.daemonOutdated ? (
+      {lan?.daemonOutdated ? (
         <div className="text-xs text-status-waiting">
           {t("remoteDevices.status.daemonOutdated")}
         </div>
       ) : null}
-      {showProviders ? <DeviceProvidersSync deviceId={device.id} /> : null}
+      {showProviders && lan ? <DeviceProvidersSync deviceId={lan.id} /> : null}
     </div>
   );
 }

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.test.tsx
@@ -559,6 +559,77 @@ describe("RemoteDevicesPanel", () => {
     expect(screen.queryByText(/192\.168\.1\.50/)).not.toBeInTheDocument();
   });
 
+  // 真实场景:远端服务器上跑着 agentred,已登录同一个账号、中转在线,但这台桌面
+  // 从没跟它 LAN 配对过 —— 它以前一行都不产生,面板里只看得见本机。
+  it("lists an account-only agentred this desktop never paired over LAN", async () => {
+    mockList.mockResolvedValueOnce([]);
+    mockServerList.mockResolvedValueOnce([
+      {
+        ID: 21,
+        Name: "cloud-box",
+        Kind: "agentred",
+        Platform: "linux",
+        Version: "0.3.0",
+        Fingerprint: "fp-cloud",
+        LastSeenAt: 1_700_000_000_000,
+        Status: 1,
+        Online: true,
+        IsThisDevice: false,
+      },
+    ]);
+
+    render(<RemoteDevicesPanel />);
+
+    expect(await screen.findByTestId("device-row")).toBeInTheDocument();
+    expect(screen.getByText("cloud-box")).toBeInTheDocument();
+    expect(screen.getByLabelText("Relay · In use")).toBeInTheDocument();
+    expect(screen.getByText(/Via relay/)).toBeInTheDocument();
+    // 没有配对行 → 不给那组作用在配对行上的动作,也没有 TLS 徽章。
+    expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument();
+    expect(screen.queryByText("OS Default")).not.toBeInTheDocument();
+    // 它在账号清单里 → 不是「未认领」。
+    expect(screen.queryByText("Unclaimed")).not.toBeInTheDocument();
+  });
+
+  it("lists an account-only agentred alongside the LAN-paired ones", async () => {
+    mockList.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "linux-srv",
+        url: "ws://192.168.1.50:7456/rpc",
+        daemonFingerprint: "fp-lan",
+        tlsMode: "default",
+        online: true,
+        lastSeenAt: 1_700_000_000_000,
+      },
+    ] as Partial<DeviceView>[]);
+    mockServerList.mockResolvedValueOnce([
+      {
+        ID: 21,
+        Name: "cloud-box",
+        Kind: "agentred",
+        Platform: "linux",
+        Version: "0.3.0",
+        Fingerprint: "fp-cloud",
+        LastSeenAt: 1_700_000_000_000,
+        Status: 1,
+        Online: true,
+        IsThisDevice: false,
+      },
+    ]);
+
+    render(<RemoteDevicesPanel />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("device-row")).toHaveLength(2),
+    );
+    expect(screen.getByText("linux-srv")).toBeInTheDocument();
+    expect(screen.getByText("cloud-box")).toBeInTheDocument();
+    // LAN 那台仍留着自己的地址位与配对动作。
+    expect(screen.getByText(/192\.168\.1\.50/)).toBeInTheDocument();
+    expect(screen.getByLabelText("More actions")).toBeInTheDocument();
+  });
+
   describe("unpair & rename use dialogs, never native window.*", () => {
     const device = {
       id: 1,

--- a/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
+++ b/frontend/src/components/agentre/remote-devices/remote-devices-panel.tsx
@@ -21,7 +21,7 @@ import { DeviceRow } from "./device-row";
 import { hostOf } from "./format";
 import { LoginDialog } from "./login-dialog";
 import { TLSTrustDialog } from "./tls-trust-dialog";
-import { useRemoteDevices, type DeviceRowModel } from "./use-remote-devices";
+import { useRemoteDevices, type DeviceView } from "./use-remote-devices";
 import { useServerLogin } from "./use-server-login";
 
 // 规格「界面与交互 › 登录」: entry point for the standard device-authorization
@@ -91,8 +91,9 @@ export function RemoteDevicesPanel({
   const [guideRequested, setGuideRequested] = useState(false);
   const [showBackendGuide, setShowBackendGuide] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
-  const [editTLSFor, setEditTLSFor] = useState<DeviceRowModel | null>(null);
-  const [removeFor, setRemoveFor] = useState<DeviceRowModel | null>(null);
+  // 改 TLS / 删配对都作用在 LAN 配对行上,这两个对话框拿的就是那一行。
+  const [editTLSFor, setEditTLSFor] = useState<DeviceView | null>(null);
+  const [removeFor, setRemoveFor] = useState<DeviceView | null>(null);
   const [renameFor, setRenameFor] = useState<{
     id: number;
     draft: string;
@@ -226,17 +227,28 @@ export function RemoteDevicesPanel({
 
       {devices.length > 0 ? (
         <div className="flex flex-col gap-2">
-          {devices.map((d) => (
-            <DeviceRow
-              key={d.id}
-              device={d}
-              now={now}
-              onRefresh={() => void refresh(d.id)}
-              onRename={() => setRenameFor({ id: d.id, draft: d.name })}
-              onEditTLS={() => setEditTLSFor(d)}
-              onRemove={() => setRemoveFor(d)}
-            />
-          ))}
+          {devices.map((d) => {
+            // 用 const 接住,窄化才进得了下面那几个闭包。
+            const lan = d.lan;
+            return (
+              <DeviceRow
+                key={d.key}
+                device={d}
+                now={now}
+                actions={
+                  lan
+                    ? {
+                        onRefresh: () => void refresh(lan.id),
+                        onRename: () =>
+                          setRenameFor({ id: lan.id, draft: lan.name }),
+                        onEditTLS: () => setEditTLSFor(lan),
+                        onRemove: () => setRemoveFor(lan),
+                      }
+                    : undefined
+                }
+              />
+            );
+          })}
         </div>
       ) : null}
 

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.test.ts
@@ -125,9 +125,13 @@ describe("mergeDeviceSources (R15)", () => {
       known: true,
       devices: [accountDevice()],
     });
-    expect(rows).toHaveLength(1);
-    expect(rows[0].account).toBeUndefined();
-    expect(rows[0].unclaimed).toBe(false);
+    const lanRow = rows.find((r) => r.lan?.id === 1);
+    expect(lanRow?.account).toBeUndefined();
+    expect(lanRow?.unclaimed).toBe(false);
+    // 这条 LAN 行没有指纹,连不上任何账号行 —— 于是那台账号设备照样自己成一行。
+    // 猜它俩是同一台机器需要一个我们没有的依据,而猜错的代价是把一台确实
+    // 在线的机器藏起来,正是这次要修的毛病。
+    expect(rows.map((r) => r.key)).toEqual(["lan:1", "account:10"]);
   });
 
   it("does not mark unclaimed when the account list is unknown (not logged in)", () => {
@@ -189,6 +193,114 @@ describe("mergeDeviceSources (R15)", () => {
     );
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.name)).toEqual(["linux-srv", "pi"]);
+  });
+
+  // ── 账号独有的机器(按指纹全外连接)────────────────────────────────────────
+  // 合并以 LAN 为左表做左连接时,一台只登记在账号里、本机从没 LAN 配对过的
+  // agentred 一行都不产生 —— 用户在远端服务器上登录了同一个账号、中转也在线,
+  // 面板却只看得见本机。两侧都要当左表。
+  it("emits a row for an account-only agentred that was never paired over LAN", () => {
+    const rows = mergeDeviceSources([], {
+      known: true,
+      devices: [accountDevice({ Fingerprint: "fp-cloud", Name: "cloud-box" })],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("cloud-box");
+    expect(rows[0].account?.Fingerprint).toBe("fp-cloud");
+    // 没有本机配对行 —— 这一行在类型上就没有 LAN 来源。
+    expect(rows[0].lan).toBeUndefined();
+    // 只有中转一条可达路径。
+    expect(rows[0].paths).toEqual([{ kind: "relay", state: "in-use" }]);
+    expect(rows[0].viaRelay).toBe(true);
+    expect(rows[0].online).toBe(true);
+    // 「未认领」= 仅本机配对、账号清单里没有它。账号独有的行按定义不是未认领。
+    expect(rows[0].unclaimed).toBe(false);
+  });
+
+  it("keeps an account-only machine listed while its relay presence is gone", () => {
+    const rows = mergeDeviceSources([], {
+      known: true,
+      devices: [
+        accountDevice({
+          Fingerprint: "fp-cloud",
+          Name: "cloud-box",
+          Online: false,
+        }),
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].paths).toEqual([{ kind: "relay", state: "dead" }]);
+    expect(rows[0].online).toBe(false);
+    expect(rows[0].viaRelay).toBe(false);
+    expect(rows[0].lastSeenAt).toBe(1_700_000_000_000);
+  });
+
+  it("produces one row per machine across LAN-only, both, and account-only", () => {
+    const rows = mergeDeviceSources(
+      [
+        lanDevice({ id: 1, name: "linux-srv", daemonFingerprint: "fp-1" }),
+        lanDevice({ id: 2, name: "pi", daemonFingerprint: "fp-lan-only" }),
+      ],
+      {
+        known: true,
+        devices: [
+          accountDevice({ ID: 10, Fingerprint: "fp-1" }),
+          accountDevice({
+            ID: 11,
+            Name: "cloud-box",
+            Fingerprint: "fp-acct-only",
+          }),
+        ],
+      },
+    );
+    expect(rows.map((r) => r.name)).toEqual(["linux-srv", "pi", "cloud-box"]);
+    expect(rows.map((r) => r.lan?.id)).toEqual([1, 2, undefined]);
+    // 两边都有的那台只占一行,不因为参与合并而被复制成两行。
+    expect(rows.filter((r) => r.account?.Fingerprint === "fp-1")).toHaveLength(
+      1,
+    );
+    expect(rows[1].unclaimed).toBe(true);
+    expect(rows[2].unclaimed).toBe(false);
+  });
+
+  // 账号清单里 kind=desktop 的机器由 DesktopDeviceRow 单独成行(R19),
+  // 合并结果里再产生一行就是同一台机器出现两次。
+  it("leaves the account's desktop entries to their own row shape", () => {
+    const rows = mergeDeviceSources([], {
+      known: true,
+      devices: [
+        accountDevice({
+          ID: 12,
+          Kind: "desktop",
+          Name: "my-mac",
+          Fingerprint: "fp-desktop",
+          IsThisDevice: true,
+        }),
+      ],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  // 配对行 id 与账号设备 ID 是两个自增序列,会撞号 —— 行键必须自带来源。
+  it("gives LAN and account-only rows distinct keys when their ids collide", () => {
+    const rows = mergeDeviceSources([lanDevice({ id: 10 })], {
+      known: true,
+      devices: [
+        accountDevice({ ID: 10, Name: "cloud-box", Fingerprint: "fp-cloud" }),
+      ],
+    });
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.key)).size).toBe(2);
+  });
+
+  // 账号清单未知(未登录 / 拉取失败)时没有账号来源,一行都不该凭空多出来。
+  it("adds no account-only rows when the account list is unknown", () => {
+    const rows = mergeDeviceSources([lanDevice()], {
+      known: false,
+      devices: [],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lan?.id).toBe(1);
   });
 });
 
@@ -320,15 +432,13 @@ describe("useRemoteDevices", () => {
       });
     });
 
-    expect(result.current.devices.find((d) => d.id === 1)?.online).toBe(true);
-    expect(result.current.devices.find((d) => d.id === 1)?.lastSeenAt).toBe(
-      12345,
-    );
+    const rowOf = (id: number) =>
+      result.current.devices.find((d) => d.lan?.id === id);
+    expect(rowOf(1)?.online).toBe(true);
+    expect(rowOf(1)?.lastSeenAt).toBe(12345);
     // 在线态变化后路径重算:LAN 直连从 dead 翻成 in-use。
-    expect(result.current.devices.find((d) => d.id === 1)?.paths).toEqual([
-      { kind: "lan", state: "in-use" },
-    ]);
-    expect(result.current.devices.find((d) => d.id === 2)?.online).toBe(false);
+    expect(rowOf(1)?.paths).toEqual([{ kind: "lan", state: "in-use" }]);
+    expect(rowOf(2)?.online).toBe(false);
   });
 
   it("ignores events for unknown id", async () => {
@@ -354,6 +464,6 @@ describe("useRemoteDevices", () => {
       });
     });
     expect(result.current.devices).toHaveLength(1);
-    expect(result.current.devices[0].id).toBe(1);
+    expect(result.current.devices[0].lan?.id).toBe(1);
   });
 });

--- a/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
+++ b/frontend/src/components/agentre/remote-devices/use-remote-devices.ts
@@ -37,10 +37,17 @@ export type AccountSource = {
   devices: server_svc.Device[];
 };
 
-/** 合并后的一行设备:LAN 视图 + 可选账号设备 + 可达路径。 */
-export type DeviceRowModel = DeviceView & {
-  /** 账号来源的设备(指纹匹配);undefined = 仅 LAN 来源。 */
-  account?: server_svc.Device;
+/** 一行设备里两种来源共有的部分。 */
+type DeviceRowBase = {
+  /**
+   * 列表键。配对行 id 与账号设备 ID 是两个各自自增的序列,会撞号,
+   * 所以键自带来源前缀。
+   */
+  key: string;
+  name: string;
+  /** 这台机器此刻有没有一条在用的可达路径。 */
+  online: boolean;
+  lastSeenAt: number;
   /** 可达路径 chips。 */
   paths: DevicePath[];
   /** 未认领:仅本机配对、账号清单里没有这台机器的指纹(且清单已知)。 */
@@ -49,6 +56,30 @@ export type DeviceRowModel = DeviceView & {
   viaRelay: boolean;
 };
 
+/**
+ * 有本机 LAN 配对行(paired_agentreds)的一行。TLS 信任、LAN 地址,以及刷新直连 /
+ * 改名 / 改 TLS / 删配对这组动作,作用的都是 lan 这一行。
+ */
+export type LanDeviceRow = DeviceRowBase & {
+  lan: DeviceView;
+  /** 账号来源的设备(指纹匹配);undefined = 这台机器还没认领到账号。 */
+  account?: server_svc.Device;
+};
+
+/** 账号独有的一行:账号清单里有、本机没有配对行 —— 中转是它唯一一条路径。 */
+export type AccountDeviceRow = DeviceRowBase & {
+  lan?: undefined;
+  account: server_svc.Device;
+};
+
+/** 合并后的一行设备。lan 在不在,就是这一行有没有 LAN 来源。 */
+export type DeviceRowModel = LanDeviceRow | AccountDeviceRow;
+
+/**
+ * 按设备指纹把两个来源合成「一行一台机器」:LAN 独有、两边都有、账号独有
+ * 三种都产生行(全外连接)。以 LAN 为左表做左连接会漏掉最后一种 —— 一台
+ * 只登记在账号里、本机从没配对过的 agentred 就整台看不见。
+ */
 export function mergeDeviceSources(
   lan: DeviceView[],
   account: AccountSource,
@@ -59,8 +90,10 @@ export function mergeDeviceSources(
       accountByFp.set(d.Fingerprint, d);
     }
   }
-  return lan.map((d) => {
+  const claimedFingerprints = new Set<string>();
+  const rows: DeviceRowModel[] = lan.map((d) => {
     const acc = accountByFp.get(d.daemonFingerprint);
+    if (acc) claimedFingerprints.add(d.daemonFingerprint);
     const online = d.online;
     const paths: DevicePath[] = [
       { kind: "lan", state: online ? "in-use" : "dead" },
@@ -78,7 +111,11 @@ export function mergeDeviceSources(
       });
     }
     return {
-      ...d,
+      key: `lan:${d.id}`,
+      name: d.name,
+      online: online || relayInUse,
+      lastSeenAt: d.lastSeenAt,
+      lan: d,
       account: acc,
       paths,
       // 指纹为空的 LAN 行无从与账号清单对照(accountByFp 也不收空键),缺少依据时
@@ -87,6 +124,30 @@ export function mergeDeviceSources(
       viaRelay: relayInUse,
     };
   });
+
+  // 账号独有:账号清单里有、没有任何配对行认领这个指纹。accountByFp 已按指纹
+  // 去重、且不收空指纹 —— 没有指纹的账号行既无从与 LAN 对照,也无从经中转寻址。
+  for (const acc of accountByFp.values()) {
+    if (claimedFingerprints.has(acc.Fingerprint)) continue;
+    // kind=desktop 的机器由 DesktopDeviceRow 单独成行(R19),这里再出一行
+    // 就是同一台机器在面板上出现两次。
+    if (acc.Kind === "desktop") continue;
+    const relayReachable = acc.Online;
+    rows.push({
+      key: `account:${acc.ID}`,
+      name: acc.Name || acc.Fingerprint,
+      online: relayReachable,
+      lastSeenAt: acc.LastSeenAt,
+      account: acc,
+      // 没有配对行 → 没有 LAN 路径,中转是唯一一条。
+      paths: [{ kind: "relay", state: relayReachable ? "in-use" : "dead" }],
+      // 它就在账号清单里,按定义不是未认领。
+      unclaimed: false,
+      viaRelay: relayReachable,
+    });
+  }
+
+  return rows;
 }
 
 type StateEvent = {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,8 +57,10 @@ type App struct {
 	peerMu           sync.Mutex
 	peerCancel       context.CancelFunc
 	peerDone         chan struct{}
-	ccUsageStop      func()
-	terminalSvc      *terminal_svc.Service
+	// peerRestartMu 串行化「停旧登记 + 建新登记」这一对操作，见 restartInboundPeer。
+	peerRestartMu sync.Mutex
+	ccUsageStop   func()
+	terminalSvc   *terminal_svc.Service
 
 	// quitConfirmed 标记本次退出已被用户确认(或自动更新重启),OnBeforeClose 见到即放行。
 	quitConfirmed   atomic.Bool
@@ -116,9 +118,7 @@ func (a *App) Startup(ctx context.Context) {
 	// Server 联机：绑定 wails 事件源后启动 boot 协程（最长一次刷新）。
 	server_svc.Server().SetEmitter(func(payload any) {
 		wailsruntime.EventsEmit(a.ctx, "server.state", payload)
-		if state, ok := payload.(map[string]any); ok && state["kind"] == "logged_in" {
-			a.startInboundPeer(context.Background())
-		}
+		a.onServerStateEvent(payload)
 	})
 	bootstrap.ServerBoot(context.Background())
 	a.startInboundPeer(context.Background())

--- a/internal/app/peer.go
+++ b/internal/app/peer.go
@@ -24,6 +24,37 @@ var newInboundPeer = func(ctx context.Context) (inboundPeer, error) {
 	return peer.NewInbound(link), nil
 }
 
+// onServerStateEvent 按登录状态的变更维护这台桌面端的入站中转登记。
+func (a *App) onServerStateEvent(payload any) {
+	state, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	switch state["kind"] {
+	case "logged_in":
+		// 重建而不是「已经有了就跳过」：登记在建立时就绑定了服务端地址与设备凭据，
+		// 而登录事件恰恰意味着这两样可能都变了。跳过等于继续以上一次登录的身份挂在
+		// 上一个服务端上 —— 新账号那边看不到这台桌面端，旧账号那边它还在线。
+		a.restartInboundPeer(context.Background())
+	case "logged_out":
+		// 登记挂在 context.Background() 上，不主动停就要一直活到应用退出：已经登出的
+		// 桌面端仍以旧凭据在旧服务端上保持可寻址。
+		a.stopInboundPeer(context.Background())
+	}
+}
+
+// restartInboundPeer 先停掉现有登记，再按当前登录状态重建。
+//
+// peerRestartMu 让相邻的两次登录状态变更不会交错成「停 A、起 A、停 B、起 B」之外的
+// 顺序：stopInboundPeer 与 startInboundPeer 各自只在自己的临界区里持锁，中间那一瞬
+// 若被另一个事件插入，就会留下一条没人认领的登记 —— 正是这次要修掉的东西。
+func (a *App) restartInboundPeer(ctx context.Context) {
+	a.peerRestartMu.Lock()
+	defer a.peerRestartMu.Unlock()
+	a.stopInboundPeer(ctx)
+	a.startInboundPeer(ctx)
+}
+
 // startInboundPeer begins at most one inbound relay registration for this App
 // process. A fresh login has no registration until the login event retries this
 // method; an already-persisted login may start before token refresh completes,

--- a/internal/app/peer_test.go
+++ b/internal/app/peer_test.go
@@ -147,3 +147,70 @@ func requireEventuallyNil(t *testing.T, condition func() bool, msg string) {
 		time.Sleep(time.Millisecond)
 	}
 }
+
+// 换服务器/换账号重新登录时，入站登记必须跟着换。
+//
+// 登记是在建立时绑定服务端地址与设备凭据的，登录事件只是「有一次登录发生了」——
+// 不重建就等于继续用上一次登录的身份挂在上一个服务端上：新账号那边看不到这台
+// 桌面端（控制台恒显示离线），而旧账号那边它还在线。桌面端的登录发生在同一个
+// 进程内，所以这条路径完全靠事件驱动，没有重启进程这个兜底。
+func TestAppInboundPeer_GivenLiveRegistration_WhenLoggingIntoAnotherServer_ThenRebuilds(t *testing.T) {
+	first := &inboundPeerStub{started: make(chan struct{}), stopped: make(chan struct{})}
+	second := &inboundPeerStub{started: make(chan struct{}), stopped: make(chan struct{})}
+	calls := 0
+	previous := newInboundPeer
+	newInboundPeer = func(context.Context) (inboundPeer, error) {
+		calls++
+		if calls == 1 {
+			return first, nil
+		}
+		return second, nil
+	}
+	t.Cleanup(func() { newInboundPeer = previous })
+
+	app := &App{}
+	app.onServerStateEvent(map[string]any{"kind": "logged_in"})
+	select {
+	case <-first.started:
+	case <-time.After(time.Second):
+		t.Fatal("第一次登录没有建立入站登记")
+	}
+
+	// 不登出，直接登录到另一个服务端。
+	app.onServerStateEvent(map[string]any{"kind": "logged_in"})
+	select {
+	case <-first.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("重新登录必须先停掉指向旧服务端的登记")
+	}
+	select {
+	case <-second.started:
+	case <-time.After(time.Second):
+		t.Fatal("重新登录必须按新的登录状态重建登记")
+	}
+	app.stopInboundPeer(context.Background())
+}
+
+// 退出登录后，那条中转登记必须停：它挂在 context.Background() 上，不主动停就要
+// 一直活到应用退出——已经登出的桌面端仍以旧凭据在旧服务端上保持可寻址。
+func TestAppInboundPeer_GivenRegistration_WhenLoggedOut_ThenStops(t *testing.T) {
+	stub := &inboundPeerStub{started: make(chan struct{}), stopped: make(chan struct{})}
+	previous := newInboundPeer
+	newInboundPeer = func(context.Context) (inboundPeer, error) { return stub, nil }
+	t.Cleanup(func() { newInboundPeer = previous })
+
+	app := &App{}
+	app.onServerStateEvent(map[string]any{"kind": "logged_in"})
+	select {
+	case <-stub.started:
+	case <-time.After(time.Second):
+		t.Fatal("登录没有建立入站登记")
+	}
+
+	app.onServerStateEvent(map[string]any{"kind": "logged_out"})
+	select {
+	case <-stub.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("登出必须停掉入站登记")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -681,6 +681,30 @@ func (d *Daemon) currentAccessToken() string {
 	return d.state.Snapshot().Credential.AccessToken
 }
 
+// relayServerURL 在每次 dial 前重新解析中转端点，返回 "" 表示这台 daemon 还没有
+// 账号可连。HubLink 收到空值会退避重试而不是把链路当作不存在。
+//
+// 未认领时**先读一次盘**：`agentred login` 是另一个进程，它把凭据写进 state.json
+// 就退出。daemon 手里是启动时读到的内存副本，不重新读盘就永远发现不了自己已经被
+// 认领 —— 那正是「先起服务、后登录」恒离线的原因。
+func (d *Daemon) relayServerURL() string {
+	if !d.state.IsClaimed() {
+		if _, err := d.state.AdoptClaimFromDisk(); err != nil {
+			log.Printf("daemon.relayServerURL: re-read state.json failed: %v", err)
+		}
+	}
+	snap := d.state.Snapshot()
+	if snap.AccountID == "" {
+		// 没有账号就没有端点。这里返回空而不是返回一个「配置里写着的」地址：
+		// 带着空 Bearer 去连只会换来一串 401，把「还没登录」伪装成「登录了但被拒」。
+		return ""
+	}
+	if d.opts.HubServerURL != "" {
+		return d.opts.HubServerURL
+	}
+	return snap.HubServerURL
+}
+
 // New constructs a Daemon from Options. It loads persistent state, creates
 // sub-systems, and registers all static (non-per-conn) RPC methods.
 func New(opts Options) (*Daemon, error) {
@@ -744,15 +768,14 @@ func New(opts Options) (*Daemon, error) {
 	}
 	// 订阅资格的账号门:登记表每次解析收件人时现问 daemon 此刻的归属账号。
 	d.conns.claimedAccountID = d.claimedAccountID
-	if st.IsClaimed() && opts.HubServerURL != "" {
-		credential := st.Snapshot().Credential
-		d.hub = rpc.NewHubLink(rpc.HubLinkOptions{
-			ServerURL:           opts.HubServerURL,
-			AccessToken:         credential.AccessToken,
-			AccessTokenProvider: d.currentAccessToken,
-		})
-		d.mux = rpc.NewMultiplexer(d.hub)
-	}
+	// 中转链路无条件构造：认领状态改由每次 dial 时重新解析（relayServerURL），
+	// 不在这里判一次。判一次的后果是未认领启动的进程即使之后登录了也永远没有链路
+	// —— login 是另一个进程，写完 state.json 就退出，没有东西会回来建它。
+	d.hub = rpc.NewHubLink(rpc.HubLinkOptions{
+		ServerURLProvider:   d.relayServerURL,
+		AccessTokenProvider: d.currentAccessToken,
+	})
+	d.mux = rpc.NewMultiplexer(d.hub)
 	d.catchup = handlers.NewSessionCatchupHandlers(handlers.SessionCatchupDeps{
 		Sessions:         d.sessionStore,
 		Journal:          journalReader{db: gormDB},
@@ -940,24 +963,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Outbound relay failures are deliberately isolated from the LAN server and
 	// running sessions. HubLink owns logging, heartbeats, and retry for Run's
 	// whole lifetime; the multiplexer consumes its raw-frame seam separately.
-	if d.hub != nil {
-		hubCtx, hubCancel := context.WithCancel(ctx)
-		go func() { _ = d.hub.Run(hubCtx) }()
-		// The credential refresher keeps the minute-lived access token ahead of
-		// expiry; a permanently dead refresh token cancels the hub link so a
-		// doomed relay is not kept alive forever (R4/R14). It never propagates
-		// to Run — local sessions and LAN stay healthy either way.
-		go d.runCredentialRefresh(ctx, hubCancel)
-		// R4 的另一半:定期把账号的吊销列表拉到本地。挂在 hubCtx 上是因为它与中转
-		// 链路共用同一份设备凭据 —— 凭据永久失效时两者一起停,最后拉到的那份列表
-		// 留在 state.json 里继续本地生效(R19 承认的延迟),本地会话与 LAN 直连
-		// 全程不受影响。
-		go d.runRevocationPoll(hubCtx)
-	}
-	if d.mux != nil {
-		defer d.mux.Close()
-		go d.serveRelayChannels(ctx, d.mux)
-	}
+	hubCtx, hubCancel := context.WithCancel(ctx)
+	go func() { _ = d.hub.Run(hubCtx) }()
+	// 凭据续期与吊销拉取都以「手上已经有凭据」为前提,所以要等认领落地再挂起来 ——
+	// 见 runAccountJobsWhenClaimed。中转链路本身不必等:它每次 dial 重新解析端点,
+	// 解析不出来就退避重试。
+	go d.runAccountJobsWhenClaimed(ctx, hubCtx, hubCancel)
+	defer d.mux.Close()
+	go d.serveRelayChannels(ctx, d.mux)
 	// 通知日志的回收:起手一次,之后按间隔跑(见 collectJournal 的留存策略)。
 	go d.runJournalCollector(ctx)
 	if err := d.gateway.Start(ctx); err != nil {
@@ -990,6 +1003,52 @@ func (d *Daemon) Run(ctx context.Context) error {
 		log.Printf("daemon.Run: connection cleanup failed errorType=%T", err)
 	}
 	return runErr
+}
+
+// claimPollInterval 是未认领时重读 state.json 的间隔。只在没有账号期间生效,
+// 认领一落地就不再轮询。
+const claimPollInterval = 5 * time.Second
+
+// runAccountJobsWhenClaimed 等到这台 daemon 被认领之后,再启动凭据续期与吊销拉取。
+//
+// 两者都以「手上已经有凭据」为前提:refresher 见到空的 refresh token 会记一行日志
+// 后**永久返回**。未认领时直接起等于把它废掉 —— 之后即使登录成功,访问令牌也没人
+// 续期,15 分钟后链路带着过期令牌掉线,再也回不来。
+func (d *Daemon) runAccountJobsWhenClaimed(ctx, hubCtx context.Context, stopRelay context.CancelFunc) {
+	if !d.awaitClaim(ctx) {
+		return
+	}
+	// The credential refresher keeps the minute-lived access token ahead of
+	// expiry; a permanently dead refresh token cancels the hub link so a
+	// doomed relay is not kept alive forever (R4/R14). It never propagates
+	// to Run — local sessions and LAN stay healthy either way.
+	go d.runCredentialRefresh(ctx, stopRelay)
+	// R4 的另一半:定期把账号的吊销列表拉到本地。挂在 hubCtx 上是因为它与中转
+	// 链路共用同一份设备凭据 —— 凭据永久失效时两者一起停,最后拉到的那份列表
+	// 留在 state.json 里继续本地生效(R19 承认的延迟),本地会话与 LAN 直连
+	// 全程不受影响。
+	go d.runRevocationPoll(hubCtx)
+}
+
+// awaitClaim 阻塞到这台 daemon 被认领,返回 false 表示 ctx 先结束了。未认领期间
+// 周期性重读 state.json:认领可能是另一个进程(`agentred login`)写下的。
+func (d *Daemon) awaitClaim(ctx context.Context) bool {
+	for {
+		if d.state.IsClaimed() {
+			return true
+		}
+		if _, err := d.state.AdoptClaimFromDisk(); err != nil {
+			log.Printf("daemon.awaitClaim: re-read state.json failed: %v", err)
+		}
+		if d.state.IsClaimed() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(claimPollInterval):
+		}
+	}
 }
 
 // runCredentialRefresh launches the R4/R14 credential refresher for the daemon's

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -889,15 +889,21 @@ func TestDaemon_GivenClaimedAndUnavailableRelay_WhenRunning_ThenLANKeepsServing(
 }
 
 // TestDaemon_GivenUnclaimedRelayURL_WhenConstructed_ThenKeepsLANOnly ensures
-// relay construction remains gated by account ownership; an unclaimed daemon
-// must not create a hub link or a multiplexer merely because a server URL exists.
+// relay **traffic** remains gated by account ownership: a configured server URL
+// alone must not get anything dialed.
+//
+// 断言的位置从「链路对象是不是 nil」挪到「端点解析得出来吗」：链路本身现在无条件
+// 存在（否则未认领启动的进程登录之后没有东西会把它建起来，见
+// TestDaemon_GivenUnclaimedAtStartup_...），拦住出站流量的是解析结果为空。
 func TestDaemon_GivenUnclaimedRelayURL_WhenConstructed_ThenKeepsLANOnly(t *testing.T) {
 	d, err := New(Options{DataDir: t.TempDir(), HubServerURL: "http://relay.example"})
 	require.NoError(t, err)
 	t.Cleanup(func() { closeDB(d.db) })
 
-	assert.Nil(t, d.hub)
-	assert.Nil(t, d.mux)
+	assert.Empty(t, d.relayServerURL(),
+		"没有账号归属时，配置里的 server URL 不足以让它去连中转")
+	assert.NotNil(t, d.hub, "链路要在，登录之后才有东西接管")
+	assert.NotNil(t, d.mux)
 }
 
 func TestDaemon_BootShutdown(t *testing.T) {
@@ -2103,4 +2109,35 @@ func prepareDaemonPi(t *testing.T, conn *client.Client, params wire.RunParams) w
 	require.NoError(t, conn.Call(ctx, wire.MethodRun, params, &prepared))
 	require.NotEmpty(t, prepared.ProviderSessionID)
 	return prepared
+}
+
+// TestDaemon_GivenUnclaimedAtStartup_WhenLoginLandsOnDisk_ThenTheRelayLinkPicksItUp
+// 钉死「先起服务、后 agentred login」这条路径。
+//
+// 认领状态原本只在 New 里判一次：未认领启动的 daemon 连 HubLink 都不构造，之后
+// 无论怎么登录都不会有中转链路——而 login 是另一个进程，它写完 state.json 就退出，
+// 没有任何东西会回来把链路建起来。症状是设备在控制台恒显示离线，且没有一行日志
+// 说明为什么，只能靠重启进程恢复。
+func TestDaemon_GivenUnclaimedAtStartup_WhenLoginLandsOnDisk_ThenTheRelayLinkPicksItUp(t *testing.T) {
+	dir := t.TempDir()
+	d, err := New(Options{DataDir: dir})
+	require.NoError(t, err)
+	t.Cleanup(func() { closeDB(d.db) })
+
+	// 未认领启动：链路必须已经存在并处于「解析不出端点」的等待态，而不是不存在。
+	require.NotNil(t, d.hub, "未认领启动也要有中转链路，否则登录之后没有东西会把它建起来")
+	require.NotNil(t, d.mux)
+	assert.Empty(t, d.relayServerURL(), "还没认领时解析不出端点")
+
+	// 另一个进程完成 login。
+	other, err := state.Load(dir)
+	require.NoError(t, err)
+	other.Mutate(func(s *state.State) { s.HubServerURL = "https://server.example" })
+	other.ClaimWithKeySet("42", "kid-1", map[string]string{"kid-1": "PEM"}, 900,
+		state.AccountCredential{DeviceID: 7, AccessToken: "at-1", RefreshToken: "rt-1"})
+	require.NoError(t, other.Save())
+
+	assert.Equal(t, "https://server.example", d.relayServerURL(),
+		"下一次 dial 重新解析时就该看到这次登录")
+	assert.Equal(t, "at-1", d.currentAccessToken(), "凭据也一并被采纳，dial 才带得上 Bearer")
 }

--- a/internal/daemon/rpc/transport_hub.go
+++ b/internal/daemon/rpc/transport_hub.go
@@ -71,6 +71,10 @@ type HubLinkOptions struct {
 	// Random produces [0,1] jitter. A test supplies a stable value.
 	Random func() float64
 
+	// Logf is the log sink, defaulting to log.Printf. Same seam as
+	// credentialRefresher.logf, so a test can read what the link reports.
+	Logf func(format string, args ...any)
+
 	// OnDial and OnDisconnect let the future multiplexer observe link lifecycle.
 	// Hooks must return promptly because they run on the link's goroutine.
 	OnDial       func()
@@ -117,6 +121,9 @@ func NewHubLink(opts HubLinkOptions) *HubLink {
 	if opts.Random == nil {
 		opts.Random = rand.Float64
 	}
+	if opts.Logf == nil {
+		opts.Logf = log.Printf
+	}
 	return &HubLink{opts: opts, frames: make(chan HubFrame, hubFrameBuffer)}
 }
 
@@ -132,6 +139,10 @@ func NewHubLink(opts HubLinkOptions) *HubLink {
 // silent except for the log line.
 func (l *HubLink) Run(ctx context.Context) error {
 	failures := 0
+	// 「还没有账号可连」是稳态而不是反复发生的故障：LAN-only 的 daemon 可以一直不
+	// 登录，而退避封顶 60s —— 每轮记一行就是每天上千行噪声，真正的失败会被淹掉。
+	// 只在进入这个状态时记一次，离开它（连上了，或换成别的失败）时复位。
+	unresolvedLogged := false
 	for {
 		if ctx.Err() != nil {
 			// Shutdown is Run's normal termination, not a relay failure.
@@ -147,9 +158,13 @@ func (l *HubLink) Run(ctx context.Context) error {
 			if errors.Is(err, ErrHubUnresolved) {
 				// 未认领不是故障：说成 dial failed 会把「这台机器还没登录」误导成
 				// 「登录了但连不上」，而这两者的处置完全不同。
-				log.Printf("rpc.HubLink: no account to connect to yet; waiting for login")
+				if !unresolvedLogged {
+					l.opts.Logf("rpc.HubLink: no account to connect to yet; waiting for login")
+					unresolvedLogged = true
+				}
 			} else {
-				log.Printf("rpc.HubLink: relay dial failed; retrying: %v", err)
+				unresolvedLogged = false
+				l.opts.Logf("rpc.HubLink: relay dial failed; retrying: %v", err)
 			}
 			if err := l.wait(ctx, failures); err != nil {
 				return l.stopRetrying(ctx, err)
@@ -173,8 +188,9 @@ func (l *HubLink) Run(ctx context.Context) error {
 		if renewed {
 			failures = 0
 		}
+		unresolvedLogged = false
 		l.notifyDisconnect(err)
-		log.Printf("rpc.HubLink: relay disconnected; retrying: %v", err)
+		l.opts.Logf("rpc.HubLink: relay disconnected; retrying: %v", err)
 		if err := l.wait(ctx, failures); err != nil {
 			return l.stopRetrying(ctx, err)
 		}
@@ -190,7 +206,7 @@ func (l *HubLink) stopRetrying(ctx context.Context, err error) error {
 	if ctx.Err() != nil {
 		return nil //nolint:nilerr // the wait error is the shutdown surfacing through the clock seam; Run's contract is a clean nil exit
 	}
-	log.Printf("rpc.HubLink: relay retry clock failed; giving up: %v", err)
+	l.opts.Logf("rpc.HubLink: relay retry clock failed; giving up: %v", err)
 	return fmt.Errorf("relay retry wait: %w", err)
 }
 

--- a/internal/daemon/rpc/transport_hub.go
+++ b/internal/daemon/rpc/transport_hub.go
@@ -27,6 +27,11 @@ const (
 // must wait for OnDial before retrying; HubLink reconnects in the background.
 var ErrHubUnavailable = errors.New("rpc: hub relay unavailable")
 
+// ErrHubUnresolved reports that there is no relay endpoint to dial yet, because
+// the daemon has no account. It is not a failure: Run backs off and retries, so
+// a login that lands later is picked up without restarting the process.
+var ErrHubUnresolved = errors.New("rpc: relay endpoint not resolved yet")
+
 // HubFrame is one raw WebSocket frame arriving from the relay. The future hub
 // multiplexer owns interpreting its payload and must select on Frames instead
 // of reading the underlying socket directly.
@@ -37,8 +42,18 @@ type HubFrame struct {
 
 // HubLinkOptions configures a daemon-owned outbound relay connection.
 type HubLinkOptions struct {
-	ServerURL   string
-	AccessToken string
+	ServerURL string
+	// ServerURLProvider re-resolves the account server base URL at every dial,
+	// the same way AccessTokenProvider re-resolves the token. When set it takes
+	// precedence over the static ServerURL field.
+	//
+	// It returns "" while the daemon has no account to connect to, and Run then
+	// stays in its retry loop instead of treating the link as nonexistent: the
+	// daemon may have started before `agentred login` ran, and login is a
+	// separate process that writes state.json and exits — nothing would come
+	// back to build the link.
+	ServerURLProvider func() string
+	AccessToken       string
 	// AccessTokenProvider re-resolves the bearer token at every dial. When set
 	// it takes precedence over the static AccessToken field. The daemon uses it
 	// to hand HubLink the freshest refreshed access token across reconnects
@@ -129,7 +144,13 @@ func (l *HubLink) Run(ctx context.Context) error {
 				// see it as a relay failure: no log, no backoff, no retry.
 				return nil //nolint:nilerr // this dial error is the shutdown surfacing through the dialer
 			}
-			log.Printf("rpc.HubLink: relay dial failed; retrying: %v", err)
+			if errors.Is(err, ErrHubUnresolved) {
+				// 未认领不是故障：说成 dial failed 会把「这台机器还没登录」误导成
+				// 「登录了但连不上」，而这两者的处置完全不同。
+				log.Printf("rpc.HubLink: no account to connect to yet; waiting for login")
+			} else {
+				log.Printf("rpc.HubLink: relay dial failed; retrying: %v", err)
+			}
 			if err := l.wait(ctx, failures); err != nil {
 				return l.stopRetrying(ctx, err)
 			}
@@ -245,7 +266,14 @@ func (l *HubLink) notifyDisconnect(err error) {
 }
 
 func (l *HubLink) dial(ctx context.Context) (*websocket.Conn, error) {
-	endpoint, err := hubEndpoint(l.opts.ServerURL)
+	serverURL := l.opts.ServerURL
+	if l.opts.ServerURLProvider != nil {
+		serverURL = l.opts.ServerURLProvider()
+	}
+	if serverURL == "" {
+		return nil, ErrHubUnresolved
+	}
+	endpoint, err := hubEndpoint(serverURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/rpc/transport_hub_test.go
+++ b/internal/daemon/rpc/transport_hub_test.go
@@ -302,3 +302,67 @@ func TestHubLink_GivenAccessTokenProvider_WhenRunning_ThenEachDialReResolvesTheT
 	assert.Equal(t, "Bearer token-2", authHeaders[1], "each dial must re-resolve the token provider")
 	mu.Unlock()
 }
+
+// TestHubLink_GivenServerURLProvider_WhenTheDaemonIsNotClaimedYet_ThenItWaitsAndConnectsAfterLogin
+// 覆盖「先起服务、后 agentred login」这条路径：daemon 启动时还没被认领，链路必须留在
+// 重试循环里等，而不是当作「不存在」——login 是另一个进程，它写完 state.json 就退出，
+// 没有任何东西会回来把链路建起来。
+func TestHubLink_GivenServerURLProvider_WhenTheDaemonIsNotClaimedYet_ThenItWaitsAndConnectsAfterLogin(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	conns := make(chan *websocket.Conn, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		conns <- ws
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var serverURL atomic.Value
+	serverURL.Store("") // 还没认领：解析不出端点
+	var resolved atomic.Int64
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	link := NewHubLink(HubLinkOptions{
+		ServerURLProvider: func() string {
+			resolved.Add(1)
+			return serverURL.Load().(string)
+		},
+		AccessTokenProvider: func() string { return "token-1" },
+		HeartbeatInterval:   100 * time.Millisecond,
+		RetryInitial:        time.Second,
+		RetryMax:            4 * time.Second,
+		RetryWait:           func(context.Context, time.Duration) error { return nil },
+		Random:              func() float64 { return 1 },
+	})
+	runDone := make(chan error, 1)
+	go func() { runDone <- link.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-runDone)
+	})
+
+	// 未认领期间：Run 必须还活着并反复重新解析，而不是退出或空连一气。
+	require.Eventually(t, func() bool { return resolved.Load() >= 3 }, 2*time.Second, 10*time.Millisecond,
+		"未认领时 Run 应当留在重试循环里反复重新解析端点")
+	select {
+	case <-conns:
+		t.Fatal("端点解析不出来时不该发起连接")
+	default:
+	}
+
+	// 另一个进程完成了 login。
+	serverURL.Store(server.URL)
+	select {
+	case <-conns:
+	case <-time.After(2 * time.Second):
+		t.Fatal("认领之后同一个 Run 循环应当连上去，不需要重启进程")
+	}
+}

--- a/internal/daemon/rpc/transport_hub_test.go
+++ b/internal/daemon/rpc/transport_hub_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -365,4 +366,47 @@ func TestHubLink_GivenServerURLProvider_WhenTheDaemonIsNotClaimedYet_ThenItWaits
 	case <-time.After(2 * time.Second):
 		t.Fatal("认领之后同一个 Run 循环应当连上去，不需要重启进程")
 	}
+}
+
+// 未认领是稳态,不是反复发生的故障:LAN-only 的 daemon 可以一直不登录,而重试退避
+// 封顶 60s —— 每轮都记一行就是每天一千多行噪声,还会把真正的失败淹掉。只在进入这个
+// 状态时记一次。
+func TestHubLink_GivenNoAccount_WhenRetryingForever_ThenSaysSoOnceNotEveryRound(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	var rounds atomic.Int64
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	link := NewHubLink(HubLinkOptions{
+		ServerURLProvider: func() string {
+			rounds.Add(1)
+			return "" // 一直没有账号
+		},
+		AccessTokenProvider: func() string { return "" },
+		HeartbeatInterval:   100 * time.Millisecond,
+		RetryInitial:        time.Second,
+		RetryMax:            4 * time.Second,
+		RetryWait:           func(context.Context, time.Duration) error { return nil },
+		Random:              func() float64 { return 1 },
+		Logf: func(format string, args ...any) {
+			mu.Lock()
+			defer mu.Unlock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+		},
+	})
+	runDone := make(chan error, 1)
+	go func() { runDone <- link.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return rounds.Load() >= 5 }, 2*time.Second, 10*time.Millisecond,
+		"重试循环应当一直在跑")
+	cancel()
+	require.NoError(t, <-runDone)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, lines, 1, "转了 %d 轮，只该说一次「还没有账号可连」，实际记了 %d 行", rounds.Load(), len(lines))
+	assert.Contains(t, lines[0], "no account")
 }

--- a/internal/daemon/state/state.go
+++ b/internal/daemon/state/state.go
@@ -142,6 +142,71 @@ func (s *State) Unclaim() {
 	})
 }
 
+// AdoptClaimFromDisk re-reads state.json and adopts an account claim that
+// appeared there while this in-memory state was still unclaimed. It reports
+// whether a claim was adopted.
+//
+// This exists because `agentred login` is a separate process: it writes the
+// credential to state.json and exits, so a daemon that was started before the
+// login holds a stale in-memory copy and would otherwise stay unclaimed — and
+// therefore off the relay — until the next restart.
+//
+// It is deliberately one-way and claim-only: an already-claimed state is left
+// untouched (this process owns its own claim, including a refresh rotation it
+// has not flushed yet), and nothing outside the claim is read back from disk.
+func (s *State) AdoptClaimFromDisk() (bool, error) {
+	if s.IsClaimed() {
+		return false, nil
+	}
+	dir := s.Dir()
+	if dir == "" {
+		return false, errors.New("state: dir not bound; load via Load(dir) first")
+	}
+	// 直接读文件而不是走 Load：Load 在文件缺失时会写一份带**新** UUID 的默认状态，
+	// 那会把这个 daemon 的身份换掉。这里只想看一眼盘上有没有认领，不该有任何写入。
+	b, err := os.ReadFile(filepath.Join(dir, stateFileName)) //nolint:gosec // 与 Load 同一路径，来自数据目录而非请求输入
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read state.json: %w", err)
+	}
+	var onDisk State
+	if err := json.Unmarshal(b, &onDisk); err != nil {
+		return false, fmt.Errorf("parse state.json: %w", err)
+	}
+	if onDisk.SchemaVersion != CurrentSchemaVersion {
+		return false, fmt.Errorf(
+			"state.json schemaVersion %d does not match expected %d; refusing to adopt its claim",
+			onDisk.SchemaVersion, CurrentSchemaVersion,
+		)
+	}
+	// onDisk 是 Unmarshal 出来的，mu 为 nil —— 只能直接读字段，不能调它的方法。
+	if onDisk.AccountID == "" {
+		return false, nil
+	}
+
+	adopted := false
+	s.Mutate(func(st *State) {
+		// 再查一次：读盘这段时间里本进程可能已经自己完成了认领（比如 RPC 触发的
+		// 登录），那份是更新的，不能被盘上这份盖掉。
+		if st.AccountID != "" {
+			return
+		}
+		st.AccountID = onDisk.AccountID
+		st.HubServerURL = onDisk.HubServerURL
+		st.Credential = onDisk.Credential
+		st.VerificationPublicKeyPEM = onDisk.VerificationPublicKeyPEM
+		st.VerificationCurrentKID = onDisk.VerificationCurrentKID
+		st.VerificationPublicKeys = cloneStrings(onDisk.VerificationPublicKeys)
+		st.MaxTokenLifetimeSeconds = onDisk.MaxTokenLifetimeSeconds
+		st.RevokedJTIs = append([]string(nil), onDisk.RevokedJTIs...)
+		st.RevocationsAsOf = onDisk.RevocationsAsOf
+		adopted = true
+	})
+	return adopted, nil
+}
+
 // Snapshot returns a deep-ish copy safe for read-only callers. Maps are
 // shallow-copied since their value types are immutable structs in this
 // codebase (PairedPeer, LLMProviderMeta) — callers must not mutate the

--- a/internal/daemon/state/state_test.go
+++ b/internal/daemon/state/state_test.go
@@ -85,6 +85,62 @@ func TestStateLoadSave(t *testing.T) {
 			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 		})
 
+		// `agentred login` 是另一个进程：它把凭据写进 state.json 就退出。运行中的
+		// daemon 手里是启动时读到的内存副本，不重新读盘就永远看不到自己已被认领。
+		convey.Convey("AdoptClaimFromDisk picks up a claim written by another process", func() {
+			st, _ := Load(dir)
+			require.NoError(t, st.Save())
+			require.False(t, st.IsClaimed())
+
+			// 另一个进程完成登录。
+			other, _ := Load(dir)
+			other.Mutate(func(s *State) { s.HubServerURL = "https://server.example" })
+			other.ClaimWithKeySet("42", "kid-1", map[string]string{"kid-1": "PEM"}, 900,
+				AccountCredential{DeviceID: 7, AccessToken: "at", RefreshToken: "rt"})
+			require.NoError(t, other.Save())
+
+			adopted, err := st.AdoptClaimFromDisk()
+			require.NoError(t, err)
+			assert.True(t, adopted, "认领是新出现的，应报告已采纳")
+			assert.True(t, st.IsClaimed())
+
+			snap := st.Snapshot()
+			assert.Equal(t, "42", snap.AccountID)
+			assert.Equal(t, "https://server.example", snap.HubServerURL)
+			assert.Equal(t, "at", snap.Credential.AccessToken)
+			assert.Equal(t, "rt", snap.Credential.RefreshToken)
+			assert.Equal(t, int64(7), snap.Credential.DeviceID)
+			assert.Equal(t, "kid-1", snap.VerificationCurrentKID)
+			assert.Equal(t, "PEM", snap.VerificationPublicKeys["kid-1"])
+			assert.Equal(t, int64(900), snap.MaxTokenLifetimeSeconds)
+		})
+
+		convey.Convey("AdoptClaimFromDisk leaves an already-claimed state alone", func() {
+			st, _ := Load(dir)
+			st.Claim("mine", "PEM-mine", AccountCredential{AccessToken: "mine-at"})
+			require.NoError(t, st.Save())
+
+			// 盘上换成了另一个账号（例如 unclaim + 重新登录留下的残留）。
+			other, _ := Load(dir)
+			other.Claim("theirs", "PEM-theirs", AccountCredential{AccessToken: "theirs-at"})
+			require.NoError(t, other.Save())
+
+			adopted, err := st.AdoptClaimFromDisk()
+			require.NoError(t, err)
+			assert.False(t, adopted, "已认领时不读盘、不覆盖内存里那份")
+			assert.Equal(t, "mine", st.Snapshot().AccountID)
+			assert.Equal(t, "mine-at", st.Snapshot().Credential.AccessToken)
+		})
+
+		convey.Convey("AdoptClaimFromDisk reports no claim when disk is still unclaimed", func() {
+			st, _ := Load(dir)
+			require.NoError(t, st.Save())
+			adopted, err := st.AdoptClaimFromDisk()
+			require.NoError(t, err)
+			assert.False(t, adopted)
+			assert.False(t, st.IsClaimed())
+		})
+
 		convey.Convey("Snapshot returns an independent copy of maps", func() {
 			st, _ := Load(dir)
 			st.Mutate(func(s *State) {

--- a/internal/service/server_svc/login.go
+++ b/internal/service/server_svc/login.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net/http"
+	"os"
 	"runtime"
 
 	"github.com/cago-frame/cago/pkg/logger"
@@ -27,6 +28,9 @@ const keychainAccountName = "agentre.server.refresh_token"
 // keychainFingerprintAccount）必须一致——R5 决策 8:账号侧不得另生成指纹。
 const accountForDeviceFingerprint = "agentre-device-fingerprint"
 
+// osHostname 是设备显示名的取值口，抽成变量供测试替换。
+var osHostname = os.Hostname
+
 // ---- request / response DTOs（私有，只在本包内用）----
 
 type deviceAuthorizeReq struct {
@@ -34,6 +38,9 @@ type deviceAuthorizeReq struct {
 	Fingerprint string `json:"fingerprint"`
 	Platform    string `json:"platform"`
 	Version     string `json:"version"`
+	// Name 是设备列表里的显示名，取本机主机名。设备流是账号侧拿到它的唯一途径：
+	// 不带上，服务端只能拿指纹缩写当名字，账号下每台机器就都长得一样了。
+	Name string `json:"name"`
 }
 
 type deviceAuthorizeResp struct {
@@ -118,11 +125,14 @@ func (s *service) StartLogin(ctx context.Context, serverURL string) (*StartLogin
 	}
 	row.ServerURL = serverURL
 
+	// 主机名取不到不影响登录：空串上报，服务端回退到指纹缩写。
+	hostname, _ := osHostname()
 	req := deviceAuthorizeReq{
 		DeviceKind:  "desktop",
 		Fingerprint: row.DeviceFingerprint,
 		Platform:    runtimePlatform(),
 		Version:     buildVersion(),
+		Name:        hostname,
 	}
 	var env envelope[deviceAuthorizeResp]
 	if _, err := s.getClient().do(ctx, http.MethodPost, "/v1/oauth/device/authorize", req, &env); err != nil {

--- a/internal/service/server_svc/login_test.go
+++ b/internal/service/server_svc/login_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -92,6 +93,10 @@ func TestStartLogin_Success(t *testing.T) {
 		body := authorizeBody.Load()
 		So(body, ShouldNotBeNil)
 		So((*body)["device_kind"], ShouldEqual, "desktop")
+		// 主机名是账号侧拿到这台机器名字的唯一途径：设备流不带它，服务端只能拿
+		// 指纹缩写当名字，设备列表里每台机器就都长得一样了。
+		wantHostname, _ := os.Hostname()
+		So((*body)["name"], ShouldEqual, wantHostname)
 		// 能力概念已从账号侧移除，桌面端不再自报一份没人校验的清单。
 		_, hasCaps := (*body)["capabilities"]
 		So(hasCaps, ShouldBeFalse)


### PR DESCRIPTION
用户报告 agentred 登录成功却在控制台恒显示离线、设备名叫 `sha256:4`、桌面端远端面板里看不到那台机器。排查下来是四个独立根因，其中三个是同一个形状：**登录/归属状态变了，依赖它的东西不跟着变，而且全程静默**。

## 1. agentred 登录后不建中转链路（`bed8dfbb`）

认领状态只在 `daemon.New` 里判一次，未认领启动的进程连 `HubLink` 都不构造。而 `agentred login` 是**另一个进程**，写完 state.json 就退出 —— 运行中的 daemon 既不会被通知也不会重新读盘，于是恒离线，且一行日志都没有，只能重启进程恢复。

改成链路无条件构造、端点在每次 dial 时重新解析（与已有的 `AccessTokenProvider` 同构），未认领时读盘采纳另一个进程写下的认领。

凭据续期与吊销拉取不能跟着无条件起：`credentialRefresher` 见到空 refresh token 会记一行日志后**永久返回**，未认领时直接起等于把它废掉 —— 之后即使登录成功，访问令牌也没人续期，15 分钟后链路带着过期令牌掉线且再也回不来。改由 `runAccountJobsWhenClaimed` 等认领落地后再挂。

## 2. 桌面端换服务器后不重建登记（`c25dfc19`）

`startInboundPeer` 在已有登记活着时直接 return。登记建立时绑定服务端地址与设备凭据，且挂在 `context.Background()` 上永不结束，所以「不登出直接登录到另一个服务端」这条路径上重建请求被静默丢弃：新账号那边看不到这台机器，旧账号那边它还在线。同时补上此前完全没有处理的 `logged_out`。

## 3. 远端面板漏掉只在账号里的 agentred（`7a72bcd9`）

`mergeDeviceSources` 的注释写的是「一行一台机器，两来源按指纹合并」，实现却是以 LAN 为左表的**左连接**。一台只登记在账号里、本机没配对过的 agentred 一行都不产生。改成按指纹全外连接；行模型拆成 `LanDeviceRow | AccountDeviceRow`，让「有没有配对行」在类型上可判别，配对行专属动作因此落不到账号独有的行上。

## 4. 登录时上报主机名（`0378d78f`）

设备流的授权请求此前不带名字，服务端只能把指纹截前 8 个字符 —— 而规范指纹是 `sha256:<64位hex>`，切出来恒为 `sha256:` 加一个十六进制字符，整个账号下最多 16 种名字。服务端侧的接收与回退在 agentre-server 仓库。

## 验证

- 全量后端测试通过；改动包 golangci-lint 0 问题
- 前端 `tsc -b` 干净、258 文件 3075 测试通过、ESLint 0 错误
- **1 号在真实二进制上端到端验证**：未认领启动 → 零外连、只记一行日志；另一个进程把认领写进 state.json → **1 秒后**自己去连 `/v1/relay/daemon`，凭据/吊销/验证公钥三条后台任务同时起来，进程全程没重启

## 已知遗留

- 面板统计文案 `remoteDevices.panel.stats` 的「已配对」现在把账号独有的行也算进去了，措辞待定
- 指纹为空的历史配对行无法参与按指纹合并，同一台机器可能出重复行；压掉它需要没有依据的猜测，猜错就是把在线机器藏起来
- `devices.name` 只在换取 token 时写，既有设备要重新登录一次才会变成主机名
